### PR TITLE
chore: remove per-file copyright/license docblock headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Moritz Friedrich
+Copyright (c) 2026 Moritz Mazetti
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Attributes/BaseExample.php
+++ b/src/Attributes/BaseExample.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Deprecated.php
+++ b/src/Attributes/Deprecated.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Description.php
+++ b/src/Attributes/Description.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Discriminator.php
+++ b/src/Attributes/Discriminator.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Example.php
+++ b/src/Attributes/Example.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/ExceptionResponse.php
+++ b/src/Attributes/ExceptionResponse.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Expose.php
+++ b/src/Attributes/Expose.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/ExternalDocs.php
+++ b/src/Attributes/ExternalDocs.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/FieldAttribute.php
+++ b/src/Attributes/FieldAttribute.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Header.php
+++ b/src/Attributes/Header.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Hide.php
+++ b/src/Attributes/Hide.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/IgnoreLint.php
+++ b/src/Attributes/IgnoreLint.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Link.php
+++ b/src/Attributes/Link.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Operation.php
+++ b/src/Attributes/Operation.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/PathParam.php
+++ b/src/Attributes/PathParam.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/PublicEndpoint.php
+++ b/src/Attributes/PublicEndpoint.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/QueryParam.php
+++ b/src/Attributes/QueryParam.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/RequestBody.php
+++ b/src/Attributes/RequestBody.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/RequestField.php
+++ b/src/Attributes/RequestField.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/ResponseExample.php
+++ b/src/Attributes/ResponseExample.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/ResponseField.php
+++ b/src/Attributes/ResponseField.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/ResponseHeader.php
+++ b/src/Attributes/ResponseHeader.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/ResponseResource.php
+++ b/src/Attributes/ResponseResource.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Security.php
+++ b/src/Attributes/Security.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Spec.php
+++ b/src/Attributes/Spec.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Summary.php
+++ b/src/Attributes/Summary.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Tag.php
+++ b/src/Attributes/Tag.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Attributes/Webhook.php
+++ b/src/Attributes/Webhook.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Attributes;

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Console;

--- a/src/Console/DiffConfigCommand.php
+++ b/src/Console/DiffConfigCommand.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Console;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Console;

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Console;

--- a/src/Console/WhyCommand.php
+++ b/src/Console/WhyCommand.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Console;

--- a/src/Contracts/Extraction/SelfDocumentingRule.php
+++ b/src/Contracts/Extraction/SelfDocumentingRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Extraction;

--- a/src/Contracts/Generator/SpecStage.php
+++ b/src/Contracts/Generator/SpecStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Generator;

--- a/src/Contracts/Lint/Rule.php
+++ b/src/Contracts/Lint/Rule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Lint;

--- a/src/Contracts/Registry/ErrorResponseContributor.php
+++ b/src/Contracts/Registry/ErrorResponseContributor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Registry/ErrorResponseResolver.php
+++ b/src/Contracts/Registry/ErrorResponseResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Registry/Plugin.php
+++ b/src/Contracts/Registry/Plugin.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Registry/PrimaryResponseResolver.php
+++ b/src/Contracts/Registry/PrimaryResponseResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Registry/QueryParameterResolver.php
+++ b/src/Contracts/Registry/QueryParameterResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Registry/RefSchemaResolver.php
+++ b/src/Contracts/Registry/RefSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Registry/RequestSchemaResolver.php
+++ b/src/Contracts/Registry/RequestSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Registry;

--- a/src/Contracts/Routing/ResourceTargetLocator.php
+++ b/src/Contracts/Routing/ResourceTargetLocator.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Routing;

--- a/src/Contracts/Routing/RouteFilter.php
+++ b/src/Contracts/Routing/RouteFilter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Contracts\Routing;

--- a/src/Core/CorePlugin.php
+++ b/src/Core/CorePlugin.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core;

--- a/src/Core/Envelopes/JsonApiEnvelope.php
+++ b/src/Core/Envelopes/JsonApiEnvelope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Envelopes;

--- a/src/Core/Envelopes/LaravelEnvelope.php
+++ b/src/Core/Envelopes/LaravelEnvelope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Envelopes;

--- a/src/Core/Envelopes/NoneEnvelope.php
+++ b/src/Core/Envelopes/NoneEnvelope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Envelopes;

--- a/src/Core/Envelopes/Rfc7807Envelope.php
+++ b/src/Core/Envelopes/Rfc7807Envelope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Envelopes;

--- a/src/Core/ErrorContributors/MiddlewareErrorContributor.php
+++ b/src/Core/ErrorContributors/MiddlewareErrorContributor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\ErrorContributors;

--- a/src/Core/ErrorContributors/ThrowsErrorContributor.php
+++ b/src/Core/ErrorContributors/ThrowsErrorContributor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\ErrorContributors;

--- a/src/Core/ErrorContributors/ValidationErrorContributor.php
+++ b/src/Core/ErrorContributors/ValidationErrorContributor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\ErrorContributors;

--- a/src/Core/Lint/RequestBodySchemaDegraded.php
+++ b/src/Core/Lint/RequestBodySchemaDegraded.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Lint;

--- a/src/Core/Lint/RuleInvalidEnumValue.php
+++ b/src/Core/Lint/RuleInvalidEnumValue.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Lint;

--- a/src/Core/Lint/RuleUnknown.php
+++ b/src/Core/Lint/RuleUnknown.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Lint;

--- a/src/Core/Lint/ThrowsUnmapped.php
+++ b/src/Core/Lint/ThrowsUnmapped.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Lint;

--- a/src/Core/Resolvers/CoreQueryParameterResolver.php
+++ b/src/Core/Resolvers/CoreQueryParameterResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Resolvers;

--- a/src/Core/Resolvers/FormRequestRequestSchemaResolver.php
+++ b/src/Core/Resolvers/FormRequestRequestSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Resolvers;

--- a/src/Core/Resolvers/PaginatorResponseResolver.php
+++ b/src/Core/Resolvers/PaginatorResponseResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Resolvers;

--- a/src/Core/RouteFilters/SkipIgnitionRoutes.php
+++ b/src/Core/RouteFilters/SkipIgnitionRoutes.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\RouteFilters;

--- a/src/Core/RouteFilters/SkipNovaRoutes.php
+++ b/src/Core/RouteFilters/SkipNovaRoutes.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\RouteFilters;

--- a/src/Core/RouteFilters/SkipPassportRoutes.php
+++ b/src/Core/RouteFilters/SkipPassportRoutes.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\RouteFilters;

--- a/src/Core/RouteFilters/SkipSelfRoutes.php
+++ b/src/Core/RouteFilters/SkipSelfRoutes.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\RouteFilters;

--- a/src/Core/RouteFilters/SkipTelescopeRoutes.php
+++ b/src/Core/RouteFilters/SkipTelescopeRoutes.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\RouteFilters;

--- a/src/Core/Support/FakerExampleSynthesiser.php
+++ b/src/Core/Support/FakerExampleSynthesiser.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support;

--- a/src/Core/Support/PaginatorSchemaFactory.php
+++ b/src/Core/Support/PaginatorSchemaFactory.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support;

--- a/src/Core/Support/SchemaFromFormRequest.php
+++ b/src/Core/Support/SchemaFromFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support;

--- a/src/Core/Support/SpecTime/AnyValue.php
+++ b/src/Core/Support/SpecTime/AnyValue.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support\SpecTime;

--- a/src/Core/Support/SpecTime/SpecTimeRequest.php
+++ b/src/Core/Support/SpecTime/SpecTimeRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support\SpecTime;

--- a/src/Core/Support/SpecTime/SpecTimeRoute.php
+++ b/src/Core/Support/SpecTime/SpecTimeRoute.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support\SpecTime;

--- a/src/Core/Support/ValidationRulesToSchema.php
+++ b/src/Core/Support/ValidationRulesToSchema.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Core\Support;

--- a/src/Enums/ComponentType.php
+++ b/src/Enums/ComponentType.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Enums;

--- a/src/Enums/MediaType.php
+++ b/src/Enums/MediaType.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Enums;

--- a/src/Enums/PaginatorKind.php
+++ b/src/Enums/PaginatorKind.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Enums;

--- a/src/Errors/ErrorDescriptor.php
+++ b/src/Errors/ErrorDescriptor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Errors;

--- a/src/Errors/ErrorResponse.php
+++ b/src/Errors/ErrorResponse.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Errors;

--- a/src/Events/LintFindingEmitted.php
+++ b/src/Events/LintFindingEmitted.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Events;

--- a/src/Events/RouteSkipped.php
+++ b/src/Events/RouteSkipped.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Events;

--- a/src/Events/SkipReason.php
+++ b/src/Events/SkipReason.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Events;

--- a/src/Events/SpecGenerationCompleted.php
+++ b/src/Events/SpecGenerationCompleted.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Events;

--- a/src/Events/SpecGenerationStarted.php
+++ b/src/Events/SpecGenerationStarted.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Events;

--- a/src/Extensions/OpenApiExtensions.php
+++ b/src/Extensions/OpenApiExtensions.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Extensions;

--- a/src/Extensions/OperationContext.php
+++ b/src/Extensions/OperationContext.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Extensions;

--- a/src/Extensions/SchemaContext.php
+++ b/src/Extensions/SchemaContext.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Extensions;

--- a/src/Generator/GenerationContext.php
+++ b/src/Generator/GenerationContext.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Generator;

--- a/src/Http/DocsController.php
+++ b/src/Http/DocsController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Http;

--- a/src/Lint/AnnotationWalker.php
+++ b/src/Lint/AnnotationWalker.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/ArrayFindingsCollector.php
+++ b/src/Lint/ArrayFindingsCollector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/EventDispatchingFindingsCollector.php
+++ b/src/Lint/EventDispatchingFindingsCollector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/Finding.php
+++ b/src/Lint/Finding.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/FindingLocation.php
+++ b/src/Lint/FindingLocation.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/FindingsCollector.php
+++ b/src/Lint/FindingsCollector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/Formatters/CliFormatter.php
+++ b/src/Lint/Formatters/CliFormatter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Formatters;

--- a/src/Lint/Formatters/Formatter.php
+++ b/src/Lint/Formatters/Formatter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Formatters;

--- a/src/Lint/Formatters/GithubFormatter.php
+++ b/src/Lint/Formatters/GithubFormatter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Formatters;

--- a/src/Lint/Formatters/JsonFormatter.php
+++ b/src/Lint/Formatters/JsonFormatter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Formatters;

--- a/src/Lint/IdentifierCase.php
+++ b/src/Lint/IdentifierCase.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LintContext.php
+++ b/src/Lint/LintContext.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LintOptions.php
+++ b/src/Lint/LintOptions.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LintResult.php
+++ b/src/Lint/LintResult.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LintRouteFilter.php
+++ b/src/Lint/LintRouteFilter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LintRunner.php
+++ b/src/Lint/LintRunner.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LinterOutputFormat.php
+++ b/src/Lint/LinterOutputFormat.php
@@ -1,15 +1,5 @@
 <?php
 
