### PR TITLE
chore: adopt Issues-based workflow; migrate planning docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,29 @@ job). A PR is mergeable when `tests` is green, Pint reports no violations (`vend
 --test`), and PHPStan passes. PHPStan runs at level 8 with `treatPhpDocTypesAsCertain: false`
 and is **CI-blocking** — `composer lint` must report no errors.
 
+## Development workflow
+
+Feature and bug work is tracked in **GitHub Issues**, not in `docs/` spec/plan files.
+Specs live in issue descriptions; implementation plans live in **draft-PR descriptions**.
+Planning issues carry the `spec` label and sit on the **Roadmap** project, bucketed into the
+`v1.0` / `v1.1` / `v1.2` milestones; the economic-sensibility tier and affected area are labels
+(`tier-0/1/2`, `area:*`).
+
+Start each work session by opening a **draft PR**:
+
+1. Branch from `main` (`feat/…`, `fix/…`, or `chore/…`).
+2. `git commit --allow-empty` so the branch has a diff, then push.
+3. `gh pr create --draft` with a proper title, the implementation plan as the body, the relevant
+   labels, `Closes #<issue>`, and Moritz as reviewer.
+
+The issue stays the durable record of *what* and *why*; the PR body is *how*. If the
+implementation deviates from the plan, record the decision and its reasoning as a **PR comment**
+(and edit the issue if the spec itself changed). Mirror progress on the Roadmap project's Status
+field (Todo → In progress → In review → Done).
+
+Merge policy: **squash-merge into `main`**, gated on green CI (`tests`, `vendor/bin/pint --test`,
+PHPStan) and Moritz's review; keep history linear. (No merge queue.)
+
 ## Architecture
 
 The codebase splits into four namespaces:
@@ -107,12 +130,33 @@ concurrent runs otherwise. `reset()` methods exist but are redundant under the s
 - Authoring attributes live in `src/Attributes/`; they are the escape hatch for cases
   convention cannot derive.
 
-## Known gaps
+## Inference philosophy & boundaries
 
-See `docs/internal/known-gaps.md` (the gap registry, by `OAPI-###` ID) and
-`docs/internal/inference-roadmap.md` (the forward plan to close the planned ones). Notably:
-no controller method-body inference (OAPI-017) — the generator reads signatures only;
-no Eloquent-model or `@OA`-annotation response-schema inference (OAPI-063 / OAPI-064);
-no Sanctum security-scheme auto-derivation, only Passport (OAPI-065); and untyped path
-parameters (OAPI-066). (`allOf`-composed schema lint, formerly OAPI-038, is resolved — see
-`CHANGELOG.md`.)
+The generator infers as much of the OpenAPI document as it can from **conventional Laravel
+usage**; authoring attributes (`src/Attributes/`) are the escape hatch, used only where the code
+genuinely cannot express the information. Every proposed inference is judged on an
+**economic-sensibility ladder**, and built at the *lowest* tier that captures the idiom:
+
+- **Tier 0 — reflection & signatures.** Class/method signatures, PHPDoc tags, attributes, model
+  metadata (`$casts`, `$hidden`, `$visible`, `$appends`, `$fillable`, migration columns), backed
+  enums, route-model-binding types, middleware names. Deterministic, cheap, no body parsing —
+  the library's whole current basis. Always prefer it.
+- **Tier 1 — bounded AST whitelist.** Parse a method body but match only a small whitelist of
+  well-known call shapes in the first N statements, with no variable tracking across calls (e.g.
+  inline `validate()`, `abort()`, `response()->json([…])`). Economical for broadly-used idioms;
+  adopt selectively, and always degrade gracefully + log when the shape isn't matched.
+- **Tier 2 — full type-flow / dataflow.** Tracking values across calls, into services, through
+  conditionals. **Refused** — fragile, expensive, never complete. Where only Tier 2 would close a
+  case, that case is by definition the authoring attribute's job.
+
+Consequences worth knowing:
+
+- **Responses are return-type-shaped.** Where an app *types* its returns (or annotates them),
+  response-schema fidelity is strong; where the shape exists only at runtime, the generator emits
+  little. "Type your returns or annotate them to get response schemas" is the honest framing.
+- An attribute is **healthy** when it supplies something the code cannot express (a runtime shape,
+  a human description, an intentional override) and a **smell** when it merely re-states something
+  a Tier 0/1 read could have inferred.
+
+The live worklist of inference measures, current gaps, and fixes is the repository's GitHub Issues
+(label `spec`) and the **Roadmap** project — not a doc in this tree.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ Index: [`docs/README.md`](docs/README.md).
 - [Troubleshooting](docs/troubleshooting.md): symptom index.
 - [Plugin authoring](docs/plugin-authoring.md): write a plugin.
 - [Architecture](docs/architecture.md): generation pipeline internals.
