### PR TITLE
chore(ci): add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true   # report coverage, never fail the build
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, files"
+  require_changes: true        # only comment when coverage actually changes
+
+ignore:
+  - "tests"
+  - "examples"


### PR DESCRIPTION
Adds a Codecov config to align Codecov's behaviour with the gating decisions already made:

- **`project`/`patch` statuses → `informational: true`** — Codecov reports coverage but never fails a PR. This matches the "no coverage threshold" choice for the merge gate and stops Codecov from posting a status that could become a stealth required check.
- **`ignore: tests/, examples/`** — the reported percentage reflects `src/` (the shipped library), not fixtures/examples.
- **`comment.require_changes: true`** — only comments when coverage actually changes.

Validated against https://codecov.io/validate ("Valid!").

🤖 Generated with [Claude Code](https://claude.com/claude-code)