-/**
- * This file is part of laravel-openapi, a Matchory application.
- *
- * Unauthorized copying of this file, via any medium, is strictly prohibited.
- * Its contents are strictly confidential and proprietary.
- *
- * @copyright 2020–2026 Matchory GmbH · All rights reserved
- * @author    Moritz Friedrich <moritz@matchory.com>
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LinterSummary.php
+++ b/src/Lint/LinterSummary.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/LoggingFindingsCollector.php
+++ b/src/Lint/LoggingFindingsCollector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/ReflectionAttributeCache.php
+++ b/src/Lint/ReflectionAttributeCache.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/RuleCatalogRenderer.php
+++ b/src/Lint/RuleCatalogRenderer.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/RuleRegistry.php
+++ b/src/Lint/RuleRegistry.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/Rules/AbstractFieldRule.php
+++ b/src/Lint/Rules/AbstractFieldRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/AbstractNamingRule.php
+++ b/src/Lint/Rules/AbstractNamingRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ComponentNameNamingInconsistent.php
+++ b/src/Lint/Rules/ComponentNameNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ComponentOrphaned.php
+++ b/src/Lint/Rules/ComponentOrphaned.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/DeprecatedAttribute.php
+++ b/src/Lint/Rules/DeprecatedAttribute.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/DeprecatedNoReplacement.php
+++ b/src/Lint/Rules/DeprecatedNoReplacement.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/DeprecatedNoSunsetDate.php
+++ b/src/Lint/Rules/DeprecatedNoSunsetDate.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/DiscriminatorInvalidMapping.php
+++ b/src/Lint/Rules/DiscriminatorInvalidMapping.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/EnumValuesUndocumented.php
+++ b/src/Lint/Rules/EnumValuesUndocumented.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ErrorsResolverFailed.php
+++ b/src/Lint/Rules/ErrorsResolverFailed.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ExternaldocsInvalidUrl.php
+++ b/src/Lint/Rules/ExternaldocsInvalidUrl.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/FieldConflictingType.php
+++ b/src/Lint/Rules/FieldConflictingType.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/FieldDescriptionMissing.php
+++ b/src/Lint/Rules/FieldDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/FieldEnumMismatch.php
+++ b/src/Lint/Rules/FieldEnumMismatch.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/FieldInvalidFormat.php
+++ b/src/Lint/Rules/FieldInvalidFormat.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/FieldNameNamingInconsistent.php
+++ b/src/Lint/Rules/FieldNameNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/FieldNoEffect.php
+++ b/src/Lint/Rules/FieldNoEffect.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/HeaderDescriptionMissing.php
+++ b/src/Lint/Rules/HeaderDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/HeaderInvalidName.php
+++ b/src/Lint/Rules/HeaderInvalidName.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/HeaderNameNamingInconsistent.php
+++ b/src/Lint/Rules/HeaderNameNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/HideExposeConflict.php
+++ b/src/Lint/Rules/HideExposeConflict.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/InfoDescriptionMissing.php
+++ b/src/Lint/Rules/InfoDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/InfoMetadataIncomplete.php
+++ b/src/Lint/Rules/InfoMetadataIncomplete.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/LinkBothOperationIdAndRef.php
+++ b/src/Lint/Rules/LinkBothOperationIdAndRef.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/LinkDuplicateName.php
+++ b/src/Lint/Rules/LinkDuplicateName.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/LinkInvalidOperation.php
+++ b/src/Lint/Rules/LinkInvalidOperation.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/LinkInvalidParameter.php
+++ b/src/Lint/Rules/LinkInvalidParameter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/LinkNeitherOperationIdNorRef.php
+++ b/src/Lint/Rules/LinkNeitherOperationIdNorRef.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/LinkParameterRequiredMissing.php
+++ b/src/Lint/Rules/LinkParameterRequiredMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/MetaNoSuppressionReason.php
+++ b/src/Lint/Rules/MetaNoSuppressionReason.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/MetaSuppressionStale.php
+++ b/src/Lint/Rules/MetaSuppressionStale.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/MetaTooManySuppressions.php
+++ b/src/Lint/Rules/MetaTooManySuppressions.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/MetaUnknownRule.php
+++ b/src/Lint/Rules/MetaUnknownRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationDescriptionMissing.php
+++ b/src/Lint/Rules/OperationDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationIdDuplicate.php
+++ b/src/Lint/Rules/OperationIdDuplicate.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationIdInvalidChars.php
+++ b/src/Lint/Rules/OperationIdInvalidChars.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationIdMissing.php
+++ b/src/Lint/Rules/OperationIdMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationIdNamingInconsistent.php
+++ b/src/Lint/Rules/OperationIdNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationSecurityMissing.php
+++ b/src/Lint/Rules/OperationSecurityMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationSummaryEqualsDescription.php
+++ b/src/Lint/Rules/OperationSummaryEqualsDescription.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OperationTagMissing.php
+++ b/src/Lint/Rules/OperationTagMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OverridesUnknownField.php
+++ b/src/Lint/Rules/OverridesUnknownField.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/OverridesUnused.php
+++ b/src/Lint/Rules/OverridesUnused.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterDescriptionMissing.php
+++ b/src/Lint/Rules/ParameterDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterDuplicateName.php
+++ b/src/Lint/Rules/ParameterDuplicateName.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterExampleConflict.php
+++ b/src/Lint/Rules/ParameterExampleConflict.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterExampleMissing.php
+++ b/src/Lint/Rules/ParameterExampleMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterNameNamingInconsistent.php
+++ b/src/Lint/Rules/ParameterNameNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterPathMustBeRequired.php
+++ b/src/Lint/Rules/ParameterPathMustBeRequired.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterQueryArrayNoExplode.php
+++ b/src/Lint/Rules/ParameterQueryArrayNoExplode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ParameterQueryNoSchema.php
+++ b/src/Lint/Rules/ParameterQueryNoSchema.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/PathParameterUndeclared.php
+++ b/src/Lint/Rules/PathParameterUndeclared.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/PathParameterUndefined.php
+++ b/src/Lint/Rules/PathParameterUndefined.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/PathSegmentNamingInconsistent.php
+++ b/src/Lint/Rules/PathSegmentNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/PathTrailingSlashInconsistent.php
+++ b/src/Lint/Rules/PathTrailingSlashInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/PublicEndpointContradictsMw.php
+++ b/src/Lint/Rules/PublicEndpointContradictsMw.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/QueryParamDuplicate.php
+++ b/src/Lint/Rules/QueryParamDuplicate.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/RefBroken.php
+++ b/src/Lint/Rules/RefBroken.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/RequestBodyDescriptionMissing.php
+++ b/src/Lint/Rules/RequestBodyDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/RequestBodyExampleMissing.php
+++ b/src/Lint/Rules/RequestBodyExampleMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/RequestBodyNoContent.php
+++ b/src/Lint/Rules/RequestBodyNoContent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/RequestBodyOnGetOrDelete.php
+++ b/src/Lint/Rules/RequestBodyOnGetOrDelete.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/RequestEmpty.php
+++ b/src/Lint/Rules/RequestEmpty.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseDescriptionMissing.php
+++ b/src/Lint/Rules/ResponseDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseDuplicateStatus.php
+++ b/src/Lint/Rules/ResponseDuplicateStatus.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseExampleMissing.php
+++ b/src/Lint/Rules/ResponseExampleMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseNoError.php
+++ b/src/Lint/Rules/ResponseNoError.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseNoSuccess.php
+++ b/src/Lint/Rules/ResponseNoSuccess.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseRedirectWithoutLocation.php
+++ b/src/Lint/Rules/ResponseRedirectWithoutLocation.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseRefUnresolvable.php
+++ b/src/Lint/Rules/ResponseRefUnresolvable.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseStatusUnconventional.php
+++ b/src/Lint/Rules/ResponseStatusUnconventional.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ResponseSuccessEmptyBody.php
+++ b/src/Lint/Rules/ResponseSuccessEmptyBody.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaAllOfTypeConflict.php
+++ b/src/Lint/Rules/SchemaAllOfTypeConflict.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaConstraintsMissing.php
+++ b/src/Lint/Rules/SchemaConstraintsMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaDescriptionMissing.php
+++ b/src/Lint/Rules/SchemaDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaEnumEmpty.php
+++ b/src/Lint/Rules/SchemaEnumEmpty.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaEnumTypeMismatch.php
+++ b/src/Lint/Rules/SchemaEnumTypeMismatch.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaExampleMissing.php
+++ b/src/Lint/Rules/SchemaExampleMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaNullableViaDeprecatedKeyword.php
+++ b/src/Lint/Rules/SchemaNullableViaDeprecatedKeyword.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SchemaRequiredWithoutProperty.php
+++ b/src/Lint/Rules/SchemaRequiredWithoutProperty.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ScopeOverlyBroad.php
+++ b/src/Lint/Rules/ScopeOverlyBroad.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SecurityInvalidScope.php
+++ b/src/Lint/Rules/SecurityInvalidScope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SecuritySchemeUndefined.php
+++ b/src/Lint/Rules/SecuritySchemeUndefined.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ServerInvalidUrl.php
+++ b/src/Lint/Rules/ServerInvalidUrl.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ServerVariableUndeclared.php
+++ b/src/Lint/Rules/ServerVariableUndeclared.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SpecConfigOrphaned.php
+++ b/src/Lint/Rules/SpecConfigOrphaned.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SpecInvalid.php
+++ b/src/Lint/Rules/SpecInvalid.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SpecRouteOrphaned.php
+++ b/src/Lint/Rules/SpecRouteOrphaned.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SpecUnknownReference.php
+++ b/src/Lint/Rules/SpecUnknownReference.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/StreamingNoContentType.php
+++ b/src/Lint/Rules/StreamingNoContentType.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/SummaryMissing.php
+++ b/src/Lint/Rules/SummaryMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/TagDuplicate.php
+++ b/src/Lint/Rules/TagDuplicate.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/TagNameNamingInconsistent.php
+++ b/src/Lint/Rules/TagNameNamingInconsistent.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/TagUndeclaredAtRoot.php
+++ b/src/Lint/Rules/TagUndeclaredAtRoot.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/TagsNoDescription.php
+++ b/src/Lint/Rules/TagsNoDescription.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/ThrowsTransitiveMissing.php
+++ b/src/Lint/Rules/ThrowsTransitiveMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/VisibilityAttributeNoOp.php
+++ b/src/Lint/Rules/VisibilityAttributeNoOp.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/WebhookDescriptionMissing.php
+++ b/src/Lint/Rules/WebhookDescriptionMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/Rules/WebhookNameDuplicate.php
+++ b/src/Lint/Rules/WebhookNameDuplicate.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;

--- a/src/Lint/SuppressionCollector.php
+++ b/src/Lint/SuppressionCollector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/SuppressionDirective.php
+++ b/src/Lint/SuppressionDirective.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/SuppressionScope.php
+++ b/src/Lint/SuppressionScope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/Tree/ApiNode.php
+++ b/src/Lint/Tree/ApiNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/ComponentSchemaNode.php
+++ b/src/Lint/Tree/ComponentSchemaNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/ExampleNode.php
+++ b/src/Lint/Tree/ExampleNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/FieldNode.php
+++ b/src/Lint/Tree/FieldNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/HeaderNode.php
+++ b/src/Lint/Tree/HeaderNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/LinkNode.php
+++ b/src/Lint/Tree/LinkNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/Node.php
+++ b/src/Lint/Tree/Node.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/OperationNode.php
+++ b/src/Lint/Tree/OperationNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/ParameterNode.php
+++ b/src/Lint/Tree/ParameterNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/QueryParameterNode.php
+++ b/src/Lint/Tree/QueryParameterNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/RequestBodyNode.php
+++ b/src/Lint/Tree/RequestBodyNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/ResponseNode.php
+++ b/src/Lint/Tree/ResponseNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/SchemaAccessor.php
+++ b/src/Lint/Tree/SchemaAccessor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/SpecTreeBuilder.php
+++ b/src/Lint/Tree/SpecTreeBuilder.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/SpecTreeWalker.php
+++ b/src/Lint/Tree/SpecTreeWalker.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/Tree/WebhookNode.php
+++ b/src/Lint/Tree/WebhookNode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Tree;

--- a/src/Lint/TreeIndex.php
+++ b/src/Lint/TreeIndex.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint;

--- a/src/Lint/Visitors/ApiRule.php
+++ b/src/Lint/Visitors/ApiRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/ComponentSchemaRule.php
+++ b/src/Lint/Visitors/ComponentSchemaRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/ExampleRule.php
+++ b/src/Lint/Visitors/ExampleRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/FieldRule.php
+++ b/src/Lint/Visitors/FieldRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/Finalizable.php
+++ b/src/Lint/Visitors/Finalizable.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/HeaderRule.php
+++ b/src/Lint/Visitors/HeaderRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/LinkRule.php
+++ b/src/Lint/Visitors/LinkRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/OperationRule.php
+++ b/src/Lint/Visitors/OperationRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/ParameterRule.php
+++ b/src/Lint/Visitors/ParameterRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/PostWalkRule.php
+++ b/src/Lint/Visitors/PostWalkRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/PreBuildRule.php
+++ b/src/Lint/Visitors/PreBuildRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/QueryParameterRule.php
+++ b/src/Lint/Visitors/QueryParameterRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/RequestBodyRule.php
+++ b/src/Lint/Visitors/RequestBodyRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/Resettable.php
+++ b/src/Lint/Visitors/Resettable.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/ResponseRule.php
+++ b/src/Lint/Visitors/ResponseRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/RouteRule.php
+++ b/src/Lint/Visitors/RouteRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/Visitor.php
+++ b/src/Lint/Visitors/Visitor.php
@@ -1,15 +1,5 @@
 <?php
 
-/**
- * This file is part of laravel-openapi, a Matchory application.
- *
- * Unauthorized copying of this file, via any medium, is strictly prohibited.
- * Its contents are strictly confidential and proprietary.
- *
- * @copyright 2020–2026 Matchory GmbH · All rights reserved
- * @author    Moritz Friedrich <moritz@matchory.com>
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/Lint/Visitors/WebhookRule.php
+++ b/src/Lint/Visitors/WebhookRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Visitors;

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi;

--- a/src/PhpStan/Rules/DuplicateResponseHeaderRule.php
+++ b/src/PhpStan/Rules/DuplicateResponseHeaderRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/DuplicateResponseStatusRule.php
+++ b/src/PhpStan/Rules/DuplicateResponseStatusRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/ExampleValueOrFileRule.php
+++ b/src/PhpStan/Rules/ExampleValueOrFileRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/ExceptionResponseOnNonThrowableRule.php
+++ b/src/PhpStan/Rules/ExceptionResponseOnNonThrowableRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/ExposeOnlyExceptRule.php
+++ b/src/PhpStan/Rules/ExposeOnlyExceptRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/FieldRangeOrderingRule.php
+++ b/src/PhpStan/Rules/FieldRangeOrderingRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/HideExposeConflictRule.php
+++ b/src/PhpStan/Rules/HideExposeConflictRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/HideOnlyExceptRule.php
+++ b/src/PhpStan/Rules/HideOnlyExceptRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/LinkOperationTargetRule.php
+++ b/src/PhpStan/Rules/LinkOperationTargetRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/PublicEndpointSecurityConflictRule.php
+++ b/src/PhpStan/Rules/PublicEndpointSecurityConflictRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/QueryParamRequiredWithDefaultRule.php
+++ b/src/PhpStan/Rules/QueryParamRequiredWithDefaultRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Rules/ResponseRefAndSchemaRule.php
+++ b/src/PhpStan/Rules/ResponseRefAndSchemaRule.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Rules;

--- a/src/PhpStan/Support/AttributeHelpers.php
+++ b/src/PhpStan/Support/AttributeHelpers.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\PhpStan\Support;

--- a/src/Plugins/ApiResources/ApiResourcesPlugin.php
+++ b/src/Plugins/ApiResources/ApiResourcesPlugin.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources;

--- a/src/Plugins/ApiResources/Attributes/ResourceField.php
+++ b/src/Plugins/ApiResources/Attributes/ResourceField.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources\Attributes;

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldTypeMissing.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldTypeMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources\Lint\Rules;

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources\Lint\Rules;

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources\Lint\Rules;

--- a/src/Plugins/ApiResources/ResourceClassLocator.php
+++ b/src/Plugins/ApiResources/ResourceClassLocator.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources;

--- a/src/Plugins/ApiResources/ResourceEnvelopeFactory.php
+++ b/src/Plugins/ApiResources/ResourceEnvelopeFactory.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources;

--- a/src/Plugins/ApiResources/ResourceRefSchemaResolver.php
+++ b/src/Plugins/ApiResources/ResourceRefSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources;

--- a/src/Plugins/ApiResources/ResourceResponseResolver.php
+++ b/src/Plugins/ApiResources/ResourceResponseResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources;

--- a/src/Plugins/ApiResources/SchemaFromResource.php
+++ b/src/Plugins/ApiResources/SchemaFromResource.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\ApiResources;

--- a/src/Plugins/Fractal/Attributes/FractalResponse.php
+++ b/src/Plugins/Fractal/Attributes/FractalResponse.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Attributes;

--- a/src/Plugins/Fractal/Attributes/TransformerField.php
+++ b/src/Plugins/Fractal/Attributes/TransformerField.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Attributes;

--- a/src/Plugins/Fractal/Attributes/TransformerInclude.php
+++ b/src/Plugins/Fractal/Attributes/TransformerInclude.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Attributes;

--- a/src/Plugins/Fractal/FractalEnvelopeFactory.php
+++ b/src/Plugins/Fractal/FractalEnvelopeFactory.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal;

--- a/src/Plugins/Fractal/FractalPlugin.php
+++ b/src/Plugins/Fractal/FractalPlugin.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal;

--- a/src/Plugins/Fractal/FractalResponseResolver.php
+++ b/src/Plugins/Fractal/FractalResponseResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal;

--- a/src/Plugins/Fractal/Lint/Rules/FractalDuplicateKey.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalDuplicateKey.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules;

--- a/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules;

--- a/src/Plugins/Fractal/Lint/Rules/FractalIncludeTransformerMissing.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalIncludeTransformerMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules;

--- a/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules;

--- a/src/Plugins/Fractal/Lint/Rules/FractalTransformerClassMissing.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalTransformerClassMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules;

--- a/src/Plugins/Fractal/SchemaFromTransformer.php
+++ b/src/Plugins/Fractal/SchemaFromTransformer.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal;

--- a/src/Plugins/Fractal/Serializer.php
+++ b/src/Plugins/Fractal/Serializer.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal;

--- a/src/Plugins/Fractal/TransformerRefSchemaResolver.php
+++ b/src/Plugins/Fractal/TransformerRefSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fractal;

--- a/src/Plugins/QueryBuilder/Attributes/AllowedFilter.php
+++ b/src/Plugins/QueryBuilder/Attributes/AllowedFilter.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder\Attributes;

--- a/src/Plugins/QueryBuilder/Attributes/AllowedInclude.php
+++ b/src/Plugins/QueryBuilder/Attributes/AllowedInclude.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder\Attributes;

--- a/src/Plugins/QueryBuilder/Attributes/AllowedSort.php
+++ b/src/Plugins/QueryBuilder/Attributes/AllowedSort.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder\Attributes;

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterTypeMissing.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterTypeMissing.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder\Lint\Rules;

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder\Lint\Rules;

--- a/src/Plugins/QueryBuilder/QueryBuilderParameterResolver.php
+++ b/src/Plugins/QueryBuilder/QueryBuilderParameterResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder;

--- a/src/Plugins/QueryBuilder/QueryBuilderPlugin.php
+++ b/src/Plugins/QueryBuilder/QueryBuilderPlugin.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\QueryBuilder;

--- a/src/Plugins/SpatieData/DataClassRequestSchemaResolver.php
+++ b/src/Plugins/SpatieData/DataClassRequestSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/DataRefSchemaResolver.php
+++ b/src/Plugins/SpatieData/DataRefSchemaResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/DataResponseResolver.php
+++ b/src/Plugins/SpatieData/DataResponseResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/DataSyntheticPayloadBuilder.php
+++ b/src/Plugins/SpatieData/DataSyntheticPayloadBuilder.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/FilePropertyChecker.php
+++ b/src/Plugins/SpatieData/FilePropertyChecker.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
+++ b/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData\Lint\Rules;

--- a/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
+++ b/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData\Lint\Rules;

--- a/src/Plugins/SpatieData/PropertyContext.php
+++ b/src/Plugins/SpatieData/PropertyContext.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/SchemaFromDataClass.php
+++ b/src/Plugins/SpatieData/SchemaFromDataClass.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Plugins/SpatieData/SpatieDataPlugin.php
+++ b/src/Plugins/SpatieData/SpatieDataPlugin.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SpatieData;

--- a/src/Registry/OpenApiRegistry.php
+++ b/src/Registry/OpenApiRegistry.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Registry;

--- a/src/Routing/ActionDescriptor.php
+++ b/src/Routing/ActionDescriptor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Routing;

--- a/src/Routing/DocComment.php
+++ b/src/Routing/DocComment.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Routing;

--- a/src/Routing/ResourceTarget.php
+++ b/src/Routing/ResourceTarget.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Routing;

--- a/src/Support/Attributes/DescriptionDirectives.php
+++ b/src/Support/Attributes/DescriptionDirectives.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Attributes;

--- a/src/Support/Attributes/FieldDefault.php
+++ b/src/Support/Attributes/FieldDefault.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Attributes;

--- a/src/Support/Attributes/ParsedDescription.php
+++ b/src/Support/Attributes/ParsedDescription.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Attributes;

--- a/src/Support/Config/ConfigDiffer.php
+++ b/src/Support/Config/ConfigDiffer.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Config;

--- a/src/Support/Extraction/DetectsAuthMiddleware.php
+++ b/src/Support/Extraction/DetectsAuthMiddleware.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Extraction/FieldDescriptor.php
+++ b/src/Support/Extraction/FieldDescriptor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Extraction/PayloadParameterScanner.php
+++ b/src/Support/Extraction/PayloadParameterScanner.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Extraction/RequestBodyExtractor.php
+++ b/src/Support/Extraction/RequestBodyExtractor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Extraction/RuleDocumentation.php
+++ b/src/Support/Extraction/RuleDocumentation.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Extraction/SecurityExtractor.php
+++ b/src/Support/Extraction/SecurityExtractor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Extraction/UriParametersExtractor.php
+++ b/src/Support/Extraction/UriParametersExtractor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;

--- a/src/Support/Generator/BaselineRegistration.php
+++ b/src/Support/Generator/BaselineRegistration.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/ComponentSchemaRegistry.php
+++ b/src/Support/Generator/ComponentSchemaRegistry.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/ExampleFileLoader.php
+++ b/src/Support/Generator/ExampleFileLoader.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/JsonSchemaFromType.php
+++ b/src/Support/Generator/JsonSchemaFromType.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/NullableSchema.php
+++ b/src/Support/Generator/NullableSchema.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/OpenApiGenerationOrchestrator.php
+++ b/src/Support/Generator/OpenApiGenerationOrchestrator.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/OpenApiGenerator.php
+++ b/src/Support/Generator/OpenApiGenerator.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/OperationBuilder.php
+++ b/src/Support/Generator/OperationBuilder.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/OperationDescriptor.php
+++ b/src/Support/Generator/OperationDescriptor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/OverrideMatcher.php
+++ b/src/Support/Generator/OverrideMatcher.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/SchemaDescriptor.php
+++ b/src/Support/Generator/SchemaDescriptor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/SpecPipeline.php
+++ b/src/Support/Generator/SpecPipeline.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator;

--- a/src/Support/Generator/Stages/ComponentsStage.php
+++ b/src/Support/Generator/Stages/ComponentsStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Generator/Stages/ErrorResponseInferenceStage.php
+++ b/src/Support/Generator/Stages/ErrorResponseInferenceStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Generator/Stages/OverridesStage.php
+++ b/src/Support/Generator/Stages/OverridesStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Generator/Stages/PathsStage.php
+++ b/src/Support/Generator/Stages/PathsStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Generator/Stages/RootStage.php
+++ b/src/Support/Generator/Stages/RootStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Generator/Stages/SecurityStage.php
+++ b/src/Support/Generator/Stages/SecurityStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Generator/Stages/TransformersStage.php
+++ b/src/Support/Generator/Stages/TransformersStage.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Generator\Stages;

--- a/src/Support/Inclusion/InclusionDecision.php
+++ b/src/Support/Inclusion/InclusionDecision.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Inclusion;

--- a/src/Support/Inclusion/InclusionEvaluator.php
+++ b/src/Support/Inclusion/InclusionEvaluator.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Inclusion;

--- a/src/Support/Inclusion/TraceEntry.php
+++ b/src/Support/Inclusion/TraceEntry.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Inclusion;

--- a/src/Support/PhpDoc/DocBlockParser.php
+++ b/src/Support/PhpDoc/DocBlockParser.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\PhpDoc;

--- a/src/Support/PhpDoc/ParsedDocBlock.php
+++ b/src/Support/PhpDoc/ParsedDocBlock.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\PhpDoc;

--- a/src/Support/Registry/ResolvedSchema.php
+++ b/src/Support/Registry/ResolvedSchema.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Registry;

--- a/src/Support/Routing/DocCommentParser.php
+++ b/src/Support/Routing/DocCommentParser.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Routing/ReturnTypeExtractor.php
+++ b/src/Support/Routing/ReturnTypeExtractor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Routing/RouteIntrospector.php
+++ b/src/Support/Routing/RouteIntrospector.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Routing/ThrowsExtractor.php
+++ b/src/Support/Routing/ThrowsExtractor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Routing/UriParameterDescriptor.php
+++ b/src/Support/Routing/UriParameterDescriptor.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Routing/UriParameterResolver.php
+++ b/src/Support/Routing/UriParameterResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Routing/WhereKind.php
+++ b/src/Support/Routing/WhereKind.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Routing;

--- a/src/Support/Spec/SpecDefinition.php
+++ b/src/Support/Spec/SpecDefinition.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Spec;

--- a/src/Support/Spec/SpecMatcher.php
+++ b/src/Support/Spec/SpecMatcher.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Spec;

--- a/src/Support/Spec/SpecRegistry.php
+++ b/src/Support/Spec/SpecRegistry.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Spec;

--- a/src/Support/Spec/SpecResolver.php
+++ b/src/Support/Spec/SpecResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Spec;

--- a/src/Support/Types/TypeNodeResolver.php
+++ b/src/Support/Types/TypeNodeResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Types;

--- a/src/Support/Visibility/VisibilityMode.php
+++ b/src/Support/Visibility/VisibilityMode.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Visibility;

--- a/src/Support/Visibility/VisibilityResolver.php
+++ b/src/Support/Visibility/VisibilityResolver.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Visibility;

--- a/src/Testing/ActionDescriptorFactory.php
+++ b/src/Testing/ActionDescriptorFactory.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Testing;

--- a/src/Testing/SchemaContextScope.php
+++ b/src/Testing/SchemaContextScope.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Testing;

--- a/tests/Arch/CoreBoundaryTest.php
+++ b/tests/Arch/CoreBoundaryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 // Enforces the one-way dependency stated in CLAUDE.md:

--- a/tests/Feature/ActionRequestBodyTest.php
+++ b/tests/Feature/ActionRequestBodyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/AuthoringAttributesTest.php
+++ b/tests/Feature/AuthoringAttributesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ClosureRouteAttributesTest.php
+++ b/tests/Feature/ClosureRouteAttributesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ComponentizedResponsesTest.php
+++ b/tests/Feature/ComponentizedResponsesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ConfigSurfaceTest.php
+++ b/tests/Feature/ConfigSurfaceTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/Console/DiffConfigCommandTest.php
+++ b/tests/Feature/Console/DiffConfigCommandTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 uses()->group('console', 'openapi');

--- a/tests/Feature/DataDiscriminatorTest.php
+++ b/tests/Feature/DataDiscriminatorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/DataValidationRulesTest.php
+++ b/tests/Feature/DataValidationRulesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/DeprecatedFieldTest.php
+++ b/tests/Feature/DeprecatedFieldTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/EnumCaseDescriptionTest.php
+++ b/tests/Feature/EnumCaseDescriptionTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/Errors/DefaultBodylessTest.php
+++ b/tests/Feature/Errors/DefaultBodylessTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Feature/Errors/EnvelopePresetSnapshotTest.php
+++ b/tests/Feature/Errors/EnvelopePresetSnapshotTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Feature/Errors/MixedExceptionsAtSameStatusTest.php
+++ b/tests/Feature/Errors/MixedExceptionsAtSameStatusTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ExampleFileLoaderTest.php
+++ b/tests/Feature/ExampleFileLoaderTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/Examples/FakerSynthesisIntegrationTest.php
+++ b/tests/Feature/Examples/FakerSynthesisIntegrationTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/tests/Feature/ExamplesTest.php
+++ b/tests/Feature/ExamplesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Examples\Shared\Flavors;

--- a/tests/Feature/ExtensionsTest.php
+++ b/tests/Feature/ExtensionsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/FormRequestSchemaTest.php
+++ b/tests/Feature/FormRequestSchemaTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/Lint/Formatters/CliFormatterTest.php
+++ b/tests/Feature/Lint/Formatters/CliFormatterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Finding;

--- a/tests/Feature/Lint/HideExposeConflictTest.php
+++ b/tests/Feature/Lint/HideExposeConflictTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Feature/Lint/IgnoreLintClassScopeTest.php
+++ b/tests/Feature/Lint/IgnoreLintClassScopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Feature/Lint/LintCommandTest.php
+++ b/tests/Feature/Lint/LintCommandTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\LintOptions;

--- a/tests/Feature/Lint/RequestEmptyTest.php
+++ b/tests/Feature/Lint/RequestEmptyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\ArrayFindingsCollector;

--- a/tests/Feature/Lint/RuleCatalogCoverageTest.php
+++ b/tests/Feature/Lint/RuleCatalogCoverageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Contracts\Lint\Rule;

--- a/tests/Feature/Lint/RuleCatalogRendererTest.php
+++ b/tests/Feature/Lint/RuleCatalogRendererTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\LinterOutputFormat;

--- a/tests/Feature/Lint/ThrowsUnmappedTest.php
+++ b/tests/Feature/Lint/ThrowsUnmappedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\ArrayFindingsCollector;

--- a/tests/Feature/Lint/VisibilityAttributeNoOpTest.php
+++ b/tests/Feature/Lint/VisibilityAttributeNoOpTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Feature/MissingPluginDependencyTest.php
+++ b/tests/Feature/MissingPluginDependencyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/MultiSchemeSecurityTest.php
+++ b/tests/Feature/MultiSchemeSecurityTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/MultiSpecNamedRouteTest.php
+++ b/tests/Feature/MultiSpecNamedRouteTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/MultiSpecRoutesTest.php
+++ b/tests/Feature/MultiSpecRoutesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/NoEagerResolutionTest.php
+++ b/tests/Feature/NoEagerResolutionTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/OperationTagsTest.php
+++ b/tests/Feature/OperationTagsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/OverridesTest.php
+++ b/tests/Feature/OverridesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/PaginatorResponseTest.php
+++ b/tests/Feature/PaginatorResponseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/PluginStageRegistrationTest.php
+++ b/tests/Feature/PluginStageRegistrationTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/Plugins/ApiResources/ApiResourceResponseTest.php
+++ b/tests/Feature/Plugins/ApiResources/ApiResourceResponseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\ApiResources;

--- a/tests/Feature/Plugins/ApiResources/Lint/ResourceFieldTypeMissingTest.php
+++ b/tests/Feature/Plugins/ApiResources/Lint/ResourceFieldTypeMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\ApiResources\Lint;

--- a/tests/Feature/Plugins/ApiResources/Lint/ResourceFieldsUndeclaredTest.php
+++ b/tests/Feature/Plugins/ApiResources/Lint/ResourceFieldsUndeclaredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\ApiResources\Lint;

--- a/tests/Feature/Plugins/ApiResources/Lint/ResourceResponseAmbiguousTest.php
+++ b/tests/Feature/Plugins/ApiResources/Lint/ResourceResponseAmbiguousTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\ApiResources\Lint;

--- a/tests/Feature/Plugins/DefaultPluginsConfigTest.php
+++ b/tests/Feature/Plugins/DefaultPluginsConfigTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins;

--- a/tests/Feature/Plugins/PluginSuiteIntegrationTest.php
+++ b/tests/Feature/Plugins/PluginSuiteIntegrationTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins;

--- a/tests/Feature/Plugins/QueryBuilder/QueryBuilderParameterTest.php
+++ b/tests/Feature/Plugins/QueryBuilder/QueryBuilderParameterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\QueryBuilder;

--- a/tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php
+++ b/tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\SpatieData;

--- a/tests/Feature/Plugins/SpatieData/DataResponseResolverTest.php
+++ b/tests/Feature/Plugins/SpatieData/DataResponseResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\SpatieData;

--- a/tests/Feature/Plugins/SpatieData/SchemaFromDataClassTest.php
+++ b/tests/Feature/Plugins/SpatieData/SchemaFromDataClassTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature\Plugins\SpatieData;

--- a/tests/Feature/QueryParamClassLevelTest.php
+++ b/tests/Feature/QueryParamClassLevelTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ResponseHeaderClassLevelTest.php
+++ b/tests/Feature/ResponseHeaderClassLevelTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ScopedDiBindingsTest.php
+++ b/tests/Feature/ScopedDiBindingsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/SelfRoutesExclusionTest.php
+++ b/tests/Feature/SelfRoutesExclusionTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 uses()->group('routing', 'openapi');

--- a/tests/Feature/StackedSecurityTest.php
+++ b/tests/Feature/StackedSecurityTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/StreamingResponseTest.php
+++ b/tests/Feature/StreamingResponseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/SummaryDescriptionAttributesTest.php
+++ b/tests/Feature/SummaryDescriptionAttributesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/UnionReturnTypeTest.php
+++ b/tests/Feature/UnionReturnTypeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/VisibilityDefaultHiddenTest.php
+++ b/tests/Feature/VisibilityDefaultHiddenTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Feature/ZeroRouteSpecTest.php
+++ b/tests/Feature/ZeroRouteSpecTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Feature;

--- a/tests/Fixtures/Action.php
+++ b/tests/Fixtures/Action.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/ActionFixture.php
+++ b/tests/Fixtures/ActionFixture.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/ActionFixtureData.php
+++ b/tests/Fixtures/ActionFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/AddressFixtureData.php
+++ b/tests/Fixtures/AddressFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Alpha/SelfRefData.php
+++ b/tests/Fixtures/Alpha/SelfRefData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Alpha;

--- a/tests/Fixtures/Auth/AuthFixtureController.php
+++ b/tests/Fixtures/Auth/AuthFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Auth;

--- a/tests/Fixtures/AuthoringFixtureController.php
+++ b/tests/Fixtures/AuthoringFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/BareWildcardArrayFormRequest.php
+++ b/tests/Fixtures/BareWildcardArrayFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Beta/SelfRefData.php
+++ b/tests/Fixtures/Beta/SelfRefData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Beta;

--- a/tests/Fixtures/CycleAFixtureData.php
+++ b/tests/Fixtures/CycleAFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/CycleBFixtureData.php
+++ b/tests/Fixtures/CycleBFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/DeeplyChainedFormRequest.php
+++ b/tests/Fixtures/DeeplyChainedFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/DeprecatedAttributeFieldFixtureData.php
+++ b/tests/Fixtures/DeprecatedAttributeFieldFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/DeprecatedFieldFixtureData.php
+++ b/tests/Fixtures/DeprecatedFieldFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Discriminator/BaseShapeData.php
+++ b/tests/Fixtures/Discriminator/BaseShapeData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Discriminator;

--- a/tests/Fixtures/Discriminator/CircleData.php
+++ b/tests/Fixtures/Discriminator/CircleData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Discriminator;

--- a/tests/Fixtures/Discriminator/RectangleData.php
+++ b/tests/Fixtures/Discriminator/RectangleData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Discriminator;

--- a/tests/Fixtures/EdgeCaseFixtureController.php
+++ b/tests/Fixtures/EdgeCaseFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Errors/CustomValidationException.php
+++ b/tests/Fixtures/Errors/CustomValidationException.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Errors;

--- a/tests/Fixtures/Errors/ErrorEnvelopeFixtureController.php
+++ b/tests/Fixtures/Errors/ErrorEnvelopeFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Errors;

--- a/tests/Fixtures/FileUploadFixtureController.php
+++ b/tests/Fixtures/FileUploadFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/FileUploadFormRequest.php
+++ b/tests/Fixtures/FileUploadFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Lint/ActionWithConflictingTypeData.php
+++ b/tests/Fixtures/Lint/ActionWithConflictingTypeData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithConflictingTypeDataController.php
+++ b/tests/Fixtures/Lint/ActionWithConflictingTypeDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithEnumMismatchData.php
+++ b/tests/Fixtures/Lint/ActionWithEnumMismatchData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithEnumMismatchDataController.php
+++ b/tests/Fixtures/Lint/ActionWithEnumMismatchDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithFileUploadData.php
+++ b/tests/Fixtures/Lint/ActionWithFileUploadData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithFileUploadDataController.php
+++ b/tests/Fixtures/Lint/ActionWithFileUploadDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithInvalidFormatData.php
+++ b/tests/Fixtures/Lint/ActionWithInvalidFormatData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithInvalidFormatDataController.php
+++ b/tests/Fixtures/Lint/ActionWithInvalidFormatDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithNoEffectData.php
+++ b/tests/Fixtures/Lint/ActionWithNoEffectData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithNoEffectDataController.php
+++ b/tests/Fixtures/Lint/ActionWithNoEffectDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithSuppressedData.php
+++ b/tests/Fixtures/Lint/ActionWithSuppressedData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithSuppressedDataController.php
+++ b/tests/Fixtures/Lint/ActionWithSuppressedDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithWrongScopeData.php
+++ b/tests/Fixtures/Lint/ActionWithWrongScopeData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ActionWithWrongScopeDataController.php
+++ b/tests/Fixtures/Lint/ActionWithWrongScopeDataController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/BadResponseResourceController.php
+++ b/tests/Fixtures/Lint/BadResponseResourceController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/BrokenController.php
+++ b/tests/Fixtures/Lint/BrokenController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/CleanController.php
+++ b/tests/Fixtures/Lint/CleanController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ConflictingTypeFixtureController.php
+++ b/tests/Fixtures/Lint/ConflictingTypeFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ConflictingTypeFixtureData.php
+++ b/tests/Fixtures/Lint/ConflictingTypeFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DeprecatedAttrClassController.php
+++ b/tests/Fixtures/Lint/DeprecatedAttrClassController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DeprecatedAttrController.php
+++ b/tests/Fixtures/Lint/DeprecatedAttrController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DeprecatedTestAttribute.php
+++ b/tests/Fixtures/Lint/DeprecatedTestAttribute.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateLinkNameController.php
+++ b/tests/Fixtures/Lint/DuplicateLinkNameController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateQueryParamController.php
+++ b/tests/Fixtures/Lint/DuplicateQueryParamController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateResponseStatusController.php
+++ b/tests/Fixtures/Lint/DuplicateResponseStatusController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateTagClassController.php
+++ b/tests/Fixtures/Lint/DuplicateTagClassController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateTagController.php
+++ b/tests/Fixtures/Lint/DuplicateTagController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateWebhookNameController.php
+++ b/tests/Fixtures/Lint/DuplicateWebhookNameController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/DuplicateWebhookNameController2.php
+++ b/tests/Fixtures/Lint/DuplicateWebhookNameController2.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/EnumMismatchFixtureController.php
+++ b/tests/Fixtures/Lint/EnumMismatchFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/EnumMismatchFixtureData.php
+++ b/tests/Fixtures/Lint/EnumMismatchFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/FakeAction.php
+++ b/tests/Fixtures/Lint/FakeAction.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/FileUploadFixtureController.php
+++ b/tests/Fixtures/Lint/FileUploadFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/FileUploadFixtureData.php
+++ b/tests/Fixtures/Lint/FileUploadFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/FixtureStatusEnum.php
+++ b/tests/Fixtures/Lint/FixtureStatusEnum.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/HideExposeConflictController.php
+++ b/tests/Fixtures/Lint/HideExposeConflictController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/IgnoreLint/IgnoreLintFixtureController.php
+++ b/tests/Fixtures/Lint/IgnoreLint/IgnoreLintFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint\IgnoreLint;

--- a/tests/Fixtures/Lint/IgnoreLint/SnakeCasedFormRequest.php
+++ b/tests/Fixtures/Lint/IgnoreLint/SnakeCasedFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint\IgnoreLint;

--- a/tests/Fixtures/Lint/IgnoreLint/SnakeCasedJsonResource.php
+++ b/tests/Fixtures/Lint/IgnoreLint/SnakeCasedJsonResource.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint\IgnoreLint;

--- a/tests/Fixtures/Lint/InvalidExternalDocsController.php
+++ b/tests/Fixtures/Lint/InvalidExternalDocsController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/InvalidFormatFixtureController.php
+++ b/tests/Fixtures/Lint/InvalidFormatFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/InvalidFormatFixtureData.php
+++ b/tests/Fixtures/Lint/InvalidFormatFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/InvalidHeaderNameController.php
+++ b/tests/Fixtures/Lint/InvalidHeaderNameController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/NestedFileUploadFixtureController.php
+++ b/tests/Fixtures/Lint/NestedFileUploadFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/NestedFileUploadFixtureData.php
+++ b/tests/Fixtures/Lint/NestedFileUploadFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/NoEffectFixtureController.php
+++ b/tests/Fixtures/Lint/NoEffectFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/NoEffectFixtureData.php
+++ b/tests/Fixtures/Lint/NoEffectFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/NoFileUploadFixtureController.php
+++ b/tests/Fixtures/Lint/NoFileUploadFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/NoFileUploadFixtureData.php
+++ b/tests/Fixtures/Lint/NoFileUploadFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/OperationSecurityMissingController.php
+++ b/tests/Fixtures/Lint/OperationSecurityMissingController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/PublicEndpointMwClassController.php
+++ b/tests/Fixtures/Lint/PublicEndpointMwClassController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/PublicEndpointMwController.php
+++ b/tests/Fixtures/Lint/PublicEndpointMwController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/ResponseEmptyController.php
+++ b/tests/Fixtures/Lint/ResponseEmptyController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SpecMethodShadowsClassController.php
+++ b/tests/Fixtures/Lint/SpecMethodShadowsClassController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SpecRouteOrphanedController.php
+++ b/tests/Fixtures/Lint/SpecRouteOrphanedController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SpecUnknownRefController.php
+++ b/tests/Fixtures/Lint/SpecUnknownRefController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/StreamingFixtureController.php
+++ b/tests/Fixtures/Lint/StreamingFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SuppressedController.php
+++ b/tests/Fixtures/Lint/SuppressedController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SuppressedFixtureController.php
+++ b/tests/Fixtures/Lint/SuppressedFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SuppressedFixtureData.php
+++ b/tests/Fixtures/Lint/SuppressedFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/SuppressedResponseEmptyController.php
+++ b/tests/Fixtures/Lint/SuppressedResponseEmptyController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/TransitiveThrowsController.php
+++ b/tests/Fixtures/Lint/TransitiveThrowsController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/UnmappedException.php
+++ b/tests/Fixtures/Lint/UnmappedException.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/UnresolvableResponseRefController.php
+++ b/tests/Fixtures/Lint/UnresolvableResponseRefController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/VisibilityNoOpController.php
+++ b/tests/Fixtures/Lint/VisibilityNoOpController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/WrongScopeFixtureController.php
+++ b/tests/Fixtures/Lint/WrongScopeFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/Lint/WrongScopeFixtureData.php
+++ b/tests/Fixtures/Lint/WrongScopeFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;

--- a/tests/Fixtures/MapInputNameFixtureData.php
+++ b/tests/Fixtures/MapInputNameFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Models/User.php
+++ b/tests/Fixtures/Models/User.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Models;

--- a/tests/Fixtures/NestedParentData.php
+++ b/tests/Fixtures/NestedParentData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/PlainArrayData.php
+++ b/tests/Fixtures/PlainArrayData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/PropertyFixtureData.php
+++ b/tests/Fixtures/PropertyFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/QueryParamClassFixtureController.php
+++ b/tests/Fixtures/QueryParamClassFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Registry/Bar/CreateData.php
+++ b/tests/Fixtures/Registry/Bar/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Bar;

--- a/tests/Fixtures/Registry/Baz/Bar/CreateData.php
+++ b/tests/Fixtures/Registry/Baz/Bar/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Baz\Bar;

--- a/tests/Fixtures/Registry/Domain/Data/Alpha/CreateData.php
+++ b/tests/Fixtures/Registry/Domain/Data/Alpha/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Domain\Data\Alpha;

--- a/tests/Fixtures/Registry/Domain/Data/Beta/CreateData.php
+++ b/tests/Fixtures/Registry/Domain/Data/Beta/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Domain\Data\Beta;

--- a/tests/Fixtures/Registry/Foo/Bar/CreateData.php
+++ b/tests/Fixtures/Registry/Foo/Bar/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Foo\Bar;

--- a/tests/Fixtures/Registry/Foo/CreateData.php
+++ b/tests/Fixtures/Registry/Foo/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Foo;

--- a/tests/Fixtures/Registry/Projects/CreateData.php
+++ b/tests/Fixtures/Registry/Projects/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Projects;

--- a/tests/Fixtures/Registry/Qux/Bar/CreateData.php
+++ b/tests/Fixtures/Registry/Qux/Bar/CreateData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Registry\Qux\Bar;

--- a/tests/Fixtures/RemoteMediaFixtureController.php
+++ b/tests/Fixtures/RemoteMediaFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/RemoteMediaFixtureRequest.php
+++ b/tests/Fixtures/RemoteMediaFixtureRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/ResponseHeaderClassFixtureController.php
+++ b/tests/Fixtures/ResponseHeaderClassFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/RouteBoundFixtureController.php
+++ b/tests/Fixtures/RouteBoundFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/RouteBoundFormRequest.php
+++ b/tests/Fixtures/RouteBoundFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/ScalarOnlyData.php
+++ b/tests/Fixtures/ScalarOnlyData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/SchemaTitleDescriptionFixtureData.php
+++ b/tests/Fixtures/SchemaTitleDescriptionFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/SimpleFormRequest.php
+++ b/tests/Fixtures/SimpleFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/StatusFixtureEnum.php
+++ b/tests/Fixtures/StatusFixtureEnum.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/TagsWithItemsFixtureData.php
+++ b/tests/Fixtures/TagsWithItemsFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/TeapotException.php
+++ b/tests/Fixtures/TeapotException.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 // Fixture: exception carrying a #[Throws] attribute for extractor tests.
 
 declare(strict_types=1);

--- a/tests/Fixtures/ThrowingRulesFixtureData.php
+++ b/tests/Fixtures/ThrowingRulesFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/Types/BrokenTypeContext.php
+++ b/tests/Fixtures/Types/BrokenTypeContext.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures\Types;

--- a/tests/Fixtures/UnitFixtureEnum.php
+++ b/tests/Fixtures/UnitFixtureEnum.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/UserBoundFormRequest.php
+++ b/tests/Fixtures/UserBoundFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/ValidationRulesFixtureController.php
+++ b/tests/Fixtures/ValidationRulesFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/ValidationRulesFixtureData.php
+++ b/tests/Fixtures/ValidationRulesFixtureData.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/VisibilityFixtureController.php
+++ b/tests/Fixtures/VisibilityFixtureController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/Fixtures/WildcardFormRequest.php
+++ b/tests/Fixtures/WildcardFormRequest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Fixtures;

--- a/tests/PhpStan/DuplicateResponseHeaderRuleTest.php
+++ b/tests/PhpStan/DuplicateResponseHeaderRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/DuplicateResponseStatusRuleTest.php
+++ b/tests/PhpStan/DuplicateResponseStatusRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/ExampleValueOrFileRuleTest.php
+++ b/tests/PhpStan/ExampleValueOrFileRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/ExceptionResponseOnNonThrowableRuleTest.php
+++ b/tests/PhpStan/ExceptionResponseOnNonThrowableRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/ExposeOnlyExceptRuleTest.php
+++ b/tests/PhpStan/ExposeOnlyExceptRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/FieldRangeOrderingRuleTest.php
+++ b/tests/PhpStan/FieldRangeOrderingRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/HideExposeConflictOnClassRuleTest.php
+++ b/tests/PhpStan/HideExposeConflictOnClassRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/HideExposeConflictRuleTest.php
+++ b/tests/PhpStan/HideExposeConflictRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/HideOnlyExceptRuleTest.php
+++ b/tests/PhpStan/HideOnlyExceptRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/LinkOperationTargetRuleTest.php
+++ b/tests/PhpStan/LinkOperationTargetRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/PublicEndpointSecurityConflictRuleTest.php
+++ b/tests/PhpStan/PublicEndpointSecurityConflictRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/QueryParamRequiredWithDefaultRuleTest.php
+++ b/tests/PhpStan/QueryParamRequiredWithDefaultRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/PhpStan/ResponseRefAndSchemaRuleTest.php
+++ b/tests/PhpStan/ResponseRefAndSchemaRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\PhpStan;

--- a/tests/Support/ActionDescriptorFactory.php
+++ b/tests/Support/ActionDescriptorFactory.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Support;

--- a/tests/Support/OperationNodeFactory.php
+++ b/tests/Support/OperationNodeFactory.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Support;

--- a/tests/Unit/Attributes/ExposeTest.php
+++ b/tests/Unit/Attributes/ExposeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\Expose;

--- a/tests/Unit/Attributes/FieldAttributeDirectivesTest.php
+++ b/tests/Unit/Attributes/FieldAttributeDirectivesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\QueryParam;

--- a/tests/Unit/Attributes/HideTest.php
+++ b/tests/Unit/Attributes/HideTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\Hide;

--- a/tests/Unit/Attributes/QueryParamTest.php
+++ b/tests/Unit/Attributes/QueryParamTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\QueryParam;

--- a/tests/Unit/Attributes/RequestFieldTest.php
+++ b/tests/Unit/Attributes/RequestFieldTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\FieldAttribute;

--- a/tests/Unit/Attributes/ResponseFieldTest.php
+++ b/tests/Unit/Attributes/ResponseFieldTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\FieldAttribute;

--- a/tests/Unit/Attributes/ResponseHeaderTest.php
+++ b/tests/Unit/Attributes/ResponseHeaderTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\ResponseHeader;

--- a/tests/Unit/Attributes/SpecTest.php
+++ b/tests/Unit/Attributes/SpecTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Attributes;

--- a/tests/Unit/Attributes/TagAttributeTest.php
+++ b/tests/Unit/Attributes/TagAttributeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\Tag;

--- a/tests/Unit/Console/ClearCommandTest.php
+++ b/tests/Unit/Console/ClearCommandTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 

--- a/tests/Unit/Console/GenerateCommandTest.php
+++ b/tests/Unit/Console/GenerateCommandTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Console/WhyCommandTest.php
+++ b/tests/Unit/Console/WhyCommandTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Console;

--- a/tests/Unit/Core/Envelopes/JsonApiEnvelopeTest.php
+++ b/tests/Unit/Core/Envelopes/JsonApiEnvelopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Auth\AuthenticationException;

--- a/tests/Unit/Core/Envelopes/LaravelEnvelopeTest.php
+++ b/tests/Unit/Core/Envelopes/LaravelEnvelopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Auth\AuthenticationException;

--- a/tests/Unit/Core/Envelopes/NoneEnvelopeTest.php
+++ b/tests/Unit/Core/Envelopes/NoneEnvelopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Auth\AuthenticationException;

--- a/tests/Unit/Core/Envelopes/Rfc7807EnvelopeTest.php
+++ b/tests/Unit/Core/Envelopes/Rfc7807EnvelopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/tests/Unit/Core/Envelopes/SubclassMatchingTest.php
+++ b/tests/Unit/Core/Envelopes/SubclassMatchingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Core\Envelopes\LaravelEnvelope;

--- a/tests/Unit/Core/Examples/FakerExampleSynthesiserTest.php
+++ b/tests/Unit/Core/Examples/FakerExampleSynthesiserTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Core\Support\FakerExampleSynthesiser;

--- a/tests/Unit/Core/Extractors/ErrorResolverChainTest.php
+++ b/tests/Unit/Core/Extractors/ErrorResolverChainTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/Extractors/FormRequestRequestSchemaResolverTest.php
+++ b/tests/Unit/Core/Extractors/FormRequestRequestSchemaResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/Extractors/SchemaFromFormRequestTest.php
+++ b/tests/Unit/Core/Extractors/SchemaFromFormRequestTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/tests/Unit/Core/Inference/MiddlewareErrorContributorTest.php
+++ b/tests/Unit/Core/Inference/MiddlewareErrorContributorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Auth\AuthenticationException;

--- a/tests/Unit/Core/Inference/ThrowsErrorContributorTest.php
+++ b/tests/Unit/Core/Inference/ThrowsErrorContributorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/Inference/ValidationErrorContributorTest.php
+++ b/tests/Unit/Core/Inference/ValidationErrorContributorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/tests/Unit/Core/RouteFilters/SkipIgnitionRoutesTest.php
+++ b/tests/Unit/Core/RouteFilters/SkipIgnitionRoutesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/RouteFilters/SkipNovaRoutesTest.php
+++ b/tests/Unit/Core/RouteFilters/SkipNovaRoutesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/RouteFilters/SkipPassportRoutesTest.php
+++ b/tests/Unit/Core/RouteFilters/SkipPassportRoutesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/RouteFilters/SkipSelfRoutesTest.php
+++ b/tests/Unit/Core/RouteFilters/SkipSelfRoutesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/RouteFilters/SkipTelescopeRoutesTest.php
+++ b/tests/Unit/Core/RouteFilters/SkipTelescopeRoutesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Core/Support/SpecTime/AnyValueTest.php
+++ b/tests/Unit/Core/Support/SpecTime/AnyValueTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Core\Support\SpecTime\AnyValue;

--- a/tests/Unit/Core/Support/SpecTime/SpecTimeRequestTest.php
+++ b/tests/Unit/Core/Support/SpecTime/SpecTimeRequestTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/tests/Unit/Errors/ErrorDescriptorTest.php
+++ b/tests/Unit/Errors/ErrorDescriptorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Validation\ValidationException;

--- a/tests/Unit/Errors/ErrorResponseTest.php
+++ b/tests/Unit/Errors/ErrorResponseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Generator/GenerationContextTest.php
+++ b/tests/Unit/Generator/GenerationContextTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/FindingTest.php
+++ b/tests/Unit/Lint/FindingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Finding;

--- a/tests/Unit/Lint/Formatters/CliFormatterTest.php
+++ b/tests/Unit/Lint/Formatters/CliFormatterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Finding;

--- a/tests/Unit/Lint/Formatters/GithubFormatterTest.php
+++ b/tests/Unit/Lint/Formatters/GithubFormatterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Finding;

--- a/tests/Unit/Lint/Formatters/JsonFormatterTest.php
+++ b/tests/Unit/Lint/Formatters/JsonFormatterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Finding;

--- a/tests/Unit/Lint/GenerationTimeRuleRegistrationTest.php
+++ b/tests/Unit/Lint/GenerationTimeRuleRegistrationTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Core\Lint\RuleUnknown;

--- a/tests/Unit/Lint/IdentifierCaseTest.php
+++ b/tests/Unit/Lint/IdentifierCaseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/LintRouteFilterTest.php
+++ b/tests/Unit/Lint/LintRouteFilterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Str;

--- a/tests/Unit/Lint/LintRunnerTest.php
+++ b/tests/Unit/Lint/LintRunnerTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Lint/RuleFixHintGuardTest.php
+++ b/tests/Unit/Lint/RuleFixHintGuardTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Core\CorePlugin;

--- a/tests/Unit/Lint/RuleUnknownTest.php
+++ b/tests/Unit/Lint/RuleUnknownTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/tests/Unit/Lint/Rules/ComponentNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/ComponentNameNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/Rules/ComponentOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/ComponentOrphanedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/DeprecatedAttributeTest.php
+++ b/tests/Unit/Lint/Rules/DeprecatedAttributeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\DeprecatedAttribute;

--- a/tests/Unit/Lint/Rules/DeprecatedNoReplacementTest.php
+++ b/tests/Unit/Lint/Rules/DeprecatedNoReplacementTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/DeprecatedNoSunsetDateTest.php
+++ b/tests/Unit/Lint/Rules/DeprecatedNoSunsetDateTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/DiscriminatorInvalidMappingTest.php
+++ b/tests/Unit/Lint/Rules/DiscriminatorInvalidMappingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/EnumValuesUndocumentedTest.php
+++ b/tests/Unit/Lint/Rules/EnumValuesUndocumentedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\EnumValuesUndocumented;

--- a/tests/Unit/Lint/Rules/ExternaldocsInvalidUrlTest.php
+++ b/tests/Unit/Lint/Rules/ExternaldocsInvalidUrlTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ExternaldocsInvalidUrl;

--- a/tests/Unit/Lint/Rules/FieldConflictingTypeTest.php
+++ b/tests/Unit/Lint/Rules/FieldConflictingTypeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\FieldConflictingType;

--- a/tests/Unit/Lint/Rules/FieldDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/FieldDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\FieldDescriptionMissing;

--- a/tests/Unit/Lint/Rules/FieldEnumMismatchTest.php
+++ b/tests/Unit/Lint/Rules/FieldEnumMismatchTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\FieldEnumMismatch;

--- a/tests/Unit/Lint/Rules/FieldInvalidFormatTest.php
+++ b/tests/Unit/Lint/Rules/FieldInvalidFormatTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\FieldInvalidFormat;

--- a/tests/Unit/Lint/Rules/FieldNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/FieldNameNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/FieldNoEffectTest.php
+++ b/tests/Unit/Lint/Rules/FieldNoEffectTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\FieldNoEffect;

--- a/tests/Unit/Lint/Rules/HeaderDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/HeaderDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\HeaderDescriptionMissing;

--- a/tests/Unit/Lint/Rules/HeaderInvalidNameTest.php
+++ b/tests/Unit/Lint/Rules/HeaderInvalidNameTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\HeaderInvalidName;

--- a/tests/Unit/Lint/Rules/HeaderNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/HeaderNameNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/InfoMetadataIncompleteTest.php
+++ b/tests/Unit/Lint/Rules/InfoMetadataIncompleteTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/LinkBothOperationIdAndRefTest.php
+++ b/tests/Unit/Lint/Rules/LinkBothOperationIdAndRefTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\LinkBothOperationIdAndRef;

--- a/tests/Unit/Lint/Rules/LinkDuplicateNameTest.php
+++ b/tests/Unit/Lint/Rules/LinkDuplicateNameTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\LinkDuplicateName;

--- a/tests/Unit/Lint/Rules/LinkInvalidOperationTest.php
+++ b/tests/Unit/Lint/Rules/LinkInvalidOperationTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\LinkInvalidOperation;

--- a/tests/Unit/Lint/Rules/LinkInvalidParameterTest.php
+++ b/tests/Unit/Lint/Rules/LinkInvalidParameterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\LintContext;

--- a/tests/Unit/Lint/Rules/LinkNeitherOperationIdNorRefTest.php
+++ b/tests/Unit/Lint/Rules/LinkNeitherOperationIdNorRefTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\LinkNeitherOperationIdNorRef;

--- a/tests/Unit/Lint/Rules/LinkParameterRequiredMissingTest.php
+++ b/tests/Unit/Lint/Rules/LinkParameterRequiredMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\LintContext;

--- a/tests/Unit/Lint/Rules/MetaNoSuppressionReasonTest.php
+++ b/tests/Unit/Lint/Rules/MetaNoSuppressionReasonTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/MetaSuppressionStaleTest.php
+++ b/tests/Unit/Lint/Rules/MetaSuppressionStaleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/MetaTooManySuppressionsTest.php
+++ b/tests/Unit/Lint/Rules/MetaTooManySuppressionsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/MetaUnknownRuleTest.php
+++ b/tests/Unit/Lint/Rules/MetaUnknownRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/OperationDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\OperationDescriptionMissing;

--- a/tests/Unit/Lint/Rules/OperationIdDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdDuplicateTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\OperationIdDuplicate;

--- a/tests/Unit/Lint/Rules/OperationIdInvalidCharsTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdInvalidCharsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\OperationIdInvalidChars;

--- a/tests/Unit/Lint/Rules/OperationIdMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\OperationIdMissing;

--- a/tests/Unit/Lint/Rules/OperationIdNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/Rules/OperationSecurityMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationSecurityMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/OperationSummaryEqualsDescriptionTest.php
+++ b/tests/Unit/Lint/Rules/OperationSummaryEqualsDescriptionTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\OperationSummaryEqualsDescription;

--- a/tests/Unit/Lint/Rules/OperationTagMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationTagMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\OperationTagMissing;

--- a/tests/Unit/Lint/Rules/OverridesRulesRegisteredTest.php
+++ b/tests/Unit/Lint/Rules/OverridesRulesRegisteredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\RuleRegistry;

--- a/tests/Unit/Lint/Rules/OverridesUnknownFieldTest.php
+++ b/tests/Unit/Lint/Rules/OverridesUnknownFieldTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\ArrayFindingsCollector;

--- a/tests/Unit/Lint/Rules/OverridesUnusedTest.php
+++ b/tests/Unit/Lint/Rules/OverridesUnusedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/ParameterDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/ParameterDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ParameterDescriptionMissing;

--- a/tests/Unit/Lint/Rules/ParameterDuplicateNameTest.php
+++ b/tests/Unit/Lint/Rules/ParameterDuplicateNameTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ParameterDuplicateName;

--- a/tests/Unit/Lint/Rules/ParameterExampleConflictTest.php
+++ b/tests/Unit/Lint/Rules/ParameterExampleConflictTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/ParameterExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/ParameterExampleMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/ParameterNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/ParameterNameNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/Rules/ParameterPathMustBeRequiredTest.php
+++ b/tests/Unit/Lint/Rules/ParameterPathMustBeRequiredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ParameterPathMustBeRequired;

--- a/tests/Unit/Lint/Rules/ParameterQueryArrayNoExplodeTest.php
+++ b/tests/Unit/Lint/Rules/ParameterQueryArrayNoExplodeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ParameterQueryArrayNoExplode;

--- a/tests/Unit/Lint/Rules/ParameterQueryNoSchemaTest.php
+++ b/tests/Unit/Lint/Rules/ParameterQueryNoSchemaTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ParameterQueryNoSchema;

--- a/tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php
+++ b/tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\PathParameterUndeclared;

--- a/tests/Unit/Lint/Rules/PathParameterUndefinedTest.php
+++ b/tests/Unit/Lint/Rules/PathParameterUndefinedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\PathParameterUndefined;

--- a/tests/Unit/Lint/Rules/PathSegmentNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/PathSegmentNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/Rules/PathTrailingSlashInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/PathTrailingSlashInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\LintContext;

--- a/tests/Unit/Lint/Rules/PublicEndpointContradictsMwTest.php
+++ b/tests/Unit/Lint/Rules/PublicEndpointContradictsMwTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/QueryParamDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/QueryParamDuplicateTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\QueryParamDuplicate;

--- a/tests/Unit/Lint/Rules/RefBrokenTest.php
+++ b/tests/Unit/Lint/Rules/RefBrokenTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/RequestBodyDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\RequestBodyDescriptionMissing;

--- a/tests/Unit/Lint/Rules/RequestBodyExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyExampleMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\RequestBodyExampleMissing;

--- a/tests/Unit/Lint/Rules/RequestBodyNoContentTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyNoContentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\RequestBodyNoContent;

--- a/tests/Unit/Lint/Rules/RequestBodyOnGetOrDeleteTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyOnGetOrDeleteTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\RequestBodyOnGetOrDelete;

--- a/tests/Unit/Lint/Rules/ResponseDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/ResponseDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseDescriptionMissing;

--- a/tests/Unit/Lint/Rules/ResponseDuplicateStatusTest.php
+++ b/tests/Unit/Lint/Rules/ResponseDuplicateStatusTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseDuplicateStatus;

--- a/tests/Unit/Lint/Rules/ResponseExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/ResponseExampleMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseExampleMissing;

--- a/tests/Unit/Lint/Rules/ResponseNoErrorTest.php
+++ b/tests/Unit/Lint/Rules/ResponseNoErrorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseNoError;

--- a/tests/Unit/Lint/Rules/ResponseNoSuccessTest.php
+++ b/tests/Unit/Lint/Rules/ResponseNoSuccessTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseNoSuccess;

--- a/tests/Unit/Lint/Rules/ResponseRedirectWithoutLocationTest.php
+++ b/tests/Unit/Lint/Rules/ResponseRedirectWithoutLocationTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseRedirectWithoutLocation;

--- a/tests/Unit/Lint/Rules/ResponseRefUnresolvableTest.php
+++ b/tests/Unit/Lint/Rules/ResponseRefUnresolvableTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/ResponseStatusUnconventionalTest.php
+++ b/tests/Unit/Lint/Rules/ResponseStatusUnconventionalTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseStatusUnconventional;

--- a/tests/Unit/Lint/Rules/ResponseSuccessEmptyBodyTest.php
+++ b/tests/Unit/Lint/Rules/ResponseSuccessEmptyBodyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ResponseSuccessEmptyBody;

--- a/tests/Unit/Lint/Rules/SchemaAllofTypeConflictTest.php
+++ b/tests/Unit/Lint/Rules/SchemaAllofTypeConflictTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SchemaConstraintsMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaConstraintsMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SchemaDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\SchemaDescriptionMissing;

--- a/tests/Unit/Lint/Rules/SchemaEnumEmptyTest.php
+++ b/tests/Unit/Lint/Rules/SchemaEnumEmptyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SchemaEnumTypeMismatchTest.php
+++ b/tests/Unit/Lint/Rules/SchemaEnumTypeMismatchTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\SchemaEnumTypeMismatch;

--- a/tests/Unit/Lint/Rules/SchemaExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaExampleMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SchemaNullableViaDeprecatedKeywordTest.php
+++ b/tests/Unit/Lint/Rules/SchemaNullableViaDeprecatedKeywordTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SchemaRequiredWithoutPropertyTest.php
+++ b/tests/Unit/Lint/Rules/SchemaRequiredWithoutPropertyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/ScopeOverlyBroadTest.php
+++ b/tests/Unit/Lint/Rules/ScopeOverlyBroadTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\ScopeOverlyBroad;

--- a/tests/Unit/Lint/Rules/SecurityInvalidScopeTest.php
+++ b/tests/Unit/Lint/Rules/SecurityInvalidScopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\SecurityInvalidScope;

--- a/tests/Unit/Lint/Rules/SecuritySchemeUndefinedTest.php
+++ b/tests/Unit/Lint/Rules/SecuritySchemeUndefinedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/ServerInvalidUrlTest.php
+++ b/tests/Unit/Lint/Rules/ServerInvalidUrlTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/ServerVariableUndeclaredTest.php
+++ b/tests/Unit/Lint/Rules/ServerVariableUndeclaredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/SpecInvalidTest.php
+++ b/tests/Unit/Lint/Rules/SpecInvalidTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/SpecRouteOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/SpecRouteOrphanedTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/SpecUnknownReferenceTest.php
+++ b/tests/Unit/Lint/Rules/SpecUnknownReferenceTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/StreamingNoContentTypeTest.php
+++ b/tests/Unit/Lint/Rules/StreamingNoContentTypeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/SummaryMissingTest.php
+++ b/tests/Unit/Lint/Rules/SummaryMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\SummaryMissing;

--- a/tests/Unit/Lint/Rules/TagDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/TagDuplicateTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\TagDuplicate;

--- a/tests/Unit/Lint/Rules/TagNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/TagNameNamingInconsistentTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\IdentifierCase;

--- a/tests/Unit/Lint/Rules/TagUndeclaredAtRootTest.php
+++ b/tests/Unit/Lint/Rules/TagUndeclaredAtRootTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\LintContext;

--- a/tests/Unit/Lint/Rules/TagsNoDescriptionTest.php
+++ b/tests/Unit/Lint/Rules/TagsNoDescriptionTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\TagsNoDescription;

--- a/tests/Unit/Lint/Rules/ThrowsTransitiveMissingTest.php
+++ b/tests/Unit/Lint/Rules/ThrowsTransitiveMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Lint/Rules/WebhookDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/WebhookDescriptionMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Rules/WebhookNameDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/WebhookNameDuplicateTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Rules\WebhookNameDuplicate;

--- a/tests/Unit/Lint/SuppressionCollectorTest.php
+++ b/tests/Unit/Lint/SuppressionCollectorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/tests/Unit/Lint/SuppressionDirectiveTest.php
+++ b/tests/Unit/Lint/SuppressionDirectiveTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Finding;

--- a/tests/Unit/Lint/Tree/SpecTreeBuilderComponentSourceClassTest.php
+++ b/tests/Unit/Lint/Tree/SpecTreeBuilderComponentSourceClassTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Lint/Tree/SpecTreeWalkerSourceClassStampingTest.php
+++ b/tests/Unit/Lint/Tree/SpecTreeWalkerSourceClassStampingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/OpenApiServiceProviderTest.php
+++ b/tests/Unit/OpenApiServiceProviderTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Contracts\Console\Kernel;

--- a/tests/Unit/Plugins/ApiResources/Attributes/ResourceFieldTest.php
+++ b/tests/Unit/Plugins/ApiResources/Attributes/ResourceFieldTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\ApiResources\Attributes;

--- a/tests/Unit/Plugins/ApiResources/ResourceClassLocatorTest.php
+++ b/tests/Unit/Plugins/ApiResources/ResourceClassLocatorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\ApiResources;

--- a/tests/Unit/Plugins/ApiResources/ResourceEnvelopeFactoryTest.php
+++ b/tests/Unit/Plugins/ApiResources/ResourceEnvelopeFactoryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\ApiResources;

--- a/tests/Unit/Plugins/ApiResources/ResourceRefSchemaResolverTest.php
+++ b/tests/Unit/Plugins/ApiResources/ResourceRefSchemaResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\ApiResources;

--- a/tests/Unit/Plugins/ApiResources/ResourceTargetTest.php
+++ b/tests/Unit/Plugins/ApiResources/ResourceTargetTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\ApiResources;

--- a/tests/Unit/Plugins/ApiResources/SchemaFromResourceTest.php
+++ b/tests/Unit/Plugins/ApiResources/SchemaFromResourceTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\ApiResources;

--- a/tests/Unit/Plugins/Fractal/Attributes/TransformerFieldTest.php
+++ b/tests/Unit/Plugins/Fractal/Attributes/TransformerFieldTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Attributes;

--- a/tests/Unit/Plugins/Fractal/Attributes/TransformerIncludeResponseTest.php
+++ b/tests/Unit/Plugins/Fractal/Attributes/TransformerIncludeResponseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Attributes;

--- a/tests/Unit/Plugins/Fractal/FractalEnvelopeFactoryTest.php
+++ b/tests/Unit/Plugins/Fractal/FractalEnvelopeFactoryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal;

--- a/tests/Unit/Plugins/Fractal/Lint/FractalDuplicateKeyTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalDuplicateKeyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Lint;

--- a/tests/Unit/Plugins/Fractal/Lint/FractalFieldsUndeclaredTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalFieldsUndeclaredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Lint;

--- a/tests/Unit/Plugins/Fractal/Lint/FractalIncludeTransformerMissingTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalIncludeTransformerMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Lint;

--- a/tests/Unit/Plugins/Fractal/Lint/FractalResponseUnboundTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalResponseUnboundTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Lint;

--- a/tests/Unit/Plugins/Fractal/Lint/FractalTransformerClassMissingTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalTransformerClassMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal\Lint;

--- a/tests/Unit/Plugins/Fractal/SchemaFromTransformerTest.php
+++ b/tests/Unit/Plugins/Fractal/SchemaFromTransformerTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal;

--- a/tests/Unit/Plugins/QueryBuilder/Attributes/AllowedFilterTest.php
+++ b/tests/Unit/Plugins/QueryBuilder/Attributes/AllowedFilterTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\QueryBuilder\Attributes;

--- a/tests/Unit/Plugins/QueryBuilder/Attributes/AllowedSortIncludeTest.php
+++ b/tests/Unit/Plugins/QueryBuilder/Attributes/AllowedSortIncludeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\QueryBuilder\Attributes;

--- a/tests/Unit/Plugins/QueryBuilder/Lint/QueryBuilderFilterTypeMissingTest.php
+++ b/tests/Unit/Plugins/QueryBuilder/Lint/QueryBuilderFilterTypeMissingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\QueryBuilder\Lint;

--- a/tests/Unit/Plugins/QueryBuilder/Lint/QueryBuilderParamsUndeclaredTest.php
+++ b/tests/Unit/Plugins/QueryBuilder/Lint/QueryBuilderParamsUndeclaredTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\QueryBuilder\Lint;

--- a/tests/Unit/Plugins/QueryBuilder/QueryBuilderParameterResolverTest.php
+++ b/tests/Unit/Plugins/QueryBuilder/QueryBuilderParameterResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Plugins\QueryBuilder;

--- a/tests/Unit/Plugins/SpatieData/DataSyntheticPayloadBuilderTest.php
+++ b/tests/Unit/Plugins/SpatieData/DataSyntheticPayloadBuilderTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Plugins\SpatieData\DataSyntheticPayloadBuilder;

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScopeTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Registry/OpenApiRegistryTest.php
+++ b/tests/Unit/Registry/OpenApiRegistryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Registry;

--- a/tests/Unit/Support/Attributes/DescriptionDirectivesTest.php
+++ b/tests/Unit/Support/Attributes/DescriptionDirectivesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Attributes\DescriptionDirectives;

--- a/tests/Unit/Support/Config/ConfigDifferTest.php
+++ b/tests/Unit/Support/Config/ConfigDifferTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Config\ConfigDiffer;

--- a/tests/Unit/Support/Extraction/FieldDescriptorTest.php
+++ b/tests/Unit/Support/Extraction/FieldDescriptorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Extraction/PayloadParameterScannerTest.php
+++ b/tests/Unit/Support/Extraction/PayloadParameterScannerTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;

--- a/tests/Unit/Support/Extraction/SecurityExtractorTest.php
+++ b/tests/Unit/Support/Extraction/SecurityExtractorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Support/Extraction/SelfDocumentingRuleTest.php
+++ b/tests/Unit/Support/Extraction/SelfDocumentingRuleTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Contracts\Extraction\SelfDocumentingRule;

--- a/tests/Unit/Support/Extraction/UriParametersExtractorTest.php
+++ b/tests/Unit/Support/Extraction/UriParametersExtractorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Generator;

--- a/tests/Unit/Support/Extraction/ValidationRulesToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/ValidationRulesToSchemaTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Validation\Rule;

--- a/tests/Unit/Support/Generator/ComponentSchemaRegistryComponentClassMapTest.php
+++ b/tests/Unit/Support/Generator/ComponentSchemaRegistryComponentClassMapTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/ComponentSchemaRegistryTest.php
+++ b/tests/Unit/Support/Generator/ComponentSchemaRegistryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/Fixtures/SmokeController.php
+++ b/tests/Unit/Support/Generator/Fixtures/SmokeController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Generator\Fixtures;

--- a/tests/Unit/Support/Generator/JsonSchemaFromTypeTest.php
+++ b/tests/Unit/Support/Generator/JsonSchemaFromTypeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Psr\Log\NullLogger;

--- a/tests/Unit/Support/Generator/NullableSchemaTest.php
+++ b/tests/Unit/Support/Generator/NullableSchemaTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/OpenApiGenerationOrchestratorTest.php
+++ b/tests/Unit/Support/Generator/OpenApiGenerationOrchestratorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Controller;

--- a/tests/Unit/Support/Generator/OpenApiGeneratorTest.php
+++ b/tests/Unit/Support/Generator/OpenApiGeneratorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Support/Generator/OperationBuilderTest.php
+++ b/tests/Unit/Support/Generator/OperationBuilderTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Support/Generator/OverrideMatcherTest.php
+++ b/tests/Unit/Support/Generator/OverrideMatcherTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Generator\OverrideMatcher;

--- a/tests/Unit/Support/Generator/Pipeline/ComponentsStageTest.php
+++ b/tests/Unit/Support/Generator/Pipeline/ComponentsStageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/Pipeline/PathsStageBindingTest.php
+++ b/tests/Unit/Support/Generator/Pipeline/PathsStageBindingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;

--- a/tests/Unit/Support/Generator/Pipeline/RootStageTest.php
+++ b/tests/Unit/Support/Generator/Pipeline/RootStageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/Pipeline/SecurityStageTest.php
+++ b/tests/Unit/Support/Generator/Pipeline/SecurityStageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/Pipeline/SpecPipelineTest.php
+++ b/tests/Unit/Support/Generator/Pipeline/SpecPipelineTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Generator\Pipeline;

--- a/tests/Unit/Support/Generator/Pipeline/TransformersStageTest.php
+++ b/tests/Unit/Support/Generator/Pipeline/TransformersStageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;

--- a/tests/Unit/Support/Generator/Stages/ErrorResponseInferenceStageTest.php
+++ b/tests/Unit/Support/Generator/Stages/ErrorResponseInferenceStageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Support/Generator/Stages/OverridesStageTest.php
+++ b/tests/Unit/Support/Generator/Stages/OverridesStageTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Route;

--- a/tests/Unit/Support/Inclusion/InclusionEvaluatorTest.php
+++ b/tests/Unit/Support/Inclusion/InclusionEvaluatorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Inclusion;

--- a/tests/Unit/Support/PhpDoc/DocBlockParserTest.php
+++ b/tests/Unit/Support/PhpDoc/DocBlockParserTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\PhpDoc;

--- a/tests/Unit/Support/Routing/DocCommentParserTest.php
+++ b/tests/Unit/Support/Routing/DocCommentParserTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Routing\DocCommentParser;

--- a/tests/Unit/Support/Routing/Fixtures/ControllerUsingThrowingTrait.php
+++ b/tests/Unit/Support/Routing/Fixtures/ControllerUsingThrowingTrait.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Routing\Fixtures;

--- a/tests/Unit/Support/Routing/Fixtures/ThrowingController.php
+++ b/tests/Unit/Support/Routing/Fixtures/ThrowingController.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Routing\Fixtures;

--- a/tests/Unit/Support/Routing/Fixtures/ThrowingTrait/ThrowingTrait.php
+++ b/tests/Unit/Support/Routing/Fixtures/ThrowingTrait/ThrowingTrait.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Routing\Fixtures\ThrowingTrait;

--- a/tests/Unit/Support/Routing/Fixtures/ThrowingTrait/TraitOnlyException.php
+++ b/tests/Unit/Support/Routing/Fixtures/ThrowingTrait/TraitOnlyException.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Routing\Fixtures\ThrowingTrait;

--- a/tests/Unit/Support/Routing/RouteIntrospectorTest.php
+++ b/tests/Unit/Support/Routing/RouteIntrospectorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Routing\Router;

--- a/tests/Unit/Support/Routing/ThrowsExtractorTest.php
+++ b/tests/Unit/Support/Routing/ThrowsExtractorTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Routing\ThrowsExtractor;

--- a/tests/Unit/Support/Routing/UriParameterResolverTest.php
+++ b/tests/Unit/Support/Routing/UriParameterResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Illuminate\Contracts\Routing\UrlRoutable;

--- a/tests/Unit/Support/Spec/SpecDefinitionTest.php
+++ b/tests/Unit/Support/Spec/SpecDefinitionTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Spec;

--- a/tests/Unit/Support/Spec/SpecMatcherTest.php
+++ b/tests/Unit/Support/Spec/SpecMatcherTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Spec;

--- a/tests/Unit/Support/Spec/SpecRegistryTest.php
+++ b/tests/Unit/Support/Spec/SpecRegistryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license       MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Spec;

--- a/tests/Unit/Support/Spec/SpecResolverTest.php
+++ b/tests/Unit/Support/Spec/SpecResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Spec;

--- a/tests/Unit/Support/Types/TypeNodeResolverTest.php
+++ b/tests/Unit/Support/Types/TypeNodeResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Types;

--- a/tests/Unit/Support/Visibility/VisibilityModeTest.php
+++ b/tests/Unit/Support/Visibility/VisibilityModeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Support\Visibility\VisibilityMode;

--- a/tests/Unit/Support/Visibility/VisibilityResolverTest.php
+++ b/tests/Unit/Support/Visibility/VisibilityResolverTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Attributes\Expose;

--- a/tests/Unit/Testing/ActionDescriptorFactoryTest.php
+++ b/tests/Unit/Testing/ActionDescriptorFactoryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Routing\ActionDescriptor;

--- a/tests/Unit/Testing/SchemaContextScopeTest.php
+++ b/tests/Unit/Testing/SchemaContextScopeTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/**
- * This file is part of radiergummi/laravel-openapi.
- *
- * @license MIT
- * @copyright (c) 2026 Moritz Friedrich
- */
-
 declare(strict_types=1);
 
 use OpenApi\Annotations as OA;


### PR DESCRIPTION
**Stack (merge bottom-up):** ① **this** → ② [plugin-namespace-reorg] → ③ [http-method-enum]

Strips the leading license/copyright docblock from every source and test file (765 files), and fixes the author name in the root `LICENSE` (`Friedrich` → `Mazetti`). The package is MIT-licensed via the root `LICENSE`; per-file headers — including two legacy the private consumer app proprietary blocks — are redundant noise. `CLAUDE.md`'s "every file has a header" convention is updated to match.

Pure deletions; no logic touched. CI green (PHPStan L8, Pint, 1542 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)