-- [Known gaps](docs/internal/known-gaps.md): limitations.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,6 @@ New to the package? Read [Getting started](getting-started.md), then
 
 | Page | Covers |
 |---|---|
-| [Known gaps](internal/known-gaps.md) | Documented limitations and workarounds. |
 | [Changelog](../CHANGELOG.md) | Release notes. |
 | [Contributing](../CONTRIBUTING.md) | Local dev, test suite, CI gates. |
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -207,6 +207,4 @@ Lint rules:
 > [!NOTE]
 > `fractal.response-unbound` is opt-in. The `fractal()` helper and
 > `Spatie\Fractalistic\Fractal` facade are invoked inside method bodies, and
-> the generator does not read method bodies. See
-> [OAPI-017](internal/known-gaps.md#oapi-017--no-method-body-inference) and
-> [OAPI-053](internal/known-gaps.md).
+> the generator does not read method bodies.

--- a/docs/request-bodies.md
+++ b/docs/request-bodies.md
@@ -20,7 +20,7 @@ validation.
 | Nested objects | No, flat key→rule map only | Yes. Nested `Data` classes become nested component schemas via `$ref`. |
 | Enums | `Rule::in([...])` / `enum:` validation rule → `enum` | Native PHP enum property → `enum`; validation `Rule::in([...])` still works |
 | Field-level enrichment | `#[RequestField]` on a `PARAM_*` class-constant whose value matches the field name | `#[RequestField]` on the promoted constructor parameter or property |
-| Transformations / computed properties | No. The generator reads signatures only (see [OAPI-017](internal/known-gaps.md#oapi-017--no-method-body-inference)). | The `Data` class can carry `Optional`-typed and computed properties. PATCH semantics are inferred from `Optional\|…\|null`. |
+| Transformations / computed properties | No. The generator reads signatures only — method bodies are not read. | The `Data` class can carry `Optional`-typed and computed properties. PATCH semantics are inferred from `Optional\|…\|null`. |
 | File / multipart | Detected from `file` / `image` / `File::…` validation rules | Same, plus a typed `UploadedFile` property is auto-detected |
 | Runtime dependency | None (ships with Laravel) | `spatie/laravel-data` |
 | Brownfield fit | Direct. Existing `FormRequest`s document themselves with no changes. | Requires migrating request DTOs (or introducing them). |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,8 +50,7 @@ The action does not type-hint a request DTO the generator recognises. Either:
 
 ## Why doesn't my inline `$request->validate(...)` produce a request body?
 
-This is the [OAPI-017](internal/known-gaps.md#oapi-017--no-method-body-inference)
-method-body inference gap. The generator reads signatures only. Inline
+This is the **method-body inference** limitation. The generator reads signatures only. Inline
 `validate()`, `request()->validate()`, and ad-hoc `response()->json([…])`
 calls are invisible. Fix it by doing one of:
 


### PR DESCRIPTION
Bootstraps the GitHub-Issues workflow and migrates the local planning corpus.

- **CLAUDE.md** — new *Development workflow* section; *Known gaps* section replaced with general inference knowledge (Tier 0/1/2 ladder, Tier-2 boundary, attribute philosophy, typed-return reality).
- **Delinked** `troubleshooting.md` / `plugins.md` / `request-bodies.md` / both READMEs from `docs/internal/known-gaps.md` (gitignored, local-only — the links 404 in the published package).
- The local planning docs (`inference-roadmap.md`, `known-gaps.md`, `fix-draft.md`, the overrides spec+plan, `dogfooding/BACKLOG.md`) were gitignored scratch and have been migrated to **issues #5–#58** + draft PRs **#59 / #60**, then removed locally.

Closes #8.