### PR TITLE
chore(ci): harden workflows and add a security policy

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,9 +15,12 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: PHP ${{ matrix.php }} · Laravel ${{ matrix.laravel }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
@@ -87,10 +90,13 @@ jobs:
 
   test-swagger-low:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: PHP 8.4 · Laravel 12 · swagger-php 5.8
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
@@ -137,9 +143,12 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
@@ -181,9 +190,12 @@ jobs:
   snapshot:
     name: Snapshot (locked toolchain)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public issue.
+
+Use GitHub's [private vulnerability reporting](https://github.com/Radiergummi/laravel-openapi/security/advisories/new)
+("Report a vulnerability" under the repository's **Security** tab), or email
+**moritz@mazetti.me**.
+
+Include enough detail to reproduce the issue (affected version, a minimal
+reproduction, and the impact you observed). You can expect an initial response
+within a few days. Once a fix is ready it will be released and the advisory
+published with credit, unless you prefer to remain anonymous.
+
+## Scope
+
+This package generates an OpenAPI document and lints it; it runs at build time
+and does not handle production request traffic. Reports are most relevant when
+generation can be made to read or write outside the project, execute arbitrary
+code from untrusted input, or leak sensitive data into the generated document.


### PR DESCRIPTION
Small hardening pass on top of the now-green CI.

- **`persist-credentials: false`** on all 5 checkout steps (both workflows). No job pushes — releases are tagged from a maintainer's machine — so the `GITHUB_TOKEN` never needs to persist in `.git/config`. Removes a credential a compromised build step (e.g. a malicious transitive dev-dep during `composer`) could otherwise read. OpenSSF-recommended.
- **`timeout-minutes: 15`** on every job, guarding against hung runs eating Actions minutes (jobs currently finish in <1 min).
- **`SECURITY.md`** with a private vulnerability-disclosure policy. GitHub **private vulnerability reporting** has been enabled on the repo (via API) to back it.

Repo-setting note: enabling the secret-scanning *extras* (non-provider patterns, validity checks) via API was a silent no-op — they're gated behind GitHub Advanced Security for this repo. Base secret scanning + push protection remain enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)