### PR TITLE
feat: introduce HttpMethod enum and thread it through the pipeline

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -37,9 +37,11 @@ use function realpath;
  */
 class GenerateCommand extends Command
 {
-    // Name/description use the version-portable string-property form rather than
-    // the #[Signature]/#[Description] attributes, which are Laravel 13+ only
-    // (Illuminate\Console\Attributes does not exist on Laravel 12).
+    /**
+     * @var list<string>
+     */
+    private const array SUPPORTED_FORMATS = ['yaml', 'json'];
+
     protected $signature = 'openapi:generate
         {spec? : Name of the spec to generate. Omit to generate every defined spec.}
         {--output= : Override output path. Requires a single spec target. Use "-" for stdout.}
@@ -47,11 +49,6 @@ class GenerateCommand extends Command
         {--explain : Print one (route × spec) decision line per route on stderr.}';
 
     protected $description = 'Generate an OpenAPI 3.1 document from the application\'s route definitions';
-
-    /**
-     * @var list<string>
-     */
-    private const array SUPPORTED_FORMATS = ['yaml', 'json'];
 
     /**
      * @throws \InvalidArgumentException
@@ -135,7 +132,7 @@ class GenerateCommand extends Command
             foreach ($specs as $spec) {
                 $decision = $evaluator->decide($descriptor, $spec, app()->environment());
                 $mark = $decision->included ? '✓' : '✗';
-                $method = $descriptor->route->methods()[0] ?? 'GET';
+                $method = $descriptor->httpMethod?->forDisplay() ?? '?';
                 $uri = $descriptor->route->uri();
                 fwrite(STDERR, "[{$spec->name}] {$mark} {$method} {$uri}  {$decision->summary}" . PHP_EOL);
             }

--- a/src/Console/WhyCommand.php
+++ b/src/Console/WhyCommand.php
@@ -32,14 +32,12 @@ use function str_contains;
  */
 class WhyCommand extends Command
 {
-    // Name/description use the version-portable string-property form rather than
-    // the #[Signature]/#[Description] attributes, which are Laravel 13+ only
-    // (Illuminate\Console\Attributes does not exist on Laravel 12).
     protected $signature = 'openapi:why
         {route : Route name (exact match) or URI substring.}
         {--for-env= : Override the environment for Hide/Expose evaluation.}';
 
     protected $description = 'Explain inclusion of a route across all defined specs';
+
     /**
      * @throws InvalidArgumentException
      * @throws ReflectionException
@@ -128,7 +126,7 @@ class WhyCommand extends Command
 
     private function printHeader(ActionDescriptor $descriptor, string $env): void
     {
-        $method = $descriptor->route->methods()[0] ?? 'GET';
+        $method = $descriptor->httpMethod?->forDisplay() ?? '?';
         $middleware = array_values(
             array_map(
                 static fn(mixed $entry): string => (string) $entry,

--- a/src/Enums/HttpMethod.php
+++ b/src/Enums/HttpMethod.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Enums;
+
+enum HttpMethod: string
+{
+    case Get = 'get';
+    case Post = 'post';
+    case Put = 'put';
+    case Patch = 'patch';
+    case Delete = 'delete';
+    case Options = 'options';
+    case Head = 'head';
+    case Trace = 'trace';
+
+    /**
+     * Resolve an {@see HttpMethod} from a raw HTTP verb (case-insensitive), such as the uppercase
+     * verbs returned by Laravel's `Route::methods()`. Returns null for unknown verbs.
+     */
+    public static function fromString(string $method): ?self
+    {
+        return self::tryFrom(strtolower($method));
+    }
+
+    public function forDisplay(): string
+    {
+        return strtoupper($this->value);
+    }
+}

--- a/src/Extensions/OperationContext.php
+++ b/src/Extensions/OperationContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Extensions;
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 
 /**
@@ -46,8 +47,8 @@ final class OperationContext
         public readonly ActionDescriptor $descriptor,
 
         /**
-         * The HTTP method in uppercase: GET, POST, PUT, PATCH, DELETE, OPTIONS.
+         * The HTTP method of the route
          */
-        public readonly string $httpMethod,
+        public readonly HttpMethod $httpMethod,
     ) {}
 }

--- a/src/Lint/FindingLocation.php
+++ b/src/Lint/FindingLocation.php
@@ -7,10 +7,9 @@ namespace Radiergummi\OpenApi\Lint;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Override;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
-
-use function strtoupper;
 
 /**
  * @implements Arrayable<string, mixed>
@@ -21,7 +20,7 @@ final readonly class FindingLocation implements Arrayable, JsonSerializable
         public ?string $file = null,
         public ?int $line = null,
         public ?string $routeName = null,
-        public ?string $routeMethod = null,
+        public ?HttpMethod $routeMethod = null,
         public ?string $routeUri = null,
         public ?string $jsonPointer = null,
     ) {}
@@ -32,7 +31,7 @@ final readonly class FindingLocation implements Arrayable, JsonSerializable
             file: $descriptor->actionReflector?->getFileName() ?: null,
             line: $descriptor->actionReflector?->getStartLine() ?: null,
             routeName: $descriptor->route->getName(),
-            routeMethod: strtoupper($descriptor->route->methods()[0] ?? 'GET'),
+            routeMethod: $descriptor->httpMethod,
             routeUri: $descriptor->route->uri(),
         );
     }

--- a/src/Lint/Formatters/CliFormatter.php
+++ b/src/Lint/Formatters/CliFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Formatters;
 
 use Override;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\LinterSummary;
 use Radiergummi\OpenApi\Lint\Visitors\PreBuildRule;
@@ -20,7 +21,6 @@ use function preg_replace;
 use function sprintf;
 use function str_replace;
 use function strlen;
-use function strtoupper;
 use function Termwind\terminal;
 use function wordwrap;
 
@@ -265,9 +265,9 @@ final class CliFormatter implements Formatter
         return implode(' ', $parts);
     }
 
-    private function formatRoute(string $method, string $uri): string
+    private function formatRoute(HttpMethod $method, string $uri): string
     {
-        $verb = sprintf('<options=bold>%s</>', strtoupper($method));
+        $verb = sprintf('<options=bold>%s</>', $method->forDisplay());
         $uri = preg_replace('/\{(\w+)(\??)}/', '<fg=cyan>{$1$2}</>', $uri);
 
         return sprintf('%s %s', $verb, $uri);

--- a/src/Lint/Rules/DeprecatedNoReplacement.php
+++ b/src/Lint/Rules/DeprecatedNoReplacement.php
@@ -59,7 +59,7 @@ final class DeprecatedNoReplacement implements Rule, OperationRuleVisitor
             level: $this->level(),
             message: sprintf(
                 'Deprecated operation %s %s does not mention a replacement in its description',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Add migration guidance to the description (e.g. "Use GET /v2/resource instead").',

--- a/src/Lint/Rules/DeprecatedNoSunsetDate.php
+++ b/src/Lint/Rules/DeprecatedNoSunsetDate.php
@@ -59,7 +59,7 @@ final class DeprecatedNoSunsetDate implements Rule, OperationRuleVisitor
             level: $this->level(),
             message: sprintf(
                 'Deprecated operation %s %s does not mention a sunset date or timeline',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Add an ISO date (e.g. "Will be removed on 2025-12-31") or quarter notation (e.g. "Sunset in Q1 2026") to the description.',

--- a/src/Lint/Rules/HeaderDescriptionMissing.php
+++ b/src/Lint/Rules/HeaderDescriptionMissing.php
@@ -42,7 +42,7 @@ final class HeaderDescriptionMissing implements Rule, HeaderRuleVisitor
             message: sprintf(
                 'Header "%s" on %s %s has no description',
                 $header->name,
-                $operation !== null ? $operation->method : '(unknown)',
+                $operation !== null ? $operation->method->forDisplay() : '(unknown)',
                 $operation !== null ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Add a description to the response header to improve API documentation.',

--- a/src/Lint/Rules/LinkBothOperationIdAndRef.php
+++ b/src/Lint/Rules/LinkBothOperationIdAndRef.php
@@ -39,7 +39,7 @@ final class LinkBothOperationIdAndRef implements Rule, LinkRuleVisitor
             message: sprintf(
                 'Link "%s" on %s %s sets both operationId ("%s") and operationRef ("%s"); only one is allowed',
                 $link->name,
-                $routeMethod ?? '?',
+                $routeMethod?->forDisplay() ?? '?',
                 $routeUri ?? '?',
                 $link->operationId,
                 $link->operationRef,

--- a/src/Lint/Rules/LinkInvalidOperation.php
+++ b/src/Lint/Rules/LinkInvalidOperation.php
@@ -35,7 +35,7 @@ final class LinkInvalidOperation implements Rule, LinkRuleVisitor
         $message = sprintf(
             'Link "%s" on %s %s references unknown operationId "%s"',
             $link->name,
-            $routeMethod ?? '?',
+            $routeMethod?->forDisplay() ?? '?',
             $routeUri ?? '?',
             $link->operationId,
         );

--- a/src/Lint/Rules/LinkInvalidParameter.php
+++ b/src/Lint/Rules/LinkInvalidParameter.php
@@ -63,7 +63,7 @@ final class LinkInvalidParameter implements Rule, LinkRuleVisitor
             $message = sprintf(
                 'Link "%s" on %s %s passes parameter "%s" which is not accepted by operation "%s"',
                 $link->name,
-                $routeMethod ?? '?',
+                $routeMethod?->forDisplay() ?? '?',
                 $routeUri ?? '?',
                 $paramName,
                 $link->operationId,

--- a/src/Lint/Rules/LinkNeitherOperationIdNorRef.php
+++ b/src/Lint/Rules/LinkNeitherOperationIdNorRef.php
@@ -35,7 +35,7 @@ final class LinkNeitherOperationIdNorRef implements Rule, LinkRuleVisitor
         $message = sprintf(
             'Link "%s" on %s %s has neither operationId nor operationRef',
             $link->name,
-            $routeMethod ?? '?',
+            $routeMethod?->forDisplay() ?? '?',
             $routeUri ?? '?',
         );
 

--- a/src/Lint/Rules/LinkParameterRequiredMissing.php
+++ b/src/Lint/Rules/LinkParameterRequiredMissing.php
@@ -53,7 +53,7 @@ final class LinkParameterRequiredMissing implements Rule, LinkRuleVisitor
             $message = sprintf(
                 'Link "%s" on %s %s does not supply required parameter "%s" for operation "%s"',
                 $link->name,
-                $routeMethod ?? '?',
+                $routeMethod?->forDisplay() ?? '?',
                 $routeUri ?? '?',
                 $requiredName,
                 $link->operationId,

--- a/src/Lint/Rules/OperationDescriptionMissing.php
+++ b/src/Lint/Rules/OperationDescriptionMissing.php
@@ -40,7 +40,7 @@ final class OperationDescriptionMissing implements Rule, OperationRuleVisitor
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has no description',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add a description to complement the summary and provide more detail to API consumers.',

--- a/src/Lint/Rules/OperationIdDuplicate.php
+++ b/src/Lint/Rules/OperationIdDuplicate.php
@@ -65,7 +65,7 @@ final class OperationIdDuplicate implements Rule, OperationRuleVisitor, Finaliza
                     message: sprintf(
                         'Duplicate operationId "%s" on %s %s (%d occurrences)',
                         $operationId,
-                        $node->method,
+                        $node->method->forDisplay(),
                         $node->pathUri,
                         count($nodes),
                     ),

--- a/src/Lint/Rules/OperationIdInvalidChars.php
+++ b/src/Lint/Rules/OperationIdInvalidChars.php
@@ -46,7 +46,7 @@ final class OperationIdInvalidChars implements Rule, OperationRuleVisitor
             message: sprintf(
                 'Operation ID "%s" on %s %s contains characters that are not safe for code generation',
                 $operation->operationId,
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Use only letters, digits, dots, hyphens and underscores in operationId, starting with a letter.',

--- a/src/Lint/Rules/OperationIdMissing.php
+++ b/src/Lint/Rules/OperationIdMissing.php
@@ -33,7 +33,7 @@ final class OperationIdMissing implements Rule, OperationRuleVisitor
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has no operationId',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add an operationId to the operation via #[Operation(operationId: "...")].',

--- a/src/Lint/Rules/OperationIdNamingInconsistent.php
+++ b/src/Lint/Rules/OperationIdNamingInconsistent.php
@@ -52,7 +52,7 @@ final readonly class OperationIdNamingInconsistent extends AbstractNamingRule im
             message: sprintf(
                 'Operation ID "%s" on %s %s does not follow the %s naming convention',
                 $operation->operationId,
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
                 $this->case->label(),
             ),

--- a/src/Lint/Rules/OperationSummaryEqualsDescription.php
+++ b/src/Lint/Rules/OperationSummaryEqualsDescription.php
@@ -41,7 +41,7 @@ final class OperationSummaryEqualsDescription implements Rule, OperationRuleVisi
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has a description identical to its summary',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Give the description more detail than the summary, or remove the redundant description.',

--- a/src/Lint/Rules/OperationTagMissing.php
+++ b/src/Lint/Rules/OperationTagMissing.php
@@ -33,7 +33,7 @@ final class OperationTagMissing implements Rule, OperationRuleVisitor
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has no tags',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add at least one tag to the operation via #[Tag] or #[Operation(tags: [...])].',

--- a/src/Lint/Rules/ParameterDuplicateName.php
+++ b/src/Lint/Rules/ParameterDuplicateName.php
@@ -45,7 +45,7 @@ final class ParameterDuplicateName implements Rule, OperationRuleVisitor
                     'Parameter "%s" (in: path) is declared %d times on %s %s',
                     $name,
                     $occurrenceCount,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Remove the duplicate parameter declaration; (name, in) must be unique per operation.',

--- a/src/Lint/Rules/ParameterPathMustBeRequired.php
+++ b/src/Lint/Rules/ParameterPathMustBeRequired.php
@@ -40,7 +40,7 @@ final class ParameterPathMustBeRequired implements Rule, ParameterRuleVisitor
             message: sprintf(
                 'Path parameter "%s" on %s %s must be required',
                 $parameter->name,
-                $operation instanceof OperationNode ? $operation->method : '(unknown)',
+                $operation instanceof OperationNode ? $operation->method->forDisplay() : '(unknown)',
                 $operation instanceof OperationNode ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Set required=true on all path parameters (OAS 3.x requirement).',

--- a/src/Lint/Rules/ParameterQueryArrayNoExplode.php
+++ b/src/Lint/Rules/ParameterQueryArrayNoExplode.php
@@ -44,7 +44,7 @@ final class ParameterQueryArrayNoExplode implements Rule, QueryParameterRuleVisi
             message: sprintf(
                 'Query parameter "%s" on %s %s has an array schema but does not set style or explode',
                 $queryParameter->name,
-                $operation instanceof OperationNode ? $operation->method : '(unknown)',
+                $operation instanceof OperationNode ? $operation->method->forDisplay() : '(unknown)',
                 $operation instanceof OperationNode ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Explicitly set style (e.g. "form") and/or explode (true/false) to avoid ambiguous array serialisation.',

--- a/src/Lint/Rules/ParameterQueryNoSchema.php
+++ b/src/Lint/Rules/ParameterQueryNoSchema.php
@@ -42,7 +42,7 @@ final class ParameterQueryNoSchema implements Rule, QueryParameterRuleVisitor
             message: sprintf(
                 'Query parameter "%s" on %s %s has no schema',
                 $queryParameter->name,
-                $operation instanceof OperationNode ? $operation->method : '(unknown)',
+                $operation instanceof OperationNode ? $operation->method->forDisplay() : '(unknown)',
                 $operation instanceof OperationNode ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Add a schema to the query parameter to declare its type and format.',

--- a/src/Lint/Rules/PathParameterUndeclared.php
+++ b/src/Lint/Rules/PathParameterUndeclared.php
@@ -54,7 +54,7 @@ final class PathParameterUndeclared implements Rule, OperationRuleVisitor
                 message: sprintf(
                     'Path placeholder "{%s}" on %s %s is not declared as a path parameter',
                     $placeholder,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: sprintf(

--- a/src/Lint/Rules/PathParameterUndefined.php
+++ b/src/Lint/Rules/PathParameterUndefined.php
@@ -41,14 +41,14 @@ final class PathParameterUndefined implements Rule, OperationRuleVisitor
                 ? sprintf(
                     'Path parameter "%s" on %s %s has no corresponding {%s} placeholder in the path',
                     $parameter->name,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                     $parameter->name,
                 )
                 : sprintf(
                     'Optional path parameter "%s" on %s %s has no corresponding {%s?} placeholder in the path',
                     $parameter->name,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                     $parameter->name,
                 );

--- a/src/Lint/Rules/PathSegmentNamingInconsistent.php
+++ b/src/Lint/Rules/PathSegmentNamingInconsistent.php
@@ -80,7 +80,7 @@ final readonly class PathSegmentNamingInconsistent extends AbstractNamingRule im
             message: sprintf(
                 'Path segment(s) [%s] on %s %s do not follow the %s naming convention',
                 implode(', ', $offending),
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
                 $this->case->label(),
             ),

--- a/src/Lint/Rules/QueryParamDuplicate.php
+++ b/src/Lint/Rules/QueryParamDuplicate.php
@@ -44,7 +44,7 @@ final class QueryParamDuplicate implements Rule, OperationRuleVisitor
                     'Query parameter "%s" is declared %d times on %s %s',
                     $name,
                     $occurrenceCount,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Remove the duplicate query parameter declaration; names must be unique per operation.',

--- a/src/Lint/Rules/RequestBodyOnGetOrDelete.php
+++ b/src/Lint/Rules/RequestBodyOnGetOrDelete.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Lint\Rules;
 
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
@@ -23,8 +24,8 @@ use function sprintf;
  */
 final class RequestBodyOnGetOrDelete implements Rule, OperationRuleVisitor
 {
-    /** @var list<string> */
-    private const DISALLOWED_METHODS = ['GET', 'DELETE'];
+    /** @var list<HttpMethod> */
+    private const array DISALLOWED_METHODS = [HttpMethod::Get, HttpMethod::Delete];
 
     /**
      * @return iterable<Finding>
@@ -45,9 +46,9 @@ final class RequestBodyOnGetOrDelete implements Rule, OperationRuleVisitor
             level: $this->level(),
             message: sprintf(
                 'Operation %s %s defines a request body, which is unconventional for %s requests',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
-                $operation->method,
+                $operation->method->forDisplay(),
             ),
             fixHint: 'Move parameters to query string or path parameters instead of using a request body.',
         );

--- a/src/Lint/Rules/ResponseDescriptionMissing.php
+++ b/src/Lint/Rules/ResponseDescriptionMissing.php
@@ -41,7 +41,7 @@ final class ResponseDescriptionMissing implements Rule, ResponseRuleVisitor
             message: sprintf(
                 'Response %d on %s %s has no description',
                 $response->statusCode,
-                $operation !== null ? $operation->method : '(unknown)',
+                $operation !== null ? $operation->method->forDisplay() : '(unknown)',
                 $operation !== null ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Add a description to the response object as required by the OpenAPI specification.',

--- a/src/Lint/Rules/ResponseDuplicateStatus.php
+++ b/src/Lint/Rules/ResponseDuplicateStatus.php
@@ -47,7 +47,7 @@ final class ResponseDuplicateStatus implements Rule, OperationRuleVisitor
                     'HTTP status %s is declared %d times on %s %s',
                     $statusCode,
                     $count,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Remove the duplicate #[Response] attribute or change the status code.',

--- a/src/Lint/Rules/ResponseExampleMissing.php
+++ b/src/Lint/Rules/ResponseExampleMissing.php
@@ -46,7 +46,7 @@ final class ResponseExampleMissing implements Rule, ResponseRuleVisitor
             message: sprintf(
                 'Response %d on %s %s has no example',
                 $response->statusCode,
-                $operation !== null ? $operation->method : '(unknown)',
+                $operation !== null ? $operation->method->forDisplay() : '(unknown)',
                 $operation !== null ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Add an "examples" entry to the response media type to illustrate the expected payload.',

--- a/src/Lint/Rules/ResponseNoError.php
+++ b/src/Lint/Rules/ResponseNoError.php
@@ -48,7 +48,7 @@ final class ResponseNoError implements Rule, OperationRuleVisitor
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has no error response (4xx/5xx)',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add at least one error response (e.g. 400, 401, 404, 422, 500) to the operation.',

--- a/src/Lint/Rules/ResponseNoSuccess.php
+++ b/src/Lint/Rules/ResponseNoSuccess.php
@@ -39,7 +39,7 @@ final class ResponseNoSuccess implements Rule, OperationRuleVisitor
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has no 2xx success response',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add at least one success response (e.g. 200, 201, 204) to the operation.',

--- a/src/Lint/Rules/ResponseRedirectWithoutLocation.php
+++ b/src/Lint/Rules/ResponseRedirectWithoutLocation.php
@@ -44,7 +44,7 @@ final class ResponseRedirectWithoutLocation implements Rule, ResponseRuleVisitor
             message: sprintf(
                 'Redirect response %d on %s %s has no Location header',
                 $response->statusCode,
-                $operation !== null ? $operation->method : '(unknown)',
+                $operation !== null ? $operation->method->forDisplay() : '(unknown)',
                 $operation !== null ? $operation->pathUri : '(unknown)',
             ),
             fixHint: 'Add a Location header to the redirect response so clients know where to follow.',

--- a/src/Lint/Rules/ResponseStatusUnconventional.php
+++ b/src/Lint/Rules/ResponseStatusUnconventional.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Lint\Rules;
 
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\ResponseNode;
@@ -37,7 +38,7 @@ final class ResponseStatusUnconventional implements Rule, ResponseRuleVisitor
 
         $method = $operation->method;
 
-        if ($method !== 'POST' && $method !== 'DELETE') {
+        if ($method !== HttpMethod::Post && $method !== HttpMethod::Delete) {
             return;
         }
 
@@ -60,20 +61,20 @@ final class ResponseStatusUnconventional implements Rule, ResponseRuleVisitor
             return;
         }
 
-        $expected = $method === 'POST' ? '201' : '204';
+        $expected = $method === HttpMethod::Post ? '201' : '204';
 
         yield new Finding(
             ruleId: $this->id(),
             level: $this->level(),
             message: sprintf(
                 'Operation %s %s uses status 200 as its only success response; consider using %s instead',
-                $method,
+                $method->forDisplay(),
                 $operation->pathUri,
                 $expected,
             ),
             fixHint: sprintf(
                 '%s operations should typically return %s instead of 200.',
-                $method,
+                $method->forDisplay(),
                 $expected,
             ),
         );

--- a/src/Lint/Rules/ResponseSuccessEmptyBody.php
+++ b/src/Lint/Rules/ResponseSuccessEmptyBody.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Lint\Rules;
 
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\ResponseNode;
@@ -45,7 +46,7 @@ final class ResponseSuccessEmptyBody implements Rule, ResponseRuleVisitor
             return;
         }
 
-        if ($response->operation()?->method === 'HEAD') {
+        if ($response->operation()?->method === HttpMethod::Head) {
             return;
         }
 
@@ -55,7 +56,7 @@ final class ResponseSuccessEmptyBody implements Rule, ResponseRuleVisitor
 
         $operation = $response->operation();
         $route = $operation !== null
-            ? sprintf('%s %s', $operation->method, $operation->pathUri)
+            ? sprintf('%s %s', $operation->method->forDisplay(), $operation->pathUri)
             : '<unknown operation>';
 
         yield new Finding(

--- a/src/Lint/Rules/ScopeOverlyBroad.php
+++ b/src/Lint/Rules/ScopeOverlyBroad.php
@@ -50,7 +50,7 @@ final readonly class ScopeOverlyBroad implements Rule, OperationRuleVisitor
                     level: $this->level(),
                     message: sprintf(
                         'Operation %s %s uses only the wildcard scope "*" — consider using more specific scopes',
-                        $operation->method,
+                        $operation->method->forDisplay(),
                         $operation->pathUri,
                     ),
                     fixHint: 'Replace the "*" scope with specific scopes from Passport::tokensCan().',

--- a/src/Lint/Rules/SecurityInvalidScope.php
+++ b/src/Lint/Rules/SecurityInvalidScope.php
@@ -48,7 +48,7 @@ final readonly class SecurityInvalidScope implements Rule, OperationRuleVisitor
                     level: $this->level(),
                     message: sprintf(
                         'Operation %s %s references undefined scope "%s"',
-                        $operation->method,
+                        $operation->method->forDisplay(),
                         $operation->pathUri,
                         $scope,
                     ),

--- a/src/Lint/Rules/SecuritySchemeUndefined.php
+++ b/src/Lint/Rules/SecuritySchemeUndefined.php
@@ -61,7 +61,7 @@ final class SecuritySchemeUndefined implements Rule, OperationRuleVisitor, Reset
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s references undefined security scheme "%s"',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                     $schemeName,
                 ),
@@ -79,25 +79,25 @@ final class SecuritySchemeUndefined implements Rule, OperationRuleVisitor, Reset
     {
         $components = $spec->components;
 
-        if ($components === Generator::UNDEFINED || $components === null) {
+        if (Generator::isDefault($components) || $components === null) {
             return [];
         }
 
         $schemes = $components->securitySchemes;
 
-        if ($schemes === Generator::UNDEFINED || !is_array($schemes)) {
+        if (Generator::isDefault($schemes) || !is_array($schemes)) {
             return [];
         }
 
         $names = [];
 
         foreach ($schemes as $scheme) {
-            if ($scheme === Generator::UNDEFINED) {
+            if (Generator::isDefault($scheme)) {
                 continue;
             }
 
             if (
-                $scheme->securityScheme !== Generator::UNDEFINED
+                !Generator::isDefault($scheme->securityScheme)
                 && $scheme->securityScheme !== null
             ) {
                 $names[] = $scheme->securityScheme;

--- a/src/Lint/Rules/SpecInvalid.php
+++ b/src/Lint/Rules/SpecInvalid.php
@@ -11,6 +11,7 @@ use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Validator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\FindingLocation;
 use Radiergummi\OpenApi\Lint\LintContext;
@@ -349,7 +350,7 @@ final readonly class SpecInvalid implements Rule, ApiRuleVisitor
                 file: $descriptor->method->getFileName() ?: null,
                 line: $descriptor->method->getStartLine() ?: null,
                 routeName: $descriptor->route->getName(),
-                routeMethod: strtoupper($parsed['method'] ?? ''),
+                routeMethod: HttpMethod::fromString($parsed['method'] ?? ''),
                 routeUri: $parsed['routeUri'],
                 jsonPointer: $jsonPointer,
             );

--- a/src/Lint/Rules/SummaryMissing.php
+++ b/src/Lint/Rules/SummaryMissing.php
@@ -31,7 +31,7 @@ final class SummaryMissing implements Rule, OperationRuleVisitor
                 level: $this->level(),
                 message: sprintf(
                     'Operation %s %s has no summary',
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add a PHPDoc summary line to the controller method.',

--- a/src/Lint/Rules/TagDuplicate.php
+++ b/src/Lint/Rules/TagDuplicate.php
@@ -40,7 +40,7 @@ final class TagDuplicate implements Rule, OperationRuleVisitor
                     'Tag "%s" is applied %d times on %s %s',
                     $tag,
                     $count,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Remove the duplicate #[Tag] attribute.',

--- a/src/Lint/Rules/TagUndeclaredAtRoot.php
+++ b/src/Lint/Rules/TagUndeclaredAtRoot.php
@@ -42,7 +42,7 @@ final class TagUndeclaredAtRoot implements Rule, ApiRuleVisitor
                     message: sprintf(
                         'Tag "%s" used on %s %s is not declared in the top-level tags array',
                         $tag,
-                        $operation->method,
+                        $operation->method->forDisplay(),
                         $operation->pathUri,
                     ),
                     location: new FindingLocation(

--- a/src/Lint/Tree/OperationNode.php
+++ b/src/Lint/Tree/OperationNode.php
@@ -7,6 +7,7 @@ namespace Radiergummi\OpenApi\Lint\Tree;
 use LogicException;
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Attributes\PublicEndpoint;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use ReflectionAttribute;
 
@@ -16,25 +17,26 @@ use function array_values;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
-use function strtolower;
 
 final class OperationNode implements Node
 {
     private ?Node $parent = null;
 
     /**
-     * @param string                                            $pathUri         For API operations: the route URI. For
-     *                                                                           webhooks: the webhook name.
-     * @param string                                            $method          Uppercase: GET, POST, etc.
-     * @param list<ParameterNode>                               $parameters      Path parameters
-     * @param list<QueryParameterNode>                          $queryParameters
-     * @param list<ResponseNode>                                $responses       All responses
-     * @param list<array{scheme: string, scopes: list<string>}> $security
-     * @param list<string>                                      $tags
+     * @param string                   $pathUri         For API operations: the route URI.
+     *                                                  For webhooks: the webhook name.
+     * @param list<ParameterNode>      $parameters      Path parameters
+     * @param list<QueryParameterNode> $queryParameters
+     * @param list<ResponseNode>       $responses       All responses
+     * @param list<array{
+     *     scheme: string,
+     *     scopes: list<string>
+     * }>                              $security
+     * @param list<string> $tags
      */
     public function __construct(
         public readonly string $pathUri,
-        public readonly string $method,
+        public readonly HttpMethod $method,
         public readonly ?string $operationId,
         public readonly ?string $summary,
         public readonly ?string $description,
@@ -58,7 +60,9 @@ final class OperationNode implements Node
     public function linkParent(Node $parent): void
     {
         if ($this->parent !== null) {
-            throw new LogicException(sprintf('Parent already linked on %s', __CLASS__));
+            throw new LogicException(
+                sprintf('Parent already linked on %s', __CLASS__),
+            );
         }
 
         $this->parent = $parent;
@@ -67,10 +71,10 @@ final class OperationNode implements Node
     public function pointer(string $append = ''): string
     {
         if ($this->webhook) {
-            $base = $this->parent?->pointer() . '/' . strtolower($this->method);
+            $base = $this->parent?->pointer() . '/' . $this->method->value;
         } else {
             $escapedPath = str_replace(['~', '/'], ['~0', '~1'], $this->pathUri);
-            $base = "#/paths/{$escapedPath}/" . strtolower($this->method);
+            $base = "#/paths/{$escapedPath}/{$this->method->value}";
         }
 
         return $append !== '' ? $base . '/' . $append : $base;
@@ -82,7 +86,7 @@ final class OperationNode implements Node
     }
 
     /**
-     * Success responses (2xx). "default" responses are excluded.
+     * Success responses (2xx). "Default" responses are excluded.
      *
      * @return list<ResponseNode>
      */
@@ -91,13 +95,13 @@ final class OperationNode implements Node
         return array_values(
             array_filter(
                 $this->responses,
-                static fn(ResponseNode $r): bool => $r->isSuccess(),
+                static fn(ResponseNode $response): bool => $response->isSuccess(),
             ),
         );
     }
 
     /**
-     * Error responses (4xx/5xx). "default" responses are excluded.
+     * Error responses (4xx/5xx). "Default" responses are excluded.
      *
      * @return list<ResponseNode>
      */
@@ -106,14 +110,13 @@ final class OperationNode implements Node
         return array_values(
             array_filter(
                 $this->responses,
-                static fn(ResponseNode $r): bool => $r->isError(),
+                static fn(ResponseNode $response): bool => $response->isError(),
             ),
         );
     }
 
     /**
-     * Returns true when the controller method or its declaring class carries
-     * `#[PublicEndpoint]`.
+     * Returns true when the controller method or its declaring class carries `#[PublicEndpoint]`.
      */
     public function hasPublicEndpointAttribute(): bool
     {
@@ -143,27 +146,30 @@ final class OperationNode implements Node
     }
 
     /**
-     * Returns true when the route carries any `auth:*`, `scope:*`, or
-     * `scopes:*` middleware.
+     * Returns true when the route carries any `auth:*`, `scope:*`, or `scopes:*` middleware.
      */
     public function hasAuthMiddleware(): bool
     {
         return $this->descriptor !== null && array_any(
             $this->descriptor->route->middleware(),
-            static fn(string $mw): bool
-                    => str_starts_with($mw, 'auth:')
-                    || str_starts_with($mw, 'scope:')
-                    || str_starts_with($mw, 'scopes:'),
+            static fn(string $middleware): bool
+                    => str_starts_with($middleware, 'auth:')
+                    || str_starts_with($middleware, 'scope:')
+                    || str_starts_with($middleware, 'scopes:'),
         );
     }
 
-    /** Convenience: source file path. */
+    /**
+     * Convenience: source file path.
+     */
     public function file(): ?string
     {
         return $this->descriptor?->actionReflector?->getFileName() ?: null;
     }
 
-    /** Convenience: source line. */
+    /**
+     * Convenience: source line.
+     */
     public function line(): ?int
     {
         return $this->descriptor?->actionReflector?->getStartLine() ?: null;

--- a/src/Lint/Tree/SpecTreeBuilder.php
+++ b/src/Lint/Tree/SpecTreeBuilder.php
@@ -7,6 +7,7 @@ namespace Radiergummi\OpenApi\Lint\Tree;
 use LogicException;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 
 use function array_filter;
@@ -26,18 +27,6 @@ use function strtoupper;
  */
 final class SpecTreeBuilder
 {
-    /** @var list<string> */
-    private const HTTP_METHODS = [
-        'get',
-        'post',
-        'put',
-        'patch',
-        'delete',
-        'options',
-        'head',
-        'trace',
-    ];
-
     /**
      * Component schemas indexed by name — populated at the start of {@see build()} so
      * {@see buildFields()} can resolve `allOf: [{$ref: …}]` branches to the underlying
@@ -107,13 +96,13 @@ final class SpecTreeBuilder
     {
         $components = $spec->components;
 
-        if ($components === Generator::UNDEFINED || $components === null) {
+        if ($components === null || Generator::isDefault($components)) {
             return [];
         }
 
         $schemas = $components->schemas;
 
-        if ($schemas === Generator::UNDEFINED || !is_array($schemas)) {
+        if (!is_array($schemas) || Generator::isDefault($schemas)) {
             return [];
         }
 
@@ -122,12 +111,12 @@ final class SpecTreeBuilder
         foreach ($schemas as $schema) {
             if (
                 !$schema instanceof OA\Schema
-                || $schema === Generator::UNDEFINED // @phpstan-ignore identical.alwaysFalse (defensive; swagger-php may leave the sentinel in place at runtime)
+                || Generator::isDefault($schema)
             ) {
                 continue;
             }
 
-            if ($schema->schema === Generator::UNDEFINED) {
+            if (Generator::isDefault($schema->schema)) {
                 continue;
             }
 
@@ -180,33 +169,30 @@ final class SpecTreeBuilder
         }
 
         foreach ($paths as $path) {
-            if ($path === Generator::UNDEFINED) {
+            if (Generator::isDefault($path)) {
                 continue;
             }
 
             $pathUri
-                = $path->path !== Generator::UNDEFINED
+                = !Generator::isDefault($path->path)
                 ? $path->path
                 : '(unknown)';
 
-            foreach (self::HTTP_METHODS as $method) {
-                $oaOperation = $path->{$method} ?? null;
+            foreach (HttpMethod::cases() as $method) {
+                $oaOperation = $path->{$method->value} ?? null;
 
-                if (
-                    $oaOperation === Generator::UNDEFINED
-                    || $oaOperation === null
-                ) {
+                if ($oaOperation === null || Generator::isDefault($oaOperation)) {
                     continue;
                 }
 
-                $upperMethod = strtoupper($method);
-                $descriptorKey = $upperMethod . ' ' . $pathUri;
+                $upperMethod = strtoupper($method->value);
+                $descriptorKey = "{$upperMethod} {$pathUri}";
                 $descriptor = $descriptorIndex[$descriptorKey] ?? null;
 
                 $operations[] = $this->buildOperation(
                     $oaOperation,
                     $pathUri,
-                    $upperMethod,
+                    $method,
                     $descriptor,
                     webhook: false,
                 );
@@ -222,7 +208,7 @@ final class SpecTreeBuilder
     private function buildOperation(
         OA\Operation $oaOperation,
         string $pathUri,
-        string $method,
+        HttpMethod $method,
         ?ActionDescriptor $descriptor,
         bool $webhook,
     ): OperationNode {
@@ -239,7 +225,7 @@ final class SpecTreeBuilder
             operationId: SchemaAccessor::undefinedToNull($oaOperation->operationId),
             summary: SchemaAccessor::undefinedToNull($oaOperation->summary),
             description: SchemaAccessor::undefinedToNull($oaOperation->description),
-            deprecated: $oaOperation->deprecated !== Generator::UNDEFINED
+            deprecated: !Generator::isDefault($oaOperation->deprecated)
             && $oaOperation->deprecated === true,
             parameters: $parameters,
             queryParameters: $queryParameters,
@@ -281,18 +267,18 @@ final class SpecTreeBuilder
     {
         $params = $operation->parameters;
 
-        if ($params === Generator::UNDEFINED || !is_array($params)) {
+        if (!is_array($params) || Generator::isDefault($params)) {
             return [];
         }
 
         $result = [];
 
         foreach ($params as $param) {
-            if ($param === Generator::UNDEFINED) {
+            if (Generator::isDefault($param)) {
                 continue;
             }
 
-            $in = $param->in !== Generator::UNDEFINED ? $param->in : null;
+            $in = !Generator::isDefault($param->in) ? $param->in : null;
 
             if ($in !== 'path') {
                 continue;
@@ -300,10 +286,10 @@ final class SpecTreeBuilder
 
             $examples = $this->buildExamplesFromParameter($param);
             $node = new ParameterNode(
-                name: $param->name !== Generator::UNDEFINED
+                name: !Generator::isDefault($param->name)
                     ? $param->name
                     : '(unknown)',
-                required: $param->required !== Generator::UNDEFINED
+                required: !Generator::isDefault($param->required)
                 && $param->required === true,
                 // @phpstan-ignore nullCoalesce.property (defensive; $schema may be unset at runtime)
                 schema: SchemaAccessor::extractSchemaType($param->schema ?? null),
@@ -331,16 +317,17 @@ final class SpecTreeBuilder
      */
     private function buildExamplesFromParameter(OA\Parameter $param): array
     {
-        $examples = $param->examples ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        $examples = $param->examples ?? Generator::UNDEFINED;
 
-        if ($examples === Generator::UNDEFINED || !is_array($examples)) {
+        if (!is_array($examples) || Generator::isDefault($examples)) {
             return [];
         }
 
         $result = [];
 
         foreach ($examples as $example) {
-            if ($example === Generator::UNDEFINED) {
+            if (Generator::isDefault($example)) {
                 continue;
             }
 
@@ -355,10 +342,10 @@ final class SpecTreeBuilder
     private function buildExampleNode(OA\Examples $example): ExampleNode
     {
         return new ExampleNode(
-            name: $example->example !== Generator::UNDEFINED
+            name: !Generator::isDefault($example->example)
                 ? $example->example
                 : null,
-            value: $example->value !== Generator::UNDEFINED
+            value: !Generator::isDefault($example->value)
                 ? $example->value
                 : null,
             summary: SchemaAccessor::undefinedToNull($example->summary),
@@ -378,18 +365,18 @@ final class SpecTreeBuilder
     {
         $params = $operation->parameters;
 
-        if ($params === Generator::UNDEFINED || !is_array($params)) {
+        if (!is_array($params) || Generator::isDefault($params)) {
             return [];
         }
 
         $result = [];
 
         foreach ($params as $param) {
-            if ($param === Generator::UNDEFINED) {
+            if (Generator::isDefault($param)) {
                 continue;
             }
 
-            $in = $param->in !== Generator::UNDEFINED ? $param->in : null;
+            $in = !Generator::isDefault($param->in) ? $param->in : null;
 
             if ($in !== 'query') {
                 continue;
@@ -398,15 +385,15 @@ final class SpecTreeBuilder
             $examples = $this->buildExamplesFromParameter($param);
             $schema = $param->schema ?? null; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
             $node = new QueryParameterNode(
-                name: $param->name !== Generator::UNDEFINED
+                name: !Generator::isDefault($param->name)
                     ? $param->name
                     : '(unknown)',
-                required: $param->required !== Generator::UNDEFINED
+                required: !Generator::isDefault($param->required)
                 && $param->required === true,
                 type: SchemaAccessor::extractSchemaType($schema),
-                hasSchema: $schema !== null && $schema !== Generator::UNDEFINED,
+                hasSchema: $schema !== null && !Generator::isDefault($schema),
                 style: SchemaAccessor::undefinedToNull($param->style),
-                explode: $param->explode !== Generator::UNDEFINED
+                explode: !Generator::isDefault($param->explode)
                     ? (bool) $param->explode
                     : null,
                 description: SchemaAccessor::undefinedToNull($param->description),
@@ -430,9 +417,9 @@ final class SpecTreeBuilder
      */
     private function buildRequestBody(OA\Operation $operation): ?RequestBodyNode
     {
-        $rb = $operation->requestBody;
+        $requestBody = $operation->requestBody;
 
-        if ($rb === Generator::UNDEFINED || $rb === null) {
+        if ($requestBody === null || Generator::isDefault($requestBody)) {
             return null;
         }
 
@@ -440,26 +427,26 @@ final class SpecTreeBuilder
         $fields = [];
         $examples = [];
         $schemaRef = null;
-        $description = SchemaAccessor::undefinedToNull($rb->description);
+        $description = SchemaAccessor::undefinedToNull($requestBody->description);
         $required
-            = $rb->required !== Generator::UNDEFINED && $rb->required === true;
+            = !Generator::isDefault($requestBody->required) && $requestBody->required === true;
 
-        $content = $rb->content;
+        $content = $requestBody->content;
 
-        if ($content !== Generator::UNDEFINED && is_array($content)) {
+        if (is_array($content) && !Generator::isDefault($content)) {
             foreach ($content as $mediaType) {
-                if ($mediaType === Generator::UNDEFINED) {
+                if (Generator::isDefault($mediaType)) {
                     continue;
                 }
 
-                if ($mediaType instanceof OA\MediaType && $mediaType->mediaType !== Generator::UNDEFINED) {
+                if ($mediaType instanceof OA\MediaType && !Generator::isDefault($mediaType->mediaType)) {
                     $contentTypes[] = $mediaType->mediaType;
                 }
 
                 if ($fields === [] && $schemaRef === null) {
                     $schema = $mediaType->schema ?? null;
 
-                    if ($schema !== null && !is_array($schema) && $schema !== Generator::UNDEFINED) {
+                    if ($schema !== null && !is_array($schema) && !Generator::isDefault($schema)) {
                         $ref = SchemaAccessor::extractRef($schema);
 
                         if ($ref !== null) {
@@ -470,18 +457,15 @@ final class SpecTreeBuilder
                     }
                 }
 
-                $mtExamples = $mediaType->examples ?? Generator::UNDEFINED;
+                $mediaTypeExamples = $mediaType->examples ?? Generator::UNDEFINED;
 
-                if (
-                    $mtExamples !== Generator::UNDEFINED
-                    && is_array($mtExamples)
-                ) {
-                    foreach ($mtExamples as $ex) {
-                        if ($ex === Generator::UNDEFINED) {
+                if (is_array($mediaTypeExamples) && !Generator::isDefault($mediaTypeExamples)) {
+                    foreach ($mediaTypeExamples as $mediaTypeExample) {
+                        if (Generator::isDefault($mediaTypeExample)) {
                             continue;
                         }
 
-                        $examples[] = $this->buildExampleNode($ex);
+                        $examples[] = $this->buildExampleNode($mediaTypeExample);
                     }
                 }
             }
@@ -494,7 +478,7 @@ final class SpecTreeBuilder
             examples: $examples,
             schemaRef: $schemaRef,
             description: $description,
-            raw: $rb,
+            raw: $requestBody,
         );
 
         // Link field and example parents
@@ -534,7 +518,7 @@ final class SpecTreeBuilder
     {
         if (
             $schema === null
-            || $schema === Generator::UNDEFINED // @phpstan-ignore identical.alwaysFalse (defensive; swagger-php may leave the sentinel in place at runtime)
+            || Generator::isDefault($schema)
         ) {
             return [];
         }
@@ -558,7 +542,7 @@ final class SpecTreeBuilder
                 nullable: SchemaAccessor::isNullable($property),
                 description: SchemaAccessor::undefinedToNull($property->description),
                 format: SchemaAccessor::undefinedToNull($property->format),
-                example: $property->example !== Generator::UNDEFINED
+                example: !Generator::isDefault($property->example)
                     ? $property->example
                     : null,
                 enum: SchemaAccessor::extractSchemaEnum($property),
@@ -608,7 +592,7 @@ final class SpecTreeBuilder
             foreach ($allOf as $branch) {
                 if (
                     !$branch instanceof OA\Schema
-                    || $branch === Generator::UNDEFINED // @phpstan-ignore identical.alwaysFalse (defensive; swagger-php may leave the sentinel in place at runtime)
+                    || Generator::isDefault($branch)
                 ) {
                     continue;
                 }
@@ -660,12 +644,12 @@ final class SpecTreeBuilder
             foreach ($localProperties as $property) {
                 if (
                     !$property instanceof OA\Property
-                    || $property === Generator::UNDEFINED // @phpstan-ignore identical.alwaysFalse (defensive; swagger-php may leave the sentinel in place at runtime)
+                    || Generator::isDefault($property)
                 ) {
                     continue;
                 }
 
-                $name = $property->property !== Generator::UNDEFINED
+                $name = !Generator::isDefault($property->property)
                     ? $property->property
                     : '(unknown)';
 
@@ -673,7 +657,7 @@ final class SpecTreeBuilder
             }
         }
 
-        if ($schema->required !== Generator::UNDEFINED && is_array($schema->required)) {
+        if (is_array($schema->required) && !Generator::isDefault($schema->required)) {
             foreach ($schema->required as $name) {
                 $required[] = $name;
             }
@@ -691,14 +675,14 @@ final class SpecTreeBuilder
     {
         $examples = $schema->examples ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
 
-        if ($examples === Generator::UNDEFINED || !is_array($examples)) {
+        if (!is_array($examples) || Generator::isDefault($examples)) {
             return [];
         }
 
         $result = [];
 
         foreach ($examples as $example) {
-            if ($example === Generator::UNDEFINED) {
+            if (Generator::isDefault($example)) {
                 continue;
             }
 
@@ -719,19 +703,19 @@ final class SpecTreeBuilder
     {
         $responses = $operation->responses;
 
-        if ($responses === Generator::UNDEFINED || !is_array($responses)) {
+        if (!is_array($responses) || Generator::isDefault($responses)) {
             return [];
         }
 
         $result = [];
 
         foreach ($responses as $response) {
-            if ($response === Generator::UNDEFINED) {
+            if (Generator::isDefault($response)) {
                 continue;
             }
 
             $statusCode
-                = $response->response !== Generator::UNDEFINED
+                = !Generator::isDefault($response->response)
                 ? $response->response
                 : 'default';
 
@@ -744,9 +728,9 @@ final class SpecTreeBuilder
 
             $content = $response->content ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
 
-            if ($content !== Generator::UNDEFINED && is_array($content)) {
+            if (is_array($content) && !Generator::isDefault($content)) {
                 foreach ($content as $mediaType) {
-                    if ($mediaType === Generator::UNDEFINED) {
+                    if (Generator::isDefault($mediaType)) {
                         continue;
                     }
 
@@ -756,7 +740,7 @@ final class SpecTreeBuilder
                         if (
                             $schema !== null
                             && !is_array($schema)
-                            && $schema !== Generator::UNDEFINED
+                            && !Generator::isDefault($schema)
                         ) {
                             $ref = SchemaAccessor::extractRef($schema);
 
@@ -768,28 +752,29 @@ final class SpecTreeBuilder
                         }
                     }
 
-                    $mtExamples = $mediaType->examples ?? Generator::UNDEFINED;
+                    $mediaTypeExamples = $mediaType->examples ?? Generator::UNDEFINED;
 
                     if (
-                        $mtExamples !== Generator::UNDEFINED
-                        && is_array($mtExamples)
+                        is_array($mediaTypeExamples)
+                        && !Generator::isDefault($mediaTypeExamples)
                     ) {
-                        foreach ($mtExamples as $ex) {
-                            if ($ex === Generator::UNDEFINED) {
+                        foreach ($mediaTypeExamples as $mediaTypeExample) {
+                            if (Generator::isDefault($mediaTypeExample)) {
                                 continue;
                             }
 
-                            $examples[] = $this->buildExampleNode($ex);
+                            $examples[] = $this->buildExampleNode($mediaTypeExample);
                         }
                     }
                 }
             }
 
-            $oaHeaders = $response->headers ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            $oaHeaders = $response->headers ?? Generator::UNDEFINED;
 
-            if ($oaHeaders !== Generator::UNDEFINED && is_array($oaHeaders)) {
+            if (is_array($oaHeaders) && !Generator::isDefault($oaHeaders)) {
                 foreach ($oaHeaders as $header) {
-                    if ($header === Generator::UNDEFINED) {
+                    if (Generator::isDefault($header)) {
                         continue;
                     }
 
@@ -797,11 +782,12 @@ final class SpecTreeBuilder
                 }
             }
 
-            $oaLinks = $response->links ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            $oaLinks = $response->links ?? Generator::UNDEFINED;
 
-            if ($oaLinks !== Generator::UNDEFINED && is_array($oaLinks)) {
+            if (is_array($oaLinks) && !Generator::isDefault($oaLinks)) {
                 foreach ($oaLinks as $link) {
-                    if ($link === Generator::UNDEFINED) {
+                    if (Generator::isDefault($link)) {
                         continue;
                     }
 
@@ -846,13 +832,13 @@ final class SpecTreeBuilder
     private function buildHeader(OA\Header $header): HeaderNode
     {
         return new HeaderNode(
-            name: $header->header !== Generator::UNDEFINED
+            name: !Generator::isDefault($header->header)
                 ? $header->header
                 : '(unknown)',
             // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
             schema: SchemaAccessor::extractSchemaType($header->schema ?? null),
             description: SchemaAccessor::undefinedToNull($header->description),
-            required: $header->required !== Generator::UNDEFINED
+            required: !Generator::isDefault($header->required)
             && $header->required === true,
             raw: $header,
         );
@@ -863,7 +849,7 @@ final class SpecTreeBuilder
         $parameters = [];
         $oaParams = $link->parameters;
 
-        if ($oaParams !== Generator::UNDEFINED && is_array($oaParams)) {
+        if (is_array($oaParams) && !Generator::isDefault($oaParams)) {
             foreach ($oaParams as $key => $value) {
                 if (is_string($key) && is_string($value)) {
                     $parameters[$key] = $value;
@@ -872,7 +858,7 @@ final class SpecTreeBuilder
         }
 
         return new LinkNode(
-            name: $link->link !== Generator::UNDEFINED
+            name: !Generator::isDefault($link->link)
                 ? $link->link
                 : '(unnamed)',
             operationId: SchemaAccessor::undefinedToNull($link->operationId),
@@ -890,21 +876,21 @@ final class SpecTreeBuilder
     {
         $security = $operation->security;
 
-        if ($security === Generator::UNDEFINED || !is_array($security)) {
+        if (!is_array($security) || Generator::isDefault($security)) {
             return [];
         }
 
         $result = [];
 
         foreach ($security as $requirement) {
-            if ($requirement === Generator::UNDEFINED) {
+            if (Generator::isDefault($requirement)) {
                 continue;
             }
 
             // OA\SecurityScheme annotation — varies by swagger-php version
             if ($requirement instanceof OA\SecurityScheme) {
                 $scheme
-                    = $requirement->securityScheme !== Generator::UNDEFINED
+                    = !Generator::isDefault($requirement->securityScheme)
                     ? $requirement->securityScheme
                     : '(unknown)';
                 $result[] = ['scheme' => $scheme, 'scopes' => []];
@@ -930,7 +916,7 @@ final class SpecTreeBuilder
     {
         $tags = $operation->tags;
 
-        if ($tags === Generator::UNDEFINED || !is_array($tags)) {
+        if (!is_array($tags) || Generator::isDefault($tags)) {
             return [];
         }
 
@@ -952,25 +938,25 @@ final class SpecTreeBuilder
     {
         $components = $spec->components;
 
-        if ($components === Generator::UNDEFINED || $components === null) {
+        if ($components === null || Generator::isDefault($components)) {
             return [];
         }
 
         $schemas = $components->schemas;
 
-        if ($schemas === Generator::UNDEFINED || !is_array($schemas)) {
+        if (!is_array($schemas) || Generator::isDefault($schemas)) {
             return [];
         }
 
         $result = [];
 
         foreach ($schemas as $schema) {
-            if ($schema === Generator::UNDEFINED) {
+            if (Generator::isDefault($schema)) {
                 continue;
             }
 
             $name
-                = $schema->schema !== Generator::UNDEFINED
+                = !Generator::isDefault($schema->schema)
                 ? $schema->schema
                 : '(unknown)';
 
@@ -1002,39 +988,38 @@ final class SpecTreeBuilder
      */
     private function buildWebhooks(OA\OpenApi $spec): array
     {
-        $webhooks = $spec->webhooks ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        $webhooks = $spec->webhooks ?? Generator::UNDEFINED;
 
-        if ($webhooks === Generator::UNDEFINED || !is_array($webhooks)) {
+        if (!is_array($webhooks) || Generator::isDefault($webhooks)) {
             return [];
         }
 
         $result = [];
 
         foreach ($webhooks as $name => $pathItem) {
-            if ($pathItem === Generator::UNDEFINED) {
+            if (Generator::isDefault($pathItem)) {
                 continue;
             }
 
             $webhookName = is_string($name) ? $name : '(unknown)';
 
             $description = SchemaAccessor::undefinedToNull(
-                $pathItem->description ?? Generator::UNDEFINED, // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+                // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+                $pathItem->description ?? Generator::UNDEFINED,
             );
 
-            foreach (self::HTTP_METHODS as $method) {
-                $oaOperation = $pathItem->{$method} ?? null;
+            foreach (HttpMethod::cases() as $method) {
+                $oaOperation = $pathItem->{$method->value} ?? null;
 
-                if (
-                    $oaOperation === Generator::UNDEFINED
-                    || $oaOperation === null
-                ) {
+                if ($oaOperation === null || Generator::isDefault($oaOperation)) {
                     continue;
                 }
 
                 $operation = $this->buildOperation(
                     $oaOperation,
                     $webhookName,
-                    strtoupper($method),
+                    $method,
                     null,
                     webhook: true,
                 );
@@ -1061,7 +1046,7 @@ final class SpecTreeBuilder
     {
         $tags = $spec->tags;
 
-        if ($tags === Generator::UNDEFINED || !is_array($tags)) {
+        if (!is_array($tags) || Generator::isDefault($tags)) {
             return [[], []];
         }
 
@@ -1069,11 +1054,11 @@ final class SpecTreeBuilder
         $descriptions = [];
 
         foreach ($tags as $tag) {
-            if ($tag === Generator::UNDEFINED) {
+            if (Generator::isDefault($tag)) {
                 continue;
             }
 
-            $name = $tag->name !== Generator::UNDEFINED ? $tag->name : null;
+            $name = !Generator::isDefault($tag->name) ? $tag->name : null;
 
             if ($name === null) {
                 continue;
@@ -1081,7 +1066,7 @@ final class SpecTreeBuilder
 
             $names[] = $name;
             $desc
-                = $tag->description !== Generator::UNDEFINED
+                = !Generator::isDefault($tag->description)
                 ? $tag->description
                 : null;
 

--- a/src/Lint/TreeIndex.php
+++ b/src/Lint/TreeIndex.php
@@ -72,7 +72,7 @@ final readonly class TreeIndex
                 $operationsByOperationId[$operation->operationId] = $operation;
             }
 
-            $routeKey = strtoupper($operation->method) . ' ' . $operation->pathUri;
+            $routeKey = strtoupper($operation->method->value) . ' ' . $operation->pathUri;
             $operationsByRouteKey[$routeKey] = $operation;
         }
 
@@ -119,11 +119,7 @@ final readonly class TreeIndex
 
             $ref = $annotation->ref;
 
-            if (
-                $ref === Generator::UNDEFINED
-                || $ref === null
-                || !is_string($ref)
-            ) {
+            if (Generator::isDefault($ref) || $ref === null || !is_string($ref)) {
                 return;
             }
 

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
@@ -62,7 +62,7 @@ final readonly class ResourceFieldsUndeclared implements Rule, OperationRuleVisi
             level: $this->level(),
             message: sprintf(
                 '%s %s returns %s but it declares no #[ResourceField] — the response schema is empty',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
                 $resourceClass,
             ),

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
@@ -46,7 +46,7 @@ final readonly class ResourceResponseAmbiguous implements Rule, OperationRuleVis
             level: $this->level(),
             message: sprintf(
                 '%s %s returns a resource collection but no #[ResponseResource] names the item class',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Add #[ResponseResource(SomeResource::class, collection: true)] to the action.',

--- a/src/Plugins/Core/ErrorContributors/ThrowsErrorContributor.php
+++ b/src/Plugins/Core/ErrorContributors/ThrowsErrorContributor.php
@@ -143,7 +143,7 @@ final readonly class ThrowsErrorContributor implements ErrorResponseContributor
                     file: $descriptor->method?->getFileName() ?: null,
                     line: $descriptor->method?->getStartLine() ?: null,
                     routeName: $descriptor->route->getName(),
-                    routeMethod: strtoupper($descriptor->route->methods()[0] ?? 'GET'),
+                    routeMethod: $descriptor->httpMethod,
                     routeUri: $descriptor->route->uri(),
                 ),
                 fixHint: $this->buildThrowsUnmappedHint($throw),

--- a/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
@@ -55,7 +55,7 @@ final readonly class FractalFieldsUndeclared implements Rule, OperationRule
             level: $this->level(),
             message: sprintf(
                 '%s %s is bound to %s, which declares no #[TransformerField] — the response schema is empty',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
                 $transformer,
             ),

--- a/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
@@ -62,7 +62,7 @@ final readonly class FractalResponseUnbound implements Rule, OperationRule
             level: $this->level(),
             message: sprintf(
                 '%s %s injects a Fractal Manager but declares no #[FractalResponse]',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Add #[FractalResponse(transformer: SomeTransformer::class)] to the action.',

--- a/src/Plugins/Fractal/Lint/Rules/FractalTransformerClassMissing.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalTransformerClassMissing.php
@@ -52,7 +52,7 @@ final readonly class FractalTransformerClassMissing implements Rule, OperationRu
             level: $this->level(),
             message: sprintf(
                 '#[FractalResponse] on %s %s names unknown transformer %s',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
                 $transformer,
             ),

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterTypeMissing.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterTypeMissing.php
@@ -45,7 +45,7 @@ final readonly class QueryBuilderFilterTypeMissing implements Rule, OperationRul
                 message: sprintf(
                     '#[AllowedFilter(\'%s\')] on %s %s has no type — the filter parameter defaults to string',
                     $filter->name,
-                    $operation->method,
+                    $operation->method->forDisplay(),
                     $operation->pathUri,
                 ),
                 fixHint: 'Add a type: to #[AllowedFilter] (\'string\', \'integer\', \'boolean\', …).',

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
@@ -23,9 +23,9 @@ use function sprintf;
  * declares none of `#[AllowedFilter]`, `#[AllowedSort]`, or `#[AllowedInclude]` — the endpoint
  * accepts filter/sort/include parameters that the generated document does not describe.
  *
- * Detection is deliberately conservative: it keys off an injected `QueryBuilder` parameter
- * (matched by FQCN string via {@see PayloadParameterScanner}, so the package need not be
- * installed), not a body-inference heuristic.
+ * Detection is deliberately conservative: it keys off an injected `QueryBuilder` parameter (matched
+ * by FQCN string via {@see PayloadParameterScanner}, so the package need not be installed), not a
+ * body-inference heuristic.
  */
 final readonly class QueryBuilderParamsUndeclared implements Rule, OperationRule
 {
@@ -65,7 +65,7 @@ final readonly class QueryBuilderParamsUndeclared implements Rule, OperationRule
             level: $this->level(),
             message: sprintf(
                 '%s %s injects a QueryBuilder but declares no #[AllowedFilter]/#[AllowedSort]/#[AllowedInclude]',
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Declare the accepted parameters with #[AllowedFilter], #[AllowedSort], and #[AllowedInclude].',

--- a/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
+++ b/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
@@ -130,7 +130,7 @@ final readonly class FieldAttributeWrongScope implements Rule, OperationRuleVisi
             message: sprintf(
                 '#[RequestField] on URI parameter $%s of %s %s applies to request-body fields, not URI parameters',
                 $param->getName(),
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Use #[PathParam] for a URI parameter.',

--- a/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
+++ b/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
@@ -66,7 +66,7 @@ final readonly class MultipartFileWithoutMultipart implements Rule, OperationRul
                 '%s::%s() accepts an UploadedFile via a Data object, but %s %s does not declare multipart/form-data',
                 $operation->descriptor->controller?->getShortName() ?? '(unknown)',
                 $operation->descriptor->method->getName(),
-                $operation->method,
+                $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
             fixHint: 'Add a multipart/form-data request body to the operation, or use #[RequestBody] with the correct media type.',

--- a/src/Routing/ActionDescriptor.php
+++ b/src/Routing/ActionDescriptor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Routing;
 
 use Illuminate\Routing\Route;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionFunction;
@@ -40,6 +41,10 @@ final class ActionDescriptor
         get => $this->method ?? $this->closure;
     }
 
+    public ?HttpMethod $httpMethod {
+        get => HttpMethod::fromString($this->route->methods[0] ?? '');
+    }
+
     /**
      * Buckets of `ReflectionAttribute`s keyed by attribute FQCN. Built lazily on first access via
      * a single `getAttributes()` call per reflector — every caller that asks for a specific
@@ -52,8 +57,8 @@ final class ActionDescriptor
 
     /**
      * @param null|ReflectionClass<object> $controller
-     * @param list<string>                 $throws     Fully-qualified exception class names resolved from
-     *                                                 the action's `@throws` lines.
+     * @param list<string>                 $throws     Fully-qualified exception class names
+     *                                                 resolved from the action's at-throws lines.
      */
     public function __construct(
         public readonly Route $route,

--- a/src/Support/Extraction/RequestBodyExtractor.php
+++ b/src/Support/Extraction/RequestBodyExtractor.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Support\Extraction;
 
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Contracts\Registry\RequestSchemaResolver;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\FindingLocation;
 use Radiergummi\OpenApi\Lint\FindingsCollector;
@@ -14,7 +15,6 @@ use Radiergummi\OpenApi\Support\Registry\ResolvedSchema;
 
 use function in_array;
 use function sprintf;
-use function strtoupper;
 
 /**
  * Iterates registered {@see RequestSchemaResolver}s (first non-null wins) and assembles an
@@ -58,23 +58,21 @@ final readonly class RequestBodyExtractor
 
     private function emitEmptyFindingIfWriteMethod(ActionDescriptor $descriptor): void
     {
-        $httpMethod = strtoupper($descriptor->route->methods()[0] ?? 'GET');
-
-        if (in_array($httpMethod, ['POST', 'PUT', 'PATCH'], true)) {
+        if (in_array($descriptor->httpMethod, [HttpMethod::Post, HttpMethod::Put, HttpMethod::Patch], true)) {
             $this->findings->emit(
                 new Finding(
                     ruleId: 'request.empty',
                     level: 2,
                     message: sprintf(
                         'No request body schema for %s %s',
-                        $httpMethod,
+                        $descriptor->httpMethod->forDisplay(),
                         $descriptor->route->uri(),
                     ),
                     location: new FindingLocation(
                         file: $descriptor->method?->getFileName() ?: null,
                         line: $descriptor->method?->getStartLine() ?: null,
                         routeName: $descriptor->route->getName(),
-                        routeMethod: $httpMethod,
+                        routeMethod: $descriptor->httpMethod,
                         routeUri: $descriptor->route->uri(),
                     ),
                     fixHint: 'Type-hint a Data class or FormRequest on the controller or injected Action.',

--- a/src/Support/Generator/OperationDescriptor.php
+++ b/src/Support/Generator/OperationDescriptor.php
@@ -6,10 +6,10 @@ namespace Radiergummi\OpenApi\Support\Generator;
 
 use Illuminate\Contracts\Support\Arrayable;
 use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 
 use function array_filter;
 use function in_array;
-use function strtoupper;
 
 /**
  * @implements Arrayable<string, mixed>
@@ -51,10 +51,14 @@ final readonly class OperationDescriptor implements Arrayable
         );
     }
 
-    public function toOpenApi(string $method): ?OA\Operation
+    /**
+     * Builds the method-specific {@see OA\Operation} and assigns it to the matching `$pathItem`
+     * property, returning the same instance (or null for verbs without a path-item slot, e.g.
+     * HEAD/TRACE). Assigning inside the match keeps the concrete operation type flowing into the
+     * concrete property, so the method → operation-class → property-name mapping lives in one place.
+     */
+    public function attachTo(OA\PathItem $pathItem, HttpMethod $method): ?OA\Operation
     {
-        $method = strtoupper($method);
-
         // swagger-php serialises explicit nulls verbatim, and OpenAPI 3.1 rejects null on optional
         // fields (externalDocs, summary, …). Drop unset optionals so they are omitted rather than
         // emitted as null.
@@ -72,12 +76,12 @@ final readonly class OperationDescriptor implements Arrayable
         }
 
         return match ($method) {
-            'GET' => new OA\Get($props),
-            'POST' => new OA\Post($props),
-            'PUT' => new OA\Put($props),
-            'PATCH' => new OA\Patch($props),
-            'DELETE' => new OA\Delete($props),
-            'OPTIONS' => new OA\Options($props),
+            HttpMethod::Get => $pathItem->get = new OA\Get($props),
+            HttpMethod::Post => $pathItem->post = new OA\Post($props),
+            HttpMethod::Put => $pathItem->put = new OA\Put($props),
+            HttpMethod::Patch => $pathItem->patch = new OA\Patch($props),
+            HttpMethod::Delete => $pathItem->delete = new OA\Delete($props),
+            HttpMethod::Options => $pathItem->options = new OA\Options($props),
             default => null,
         };
     }
@@ -98,10 +102,14 @@ final readonly class OperationDescriptor implements Arrayable
         ];
     }
 
-    private function shouldAttachBody(string $method): bool
+    private function shouldAttachBody(HttpMethod $method): bool
     {
         return
             $this->requestBody !== null
-            && in_array($method, ['POST', 'PUT', 'PATCH'], strict: true);
+            && in_array($method, [
+                HttpMethod::Post,
+                HttpMethod::Put,
+                HttpMethod::Patch,
+            ], strict: true);
     }
 }

--- a/src/Support/Generator/Stages/ErrorResponseInferenceStage.php
+++ b/src/Support/Generator/Stages/ErrorResponseInferenceStage.php
@@ -12,11 +12,13 @@ use Radiergummi\OpenApi\Contracts\Generator\SpecStage;
 use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseContributor;
 use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseResolver;
 use Radiergummi\OpenApi\Enums\ComponentType;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Errors\ErrorDescriptor;
 use Radiergummi\OpenApi\Errors\ErrorResponse;
 use Radiergummi\OpenApi\Generator\GenerationContext;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\FindingsCollector;
+use Radiergummi\OpenApi\Lint\Rules\ErrorsResolverFailed;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Throwable;
 
@@ -40,11 +42,12 @@ use function sprintf;
 final readonly class ErrorResponseInferenceStage implements SpecStage
 {
     /**
-     * Fix hint emitted with every `errors.resolver-failed` finding. Public so the lint rule
-     * stub ({@see \Radiergummi\OpenApi\Lint\Rules\ErrorsResolverFailed}) can reference it
-     * without forcing a Support → Lint import.
+     * Fix hint emitted with every `errors.resolver-failed` finding. Public, so the lint rule
+     * stub ({@see ErrorsResolverFailed}) can reference it without forcing a Support → Lint import.
      */
-    public const string RESOLVER_FAILED_FIX_HINT = 'Fix the throwing ErrorResponseResolver — implementations must catch internally and return null on failure.';
+    public const string RESOLVER_FAILED_FIX_HINT
+        = 'Fix the throwing ErrorResponseResolver — implementations must catch internally and'
+        . ' return null on failure.';
 
     /**
      * Maps HTTP status codes to stable `components.responses` component names.
@@ -63,8 +66,6 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
         429 => 'TooManyRequests',
         500 => 'InternalServerError',
     ];
-
-    private const array HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options'];
 
     /**
      * @param list<ErrorResponseContributor> $contributors
@@ -95,8 +96,8 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
     private function decorateContainers(array $containers, GenerationContext $ctx): void
     {
         foreach ($containers as $container) {
-            foreach (self::HTTP_METHODS as $verb) {
-                $operation = $container->{$verb} ?? Generator::UNDEFINED;
+            foreach (HttpMethod::cases() as $method) {
+                $operation = $container->{$method->value} ?? Generator::UNDEFINED;
 
                 if (!$operation instanceof OA\Operation) {
                     continue;
@@ -149,7 +150,11 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
         foreach ($byStatus as $descriptor) {
             $body = $this->resolveBody($descriptor);
             $componentName = self::STATUS_COMPONENT_NAMES[$descriptor->status] ?? null;
-            $additions[] = $this->buildResponse($descriptor, $body, $componentName);
+            $additions[] = $this->buildResponse(
+                $descriptor,
+                $body,
+                $componentName,
+            );
         }
 
         $operation->responses = [...$existing, ...$additions];
@@ -158,14 +163,13 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
     // region Body resolution helpers
 
     /**
-     * Walks the resolver chain for one descriptor. First non-null wins. Returns null when
-     * every resolver passes — the stage then emits a bodyless response.
+     * Walks the resolver chain for one descriptor. First non-null wins. Returns null when every
+     * resolver passes — the stage then emits a bodyless response.
      *
-     * The {@see ErrorResponseResolver} contract requires implementations to catch internally
-     * and return null on failure, but the stage defends against misbehaving resolvers
-     * anyway: a throwing resolver emits a `errors.resolver-failed` finding and the chain
-     * continues, matching the spec's promise that a single bad resolver does not abort the
-     * full generation run.
+     * The {@see ErrorResponseResolver} contract requires implementations to catch internally and
+     * return null on failure, but the stage defends against misbehaving resolvers anyway: a
+     * throwing resolver emits a `errors.resolver-failed` finding and the chain continues, matching
+     * the spec's promise that a single bad resolver does not abort the full generation run.
      */
     private function resolveBody(ErrorDescriptor $descriptor): ?ErrorResponse
     {
@@ -205,16 +209,15 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
     }
 
     /**
-     * Composes the resolver's body slice with the stage-owned fields: response key,
-     * default description, named-component registration.
+     * Composes the resolver's body slice with the stage-owned fields: response key, default
+     * description, named-component registration.
      *
-     * A named component is only used when the body is empty (description-only). When a
-     * resolver produces content, headers, or links, the response is inlined per operation to
-     * avoid first-write-wins collisions on the shared component — e.g. two operations at 422
-     * with different resolver outputs (generic Error vs. ValidationError) would otherwise
-     * silently share the first registration. The shared schemas referenced inside the content
-     * (e.g. `$ref: '#/components/schemas/Error'`) are still reused; only the response wrapper
-     * is inlined.
+     * A named component is only used when the body is empty (description-only). When a resolver
+     * produces content, headers, or links, the response is inlined per operation to avoid
+     * first-write-wins collisions on the shared component — e.g. two operations at 422 with
+     * different resolver outputs (generic Error vs. ValidationError) would otherwise silently share
+     * the first registration. The shared schemas referenced inside the content (e.g.
+     * `$ref: '#/components/schemas/Error'`) are still reused; only the response wrapper is inlined.
      */
     private function buildResponse(
         ErrorDescriptor $descriptor,
@@ -225,8 +228,8 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
         $content = $headers = $links = null;
 
         if ($body !== null) {
-            // Only override the curated default description when the resolver supplied a
-            // non-empty string; OpenAPI 3.1 requires response.description to be non-empty.
+            // Only override the curated default description when the resolver supplied a non-empty
+            // string; OpenAPI 3.1 requires response.description to be non-empty.
             if ($body->description !== null && $body->description !== '') {
                 $description = $body->description;
             }
@@ -246,10 +249,10 @@ final readonly class ErrorResponseInferenceStage implements SpecStage
 
         $hasBody = $content !== null || $headers !== null || $links !== null;
 
-        // Share via a named response component only when the body is empty
-        // (description-only). Resolver-produced bodies may vary by descriptor —
-        // e.g. validation vs generic at status 422 — so we inline them per operation
-        // to avoid first-write-wins collisions on the shared component.
+        // Share via a named response component only when the body is empty (description-only).
+        // Resolver-produced bodies may vary by descriptor — e.g., validation vs. generic at
+        // status 422 — so we inline them per operation to avoid first-write-wins collisions on the
+        // shared component.
         if ($componentName !== null && !$hasBody) {
             $this->registry->registerNamedResponse(
                 $componentName,

--- a/src/Support/Generator/Stages/OverridesStage.php
+++ b/src/Support/Generator/Stages/OverridesStage.php
@@ -8,8 +8,10 @@ use Illuminate\Container\Attributes\Scoped;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 use Radiergummi\OpenApi\Contracts\Generator\SpecStage;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Generator\GenerationContext;
 use Radiergummi\OpenApi\Support\Generator\OverrideMatcher;
+use Radiergummi\OpenApi\Support\Generator\SpecPipeline;
 
 use function is_array;
 use function str_starts_with;
@@ -21,44 +23,32 @@ use function substr;
  * Runs after every registry-resolved stage (so config overrides beat plugin contributions and
  * convention-derived values) but before the terminal {@see TransformersStage} (so a user's
  * code-based `transformDocument()` callback retains the final word). Wired as a fixed pre-terminal
- * step in {@see \Radiergummi\OpenApi\Support\Generator\SpecPipeline} — always loaded, independent
- * of any plugin. Spec-only: it mutates the emitted document, never the host app.
+ * step in {@see SpecPipeline} — always loaded, independent of any plugin. Spec-only: it mutates the
+ * emitted document, never the host app.
  *
  * @internal
  */
 #[Scoped]
 final readonly class OverridesStage implements SpecStage
 {
-    /** @var list<string> lowercase HTTP verb properties on an {@see OA\PathItem} */
-    private const array HTTP_METHODS = [
-        'get',
-        'post',
-        'put',
-        'patch',
-        'delete',
-        'options',
-        'head',
-        'trace',
-    ];
-
     public function __construct(
         private OverrideMatcher $matcher,
     ) {}
 
     public function apply(OA\OpenApi $document, GenerationContext $context): void
     {
-        // The default install configures no overrides — skip the whole document walk.
-        if (!$this->matcher->hasOverrides() || !is_array($document->paths)) {
+        // The default installation configures no overrides — skip the whole document walk.
+        if (!is_array($document->paths) || !$this->matcher->hasOverrides()) {
             return;
         }
 
         foreach ($document->paths as $pathItem) {
-            if (!$pathItem instanceof OA\PathItem || $pathItem->path === Generator::UNDEFINED) {
+            if (!$pathItem instanceof OA\PathItem || Generator::isDefault($pathItem->path)) {
                 continue;
             }
 
-            foreach (self::HTTP_METHODS as $method) {
-                $operation = $pathItem->{$method} ?? null;
+            foreach (HttpMethod::cases() as $method) {
+                $operation = $pathItem->{$method->value} ?? null;
 
                 if (!$operation instanceof OA\Operation) {
                     continue;
@@ -85,7 +75,7 @@ final readonly class OverridesStage implements SpecStage
     {
         foreach ($fields as $field => $value) {
             if (str_starts_with($field, 'x-')) {
-                $x = $operation->x === Generator::UNDEFINED ? [] : $operation->x;
+                $x = Generator::isDefault($operation->x) ? [] : $operation->x;
                 $x[substr($field, 2)] = $value;
                 $operation->x = $x;
 

--- a/src/Support/Generator/Stages/PathsStage.php
+++ b/src/Support/Generator/Stages/PathsStage.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Attributes\Webhook as WebhookAttribute;
 use Radiergummi\OpenApi\Contracts\Generator\SpecStage;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Events\RouteSkipped;
 use Radiergummi\OpenApi\Extensions\OpenApiExtensions;
 use Radiergummi\OpenApi\Extensions\OperationContext;
@@ -34,7 +35,6 @@ use function preg_match;
 use function preg_replace;
 use function str_ends_with;
 use function strtolower;
-use function strtoupper;
 use function ucfirst;
 
 /**
@@ -130,18 +130,18 @@ final readonly class PathsStage implements SpecStage
     {
         $operation = $this->operationBuilder->build($action, [$this->deriveTag($action)]);
 
-        foreach ($action->route->methods() as $method) {
-            $upper = strtoupper($method);
+        foreach ($action->route->methods() as $routeMethod) {
+            $method = HttpMethod::fromString($routeMethod) ?? HttpMethod::Get;
 
-            if ($upper === 'HEAD') {
+            if ($method === HttpMethod::Head) {
                 continue;
             }
 
             $resolved = $operation->operationId !== null
                 ? $operation
-                : $operation->withOperationId($this->buildOperationId($action, $upper));
+                : $operation->withOperationId($this->buildOperationId($action, $method));
 
-            $operationSchema = $resolved->toOpenApi($method);
+            $operationSchema = $resolved->attachTo($pathItem, $method);
 
             if ($operationSchema === null) {
                 continue;
@@ -151,10 +151,8 @@ final readonly class PathsStage implements SpecStage
 
             OpenApiExtensions::applyOperationTransformers(
                 $operationSchema,
-                new OperationContext($action, $upper),
+                new OperationContext($action, $method),
             );
-
-            $pathItem->{strtolower($upper)} = $operationSchema;
         }
     }
 
@@ -200,24 +198,24 @@ final readonly class PathsStage implements SpecStage
      * 1. Named route → `{name}.{method}` for multi-method routes, plain `{name}` otherwise.
      * 2. Generated/unnamed (`generated::*` prefix or null) → `{method}_{sanitised_path}`.
      */
-    private function buildOperationId(ActionDescriptor $descriptor, string $method): string
+    private function buildOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
     {
         $name = $descriptor->route->getName();
         $methods = array_filter(
             $descriptor->route->methods(),
-            static fn(string $m): bool => strtoupper($m) !== 'HEAD',
+            static fn(string $method): bool => HttpMethod::fromString($method) !== HttpMethod::Head,
         );
 
         if ($name !== null && !Str::startsWith($name, 'generated::')) {
             return count($methods) > 1
-                ? $name . '.' . strtolower($method)
+                ? $name . '.' . strtolower($method->value)
                 : $name;
         }
 
         $sanitised = preg_replace('/[^a-zA-Z0-9]+/', '_', $descriptor->route->uri())
             ?? $descriptor->route->uri();
 
-        return strtolower($method) . '_' . $sanitised;
+        return strtolower($method->value) . '_' . $sanitised;
     }
 
     private function normalisePath(string $uri): string

--- a/src/Testing/ActionDescriptorFactory.php
+++ b/src/Testing/ActionDescriptorFactory.php
@@ -51,7 +51,7 @@ final class ActionDescriptorFactory
         $route = new Route(
             $httpMethods,
             $uri,
-            ['controller' => $controller . '@' . $method],
+            ['controller' => "{$controller}@{$method}"],
         );
 
         return new ActionDescriptor(

--- a/tests/Feature/ExtensionsTest.php
+++ b/tests/Feature/ExtensionsTest.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Tests\Feature;
 
 use Illuminate\Support\Facades\Route;
 use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Extensions\OpenApiExtensions;
 use Radiergummi\OpenApi\Extensions\OperationContext;
 use Radiergummi\OpenApi\Extensions\SchemaContext;
@@ -59,7 +60,7 @@ it('invokes a registered operation transformer for each assembled operation', fu
 
     OpenApiExtensions::transformOperation(
         static function (OA\Operation $op, OperationContext $context) use (&$seen): void {
-            $seen[] = $context->httpMethod . ' ' . $context->routeUri;
+            $seen[] = $context->httpMethod->forDisplay() . ' ' . $context->routeUri;
         },
     );
 
@@ -95,8 +96,8 @@ it('passes the correct HTTP method in the operation context', function (): void 
 
     app(OpenApiGenerator::class)->generate(app(SpecRegistry::class)->default(), 'testing');
 
-    expect($methods)->toContain('POST')
-        ->and($methods)->toContain('GET');
+    expect($methods)->toContain(HttpMethod::Post)
+        ->and($methods)->toContain(HttpMethod::Get);
 });
 
 it('passes the correct controller class and method name in the operation context', function (): void {

--- a/tests/Feature/Lint/Formatters/CliFormatterTest.php
+++ b/tests/Feature/Lint/Formatters/CliFormatterTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\FindingLocation;
 use Radiergummi\OpenApi\Lint\Formatters\CliFormatter;
@@ -20,7 +21,7 @@ it('renders findings grouped by file', function (): void {
                 new FindingLocation(
                     file: 'F.php',
                     line: 10,
-                    routeMethod: 'GET',
+                    routeMethod: HttpMethod::Get,
                     routeUri: '/foo',
                 ),
             ),
@@ -31,7 +32,7 @@ it('renders findings grouped by file', function (): void {
                 new FindingLocation(
                     file: 'F.php',
                     line: 5,
-                    routeMethod: 'POST',
+                    routeMethod: HttpMethod::Post,
                     routeUri: '/bar',
                 ),
             ),
@@ -42,7 +43,7 @@ it('renders findings grouped by file', function (): void {
                 new FindingLocation(
                     file: 'G.php',
                     line: 3,
-                    routeMethod: 'GET',
+                    routeMethod: HttpMethod::Get,
                     routeUri: '/baz',
                 ),
             ),
@@ -76,7 +77,7 @@ it('renders findings without a source location first', function (): void {
                 new FindingLocation(
                     file: 'Z.php',
                     line: 10,
-                    routeMethod: 'GET',
+                    routeMethod: HttpMethod::Get,
                     routeUri: '/foo',
                 ),
             ),
@@ -115,7 +116,7 @@ it('renders file groups as trees with connector characters', function (): void {
                 new FindingLocation(
                     file: 'F.php',
                     line: 10,
-                    routeMethod: 'GET',
+                    routeMethod: HttpMethod::Get,
                     routeUri: '/foo',
                 ),
             ),
@@ -126,7 +127,7 @@ it('renders file groups as trees with connector characters', function (): void {
                 new FindingLocation(
                     file: 'F.php',
                     line: 5,
-                    routeMethod: 'POST',
+                    routeMethod: HttpMethod::Post,
                     routeUri: '/bar',
                 ),
                 fixHint: 'Add a response schema',

--- a/tests/Support/OperationNodeFactory.php
+++ b/tests/Support/OperationNodeFactory.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Support;
 
+use LogicException;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\ApiNode;
 use Radiergummi\OpenApi\Lint\Tree\ComponentSchemaNode;
@@ -35,15 +37,14 @@ use Radiergummi\OpenApi\Routing\ActionDescriptor;
 final class OperationNodeFactory
 {
     /**
-     * An `OperationNode` carrying `$descriptor`. Document-shaped fields are empty
-     * by default — most lint rules resolve everything from the descriptor's
-     * reflection rather than from the produced operation. Optional overrides let
-     * tests vary the HTTP method, the document-side `pathUri` / `operationId`,
-     * or the `raw` swagger-php operation when a rule actually inspects them.
+     * An `OperationNode` carrying `$descriptor`. Document-shaped fields are empty by default — most
+     * lint rules resolve everything from the descriptor's reflection rather than from the produced
+     * operation. Optional overrides let tests vary the HTTP method, the document-side `pathUri` /
+     * `operationId`, or the `raw` swagger-php operation when a rule actually inspects them.
      */
     public static function forDescriptor(
         ActionDescriptor $descriptor,
-        string $method = 'GET',
+        HttpMethod $method = HttpMethod::Get,
         ?string $pathUri = null,
         ?string $operationId = null,
         ?OA\Operation $raw = null,
@@ -68,22 +69,22 @@ final class OperationNodeFactory
     }
 
     /**
-     * A minimal valid `LintContext`. The plugin lint rules never read it, but
-     * `checkOperation()` requires a non-null instance. `$payloadClasses` lets
-     * tests opt in to the Data-plugin payload-class detection path;
-     * `$declaredTags` lets api-level rules (e.g. `tag.*`) see a non-empty
-     * `ApiNode->declaredTags`.
+     * A minimal valid `LintContext`. The plugin lint rules never read it, but `checkOperation()`
+     * requires a non-null instance. `$payloadClasses` lets tests opt in to the Data-plugin
+     * payload-class detection path; `$declaredTags` lets api-level rules (e.g. `tag.*`) see a
+     * non-empty `ApiNode->declaredTags`.
      *
      * @param list<class-string>           $payloadClasses
      * @param list<string>                 $declaredTags
-     * @param array<string, OperationNode> $operationsByOperationId prepopulates the `TreeIndex` lookup
-     *                                                              used by link / security cross-ref rules
-     * @param list<OperationNode>          $operations              populates `ApiNode->operations`; used by
-     *                                                              api-level rules (e.g. `tag.undeclared-at-root`)
+     * @param array<string, OperationNode> $operationsByOperationId prepopulates the `TreeIndex` lookup used by link /
+     *                                                              security cross-ref rules
+     * @param list<OperationNode>          $operations              populates `ApiNode->operations`; used by api-level
+     *                                                              rules (e.g. `tag.undeclared-at-root`)
      * @param list<WebhookNode>            $webhooks                populates `ApiNode->webhooks`
-     * @param array<string, string>        $tagDescriptions         tag name → description; used by `tags.no-description`
-     * @param list<string>                 $registeredScopes        prepopulates `TreeIndex->registeredScopes`;
-     *                                                              used by security/scope rules
+     * @param array<string, string>        $tagDescriptions         tag name → description; used by
+     *                                                              `tags.no-description`
+     * @param list<string>                 $registeredScopes        prepopulates `TreeIndex->registeredScopes`; used by
+     *                                                              security/scope rules
      */
     public static function emptyContext(
         array $payloadClasses = [],
@@ -124,20 +125,23 @@ final class OperationNodeFactory
     }
 
     /**
-     * A standalone `OperationNode` with safe defaults. Children passed in
-     * `$responses`, `$requestBody`, `$parameters`, and `$queryParameters` are
-     * linked to the produced operation so that rules walking up the tree
-     * (e.g. for `pathUri` / `method`) work without ceremony.
+     * A standalone `OperationNode` with safe defaults.
+     *
+     * Children passed in `$responses`, `$requestBody`, `$parameters`, and `$queryParameters` are
+     * linked to the produced operation so that rules walking up the tree (e.g., for `pathUri` /
+     * `method`) work without ceremony.
      *
      * @param list<ParameterNode>                               $parameters
      * @param list<QueryParameterNode>                          $queryParameters
      * @param null|list<ResponseNode>                           $responses       defaults to a single 200 response
      * @param list<array{scheme: string, scopes: list<string>}> $security
      * @param list<string>                                      $tags
+     *
+     * @throws LogicException
      */
     public static function makeOperation(
         string $pathUri = '/test',
-        string $method = 'GET',
+        HttpMethod $method = HttpMethod::Get,
         ?string $operationId = 'test.index',
         ?string $summary = null,
         ?string $description = null,
@@ -190,13 +194,15 @@ final class OperationNodeFactory
     }
 
     /**
-     * A `ResponseNode` with safe defaults. Use within `makeOperation(responses:
-     * [...])` to attach parents automatically.
+     * A `ResponseNode` with safe defaults. Use within `makeOperation(responses: […])` to attach
+     * parents automatically.
      *
      * @param list<FieldNode>   $fields
      * @param list<ExampleNode> $examples
      * @param list<HeaderNode>  $headers
      * @param list<LinkNode>    $links
+     *
+     * @throws LogicException
      */
     public static function makeResponse(
         int|string $statusCode = 200,
@@ -231,8 +237,8 @@ final class OperationNodeFactory
     }
 
     /**
-     * A `HeaderNode` with safe defaults. Wrap inside `makeResponse(headers:
-     * [...])` to attach the parent automatically.
+     * A `HeaderNode` with safe defaults. Wrap inside `makeResponse(headers: […])` to attach the
+     * parent automatically.
      */
     public static function makeHeader(
         string $name = 'X-Header',
@@ -270,8 +276,8 @@ final class OperationNodeFactory
     }
 
     /**
-     * A `LinkNode` with safe defaults. Wrap inside `makeResponse(links: [...])`
-     * to attach the parent automatically.
+     * A `LinkNode` with safe defaults. Wrap inside `makeResponse(links: […])` to attach the
+     * parent automatically.
      *
      * @param array<string, string> $parameters
      */
@@ -322,7 +328,7 @@ final class OperationNodeFactory
 
     /**
      * A path/header-style `ParameterNode` with safe defaults. Wrap inside
-     * `makeOperation(parameters: [...])` to attach the parent automatically.
+     * `makeOperation(parameters: […])` to attach the parent automatically.
      *
      * @param list<ExampleNode> $examples
      */
@@ -347,8 +353,8 @@ final class OperationNodeFactory
     }
 
     /**
-     * A `QueryParameterNode` with safe defaults. Wrap inside
-     * `makeOperation(queryParameters: [...])` to attach the parent automatically.
+     * A `QueryParameterNode` with safe defaults. Wrap inside `makeOperation(queryParameters: […])`
+     * to attach the parent automatically.
      *
      * @param null|list<string> $enum
      * @param list<ExampleNode> $examples
@@ -380,8 +386,8 @@ final class OperationNodeFactory
     }
 
     /**
-     * A `FieldNode` with safe defaults. Standalone — caller is responsible for
-     * placing it inside a parent's `fields:` list if a rule walks up the tree.
+     * A `FieldNode` with safe defaults. Standalone — caller is responsible for placing it inside a
+     * parent's `fields:` list if a rule walks up the tree.
      *
      * @param null|list<mixed>  $enum
      * @param list<FieldNode>   $children
@@ -418,10 +424,12 @@ final class OperationNodeFactory
     }
 
     /**
-     * A `WebhookNode` with safe defaults. The wrapped operation is built via
-     * `makeOperation()` unless callers pass their own. `linkParent` is left to
-     * the caller — the api-level `WebhookNameDuplicate` finalize path doesn't
-     * need it, and most other rules only inspect the wrapped operation.
+     * A `WebhookNode` with safe defaults. The wrapped operation is built via `makeOperation()`
+     * unless callers pass their own. `linkParent` is left to the caller — the api-level
+     * `WebhookNameDuplicate` finalize path doesn't need it, and most other rules only inspect the
+     * wrapped operation.
+     *
+     * @throws LogicException
      */
     public static function makeWebhook(
         string $name = 'sample.event',
@@ -434,7 +442,7 @@ final class OperationNodeFactory
             description: $description,
             operation: $operation ?? self::makeOperation(
                 pathUri: $name,
-                method: 'POST',
+                method: HttpMethod::Post,
                 operationId: 'webhook.' . $name,
                 responses: [],
                 webhook: true,
@@ -462,17 +470,17 @@ final class OperationNodeFactory
         );
     }
 
-    private static function rawForMethod(string $method): OA\Operation
+    private static function rawForMethod(HttpMethod $method): OA\Operation
     {
         $context = ['_context' => new Context()];
 
-        return match (strtoupper($method)) {
-            'POST' => new OA\Post($context),
-            'PUT' => new OA\Put($context),
-            'DELETE' => new OA\Delete($context),
-            'PATCH' => new OA\Patch($context),
-            'HEAD' => new OA\Head($context),
-            'OPTIONS' => new OA\Options($context),
+        return match ($method) {
+            HttpMethod::Post => new OA\Post($context),
+            HttpMethod::Put => new OA\Put($context),
+            HttpMethod::Delete => new OA\Delete($context),
+            HttpMethod::Patch => new OA\Patch($context),
+            HttpMethod::Head => new OA\Head($context),
+            HttpMethod::Options => new OA\Options($context),
             default => new OA\Get($context),
         };
     }

--- a/tests/Unit/Lint/FindingTest.php
+++ b/tests/Unit/Lint/FindingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Lint\FindingLocation;
 
@@ -12,7 +13,7 @@ it('constructs a Finding with required fields and exposes them readonly', functi
         file: 'app/Http/Controllers/Foo.php',
         line: 42,
         routeName: 'foo.show',
-        routeMethod: 'GET',
+        routeMethod: HttpMethod::Get,
         routeUri: 'foo/{id}',
     );
 
@@ -50,7 +51,7 @@ it('withLevel returns a copy with the new level and all other fields preserved',
         file: 'app/Http/Controllers/Foo.php',
         line: 10,
         routeName: 'foo.index',
-        routeMethod: 'GET',
+        routeMethod: HttpMethod::Get,
         routeUri: 'foo',
     );
 

--- a/tests/Unit/Lint/Rules/FieldConflictingTypeTest.php
+++ b/tests/Unit/Lint/Rules/FieldConflictingTypeTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\FieldConflictingType;
 use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
 use Radiergummi\OpenApi\Tests\Fixtures\Lint\ActionWithConflictingTypeData;
@@ -21,19 +22,29 @@ function makeDirectScannerForConflictingType(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
 
-    expect($rule->id())->toBe('field.conflicting-type')
+    expect($rule->id())
+        ->toBe('field.conflicting-type')
         ->and($rule->level())->toBe(1);
 });
 
 it('emits a finding when RequestField type contradicts the PHP type', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ConflictingTypeFixtureController::class, 'withConflict', '/fixture');
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ConflictingTypeFixtureController::class,
+        'withConflict',
+        '/fixture',
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.conflicting-type')
         ->and($findings[0]->level)->toBe(1)
         ->and($findings[0]->message)->toContain('$conflicting')
@@ -43,7 +54,7 @@ it('emits a finding when RequestField type contradicts the PHP type', function (
 
 it('emits no findings when there is no descriptor on the operation', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
-    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test', method: 'POST');
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test', method: HttpMethod::Post);
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -53,8 +64,16 @@ it('emits no findings when there is no descriptor on the operation', function ()
 
 it('emits no findings when the method has no Data class parameters', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ConflictingTypeFixtureController::class, 'withoutData', '/fixture');
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ConflictingTypeFixtureController::class,
+        'withoutData',
+        '/fixture',
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -64,22 +83,39 @@ it('emits no findings when the method has no Data class parameters', function ()
 
 it('does not flag matching types or properties without explicit type', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ConflictingTypeFixtureController::class, 'withConflict', '/fixture');
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ConflictingTypeFixtureController::class,
+        'withConflict',
+        '/fixture',
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
     // Only the $conflicting property should fire; $matching (string→string)
     // and $noExplicitType (no type param) should not.
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('$conflicting');
 });
 
 it('provides a fix hint with the expected type', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ConflictingTypeFixtureController::class, 'withConflict', '/fixture');
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ConflictingTypeFixtureController::class,
+        'withConflict',
+        '/fixture',
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -88,8 +124,17 @@ it('provides a fix hint with the expected type', function (): void {
 });
 
 it('emits a finding for a Data class injected through a Domain Action', function (): void {
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ActionWithConflictingTypeDataController::class, 'create', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ActionWithConflictingTypeDataController::class,
+        'create',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     // Scanner descends into ActionWithConflictingTypeData's constructor to find ConflictingTypeFixtureData.
@@ -98,7 +143,8 @@ it('emits a finding for a Data class injected through a Domain Action', function
         new FieldConflictingType($scanner)->checkOperation($operation, $context),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.conflicting-type')
         ->and($findings[0]->message)->toContain('$conflicting');
 });

--- a/tests/Unit/Lint/Rules/FieldEnumMismatchTest.php
+++ b/tests/Unit/Lint/Rules/FieldEnumMismatchTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\FieldEnumMismatch;
 use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
 use Radiergummi\OpenApi\Tests\Fixtures\Lint\ActionWithEnumMismatchData;
@@ -21,19 +22,30 @@ function makeDirectScannerForEnumMismatch(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
 
-    expect($rule->id())->toBe('field.enum-mismatch')
+    expect($rule->id())
+        ->toBe('field.enum-mismatch')
         ->and($rule->level())->toBe(0);
 });
 
 it('emits a finding when RequestField enum values do not match BackedEnum cases', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(EnumMismatchFixtureController::class, 'withMismatch', '/fixture', ['PUT']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'PUT', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        EnumMismatchFixtureController::class,
+        'withMismatch',
+        '/fixture',
+        ['PUT'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Put,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.enum-mismatch')
         ->and($findings[0]->level)->toBe(0)
         ->and($findings[0]->message)->toContain('$mismatched')
@@ -43,7 +55,7 @@ it('emits a finding when RequestField enum values do not match BackedEnum cases'
 
 it('emits no findings when there is no descriptor on the operation', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
-    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test', method: 'PUT');
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test', method: HttpMethod::Put);
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -53,8 +65,17 @@ it('emits no findings when there is no descriptor on the operation', function ()
 
 it('emits no findings when the method has no Data class parameters', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(EnumMismatchFixtureController::class, 'withoutData', '/fixture', ['PUT']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'PUT', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        EnumMismatchFixtureController::class,
+        'withoutData',
+        '/fixture',
+        ['PUT'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Put,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -64,22 +85,41 @@ it('emits no findings when the method has no Data class parameters', function ()
 
 it('does not flag matching enums, properties without enum, or non-BackedEnum types', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(EnumMismatchFixtureController::class, 'withMismatch', '/fixture', ['PUT']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'PUT', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        EnumMismatchFixtureController::class,
+        'withMismatch',
+        '/fixture',
+        ['PUT'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Put,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
     // Only $mismatched should fire; $matching (exact cases), $noEnum (null),
     // and $nonEnumType (string, not BackedEnum) should not.
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('$mismatched');
 });
 
 it('reports missing enum case values in the finding message', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(EnumMismatchFixtureController::class, 'withMismatch', '/fixture', ['PUT']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'PUT', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        EnumMismatchFixtureController::class,
+        'withMismatch',
+        '/fixture',
+        ['PUT'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Put,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -89,8 +129,17 @@ it('reports missing enum case values in the finding message', function (): void 
 });
 
 it('emits a finding for a Data class injected through a Domain Action', function (): void {
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ActionWithEnumMismatchDataController::class, 'create', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'PUT', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ActionWithEnumMismatchDataController::class,
+        'create',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Put,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     // Scanner descends into ActionWithEnumMismatchData's constructor to find EnumMismatchFixtureData.
@@ -99,7 +148,8 @@ it('emits a finding for a Data class injected through a Domain Action', function
         new FieldEnumMismatch($scanner)->checkOperation($operation, $context),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.enum-mismatch')
         ->and($findings[0]->message)->toContain('$mismatched');
 });

--- a/tests/Unit/Lint/Rules/FieldInvalidFormatTest.php
+++ b/tests/Unit/Lint/Rules/FieldInvalidFormatTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\FieldInvalidFormat;
 use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
 use Radiergummi\OpenApi\Tests\Fixtures\Lint\ActionWithInvalidFormatData;
@@ -21,19 +22,26 @@ function makeDirectScannerForInvalidFormat(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
 
-    expect($rule->id())->toBe('field.invalid-format')
+    expect($rule->id())
+        ->toBe('field.invalid-format')
         ->and($rule->level())->toBe(3);
 });
 
 it('emits a finding when RequestField declares an unrecognized format', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(InvalidFormatFixtureController::class, 'withInvalidFormat', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        InvalidFormatFixtureController::class,
+        'withInvalidFormat',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor($descriptor, method: HttpMethod::Post, pathUri: '/api/v0/test');
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.invalid-format')
         ->and($findings[0]->level)->toBe(3)
         ->and($findings[0]->message)->toContain('$invalidFormat')
@@ -42,7 +50,7 @@ it('emits a finding when RequestField declares an unrecognized format', function
 
 it('emits no findings when there is no descriptor on the operation', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
-    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test', method: 'POST');
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test', method: HttpMethod::Post);
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -52,8 +60,13 @@ it('emits no findings when there is no descriptor on the operation', function ()
 
 it('emits no findings when the method has no Data class parameters', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(InvalidFormatFixtureController::class, 'withoutData', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        InvalidFormatFixtureController::class,
+        'withoutData',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor($descriptor, method: HttpMethod::Post, pathUri: '/api/v0/test');
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
@@ -63,32 +76,57 @@ it('emits no findings when the method has no Data class parameters', function ()
 
 it('does not flag valid formats or properties without a format', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(InvalidFormatFixtureController::class, 'withInvalidFormat', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        InvalidFormatFixtureController::class,
+        'withInvalidFormat',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor($descriptor, method: HttpMethod::Post, pathUri: '/api/v0/test');
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
     // Only $invalidFormat should fire; $validFormat (date-time) and $noFormat (null) should not.
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('$invalidFormat');
 });
 
 it('provides a fix hint listing valid formats', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
-    $descriptor = ActionDescriptorFactory::forControllerMethod(InvalidFormatFixtureController::class, 'withInvalidFormat', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        InvalidFormatFixtureController::class,
+        'withInvalidFormat',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     $findings = iterator_to_array($rule->checkOperation($operation, $context));
 
-    expect($findings[0]->fixHint)->toContain('date-time')
+    expect($findings[0]->fixHint)
+        ->toContain('date-time')
         ->and($findings[0]->fixHint)->toContain('uuid');
 });
 
 it('emits a finding for a Data class injected through a Domain Action', function (): void {
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ActionWithInvalidFormatDataController::class, 'create', '/fixture', ['POST']);
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ActionWithInvalidFormatDataController::class,
+        'create',
+        '/fixture',
+        ['POST'],
+    );
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
     $context = OperationNodeFactory::emptyContext(payloadClasses: [Data::class]);
 
     // Scanner descends into ActionWithInvalidFormatData's constructor to find InvalidFormatFixtureData.
@@ -97,7 +135,8 @@ it('emits a finding for a Data class injected through a Domain Action', function
         new FieldInvalidFormat($scanner)->checkOperation($operation, $context),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.invalid-format')
         ->and($findings[0]->message)->toContain('$invalidFormat');
 });

--- a/tests/Unit/Lint/Rules/LinkBothOperationIdAndRefTest.php
+++ b/tests/Unit/Lint/Rules/LinkBothOperationIdAndRefTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\LinkBothOperationIdAndRef;
 use Radiergummi\OpenApi\Lint\Tree\LinkNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
@@ -15,7 +16,7 @@ function makeLinkBothFieldsNode(?string $operationId, ?string $operationRef): Li
         operationRef: $operationRef,
     );
     OperationNodeFactory::makeOperation(
-        method: 'POST',
+        method: HttpMethod::Post,
         responses: [OperationNodeFactory::makeResponse(statusCode: 201, description: null, links: [$link])],
     );
 

--- a/tests/Unit/Lint/Rules/LinkInvalidOperationTest.php
+++ b/tests/Unit/Lint/Rules/LinkInvalidOperationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\LinkInvalidOperation;
 use Radiergummi\OpenApi\Lint\Tree\LinkNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
@@ -12,7 +13,7 @@ function makeLinkInvalidOperationNode(?string $operationId): LinkNode
 {
     $link = OperationNodeFactory::makeLink(operationId: $operationId);
     OperationNodeFactory::makeOperation(
-        method: 'POST',
+        method: HttpMethod::Post,
         responses: [OperationNodeFactory::makeResponse(statusCode: 201, description: null, links: [$link])],
     );
 

--- a/tests/Unit/Lint/Rules/LinkInvalidParameterTest.php
+++ b/tests/Unit/Lint/Rules/LinkInvalidParameterTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Rules\LinkInvalidParameter;
 use Radiergummi\OpenApi\Lint\Tree\LinkNode;
@@ -20,7 +21,7 @@ function makeLinkInvalidParamNode(?string $operationId, array $parameters): Link
         parameters: $parameters,
     );
     OperationNodeFactory::makeOperation(
-        method: 'POST',
+        method: HttpMethod::Post,
         responses: [OperationNodeFactory::makeResponse(statusCode: 201, description: null, links: [$link])],
     );
 
@@ -44,7 +45,11 @@ function makeLinkInvalidParamContext(
             $pathParams,
         ),
         queryParameters: array_map(
-            static fn(string $name) => OperationNodeFactory::makeQueryParameter(name: $name, type: null, hasSchema: false),
+            static fn(string $name) => OperationNodeFactory::makeQueryParameter(
+                name: $name,
+                type: null,
+                hasSchema: false,
+            ),
             $queryParams,
         ),
     );
@@ -151,6 +156,6 @@ it('skips links without a resolvable target', function (?string $operationId, st
 
     expect($findings)->toBe([]);
 })->with([
-    'no operationId on link'    => [null, 'foo.show'],
+    'no operationId on link' => [null, 'foo.show'],
     'unknown target operationId' => ['nonexistent', 'different.operation'],
 ]);

--- a/tests/Unit/Lint/Rules/LinkNeitherOperationIdNorRefTest.php
+++ b/tests/Unit/Lint/Rules/LinkNeitherOperationIdNorRefTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\LinkNeitherOperationIdNorRef;
 use Radiergummi\OpenApi\Lint\Tree\LinkNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
@@ -15,7 +16,7 @@ function makeLinkNeitherFieldNode(?string $operationId, ?string $operationRef): 
         operationRef: $operationRef,
     );
     OperationNodeFactory::makeOperation(
-        method: 'POST',
+        method: HttpMethod::Post,
         responses: [OperationNodeFactory::makeResponse(statusCode: 201, description: null, links: [$link])],
     );
 

--- a/tests/Unit/Lint/Rules/LinkParameterRequiredMissingTest.php
+++ b/tests/Unit/Lint/Rules/LinkParameterRequiredMissingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Rules\LinkParameterRequiredMissing;
 use Radiergummi\OpenApi\Lint\Tree\LinkNode;
@@ -22,7 +23,7 @@ function makeLinkRequiredMissingNode(?string $operationId, array $parameters): L
         parameters: $parameters,
     );
     OperationNodeFactory::makeOperation(
-        method: 'POST',
+        method: HttpMethod::Post,
         responses: [OperationNodeFactory::makeResponse(statusCode: 201, description: null, links: [$link])],
     );
 

--- a/tests/Unit/Lint/Rules/OperationIdDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdDuplicateTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\OperationIdDuplicate;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
@@ -10,7 +11,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new OperationIdDuplicate();
 
-    expect($rule->id())->toBe('operation.id-duplicate')
+    expect($rule->id())
+        ->toBe('operation.id-duplicate')
         ->and($rule->level())->toBe(0);
 });
 
@@ -43,7 +45,8 @@ it('emits findings for duplicate operationIds', function (): void {
 
     $findings = iterator_to_array($rule->finalize($context));
 
-    expect($findings)->toHaveCount(2)
+    expect($findings)
+        ->toHaveCount(2)
         ->and($findings[0]->ruleId)->toBe('operation.id-duplicate')
         ->and($findings[0]->level)->toBe(0)
         ->and($findings[0]->message)->toContain('users.index')
@@ -77,16 +80,21 @@ it('reports the correct path and method for each duplicate occurrence', function
     $context = OperationNodeFactory::emptyContext();
 
     $op1 = OperationNodeFactory::makeOperation(pathUri: '/alpha', operationId: 'duplicate.id');
-    $op2 = OperationNodeFactory::makeOperation(pathUri: '/beta', method: 'POST', operationId: 'duplicate.id');
+    $op2 = OperationNodeFactory::makeOperation(
+        pathUri: '/beta',
+        method: HttpMethod::Post,
+        operationId: 'duplicate.id',
+    );
 
     iterator_to_array($rule->checkOperation($op1, $context));
     iterator_to_array($rule->checkOperation($op2, $context));
 
     $findings = iterator_to_array($rule->finalize($context));
 
-    expect($findings)->toHaveCount(2)
+    expect($findings)
+        ->toHaveCount(2)
         ->and($findings[0]->location->routeUri)->toBe('/alpha')
-        ->and($findings[0]->location->routeMethod)->toBe('GET')
+        ->and($findings[0]->location->routeMethod)->toBe(HttpMethod::Get)
         ->and($findings[1]->location->routeUri)->toBe('/beta')
-        ->and($findings[1]->location->routeMethod)->toBe('POST');
+        ->and($findings[1]->location->routeMethod)->toBe(HttpMethod::Post);
 });

--- a/tests/Unit/Lint/Rules/OperationIdMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdMissingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\OperationIdMissing;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
@@ -10,17 +11,14 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new OperationIdMissing();
 
-    expect($rule->id())->toBe('operation.id-missing')
+    expect($rule->id())
+        ->toBe('operation.id-missing')
         ->and($rule->level())->toBe(1);
 });
 
 it('emits no finding when the operation has an operationId', function (): void {
     $rule = new OperationIdMissing();
-    $operation = OperationNodeFactory::makeOperation(
-        pathUri: '/users',
-        method: 'GET',
-        operationId: 'users.index',
-    );
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/users', operationId: 'users.index');
 
     $findings = iterator_to_array(
         $rule->checkOperation($operation, OperationNodeFactory::emptyContext()),
@@ -31,17 +29,14 @@ it('emits no finding when the operation has an operationId', function (): void {
 
 it('emits a finding when an operation has no operationId', function (): void {
     $rule = new OperationIdMissing();
-    $operation = OperationNodeFactory::makeOperation(
-        pathUri: '/users',
-        method: 'GET',
-        operationId: null,
-    );
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/users', operationId: null);
 
     $findings = iterator_to_array(
         $rule->checkOperation($operation, OperationNodeFactory::emptyContext()),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('operation.id-missing')
         ->and($findings[0]->level)->toBe(1)
         ->and($findings[0]->message)->toContain('GET')
@@ -53,15 +48,16 @@ it('emits a finding per operation missing an operationId', function (): void {
     $rule = new OperationIdMissing();
     $context = OperationNodeFactory::emptyContext();
 
-    $op1 = OperationNodeFactory::makeOperation(pathUri: '/users', method: 'GET', operationId: null);
-    $op2 = OperationNodeFactory::makeOperation(pathUri: '/posts', method: 'POST', operationId: null);
+    $op1 = OperationNodeFactory::makeOperation(pathUri: '/users', operationId: null);
+    $op2 = OperationNodeFactory::makeOperation(pathUri: '/posts', method: HttpMethod::Post, operationId: null);
 
     $findings = [
         ...iterator_to_array($rule->checkOperation($op1, $context)),
         ...iterator_to_array($rule->checkOperation($op2, $context)),
     ];
 
-    expect($findings)->toHaveCount(2)
+    expect($findings)
+        ->toHaveCount(2)
         ->and($findings[0]->message)->toContain('GET')
         ->and($findings[0]->message)->toContain('/users')
         ->and($findings[1]->message)->toContain('POST')
@@ -72,14 +68,15 @@ it('does not flag operations that have an operationId alongside missing ones', f
     $rule = new OperationIdMissing();
     $context = OperationNodeFactory::emptyContext();
 
-    $opWithId = OperationNodeFactory::makeOperation(pathUri: '/users', method: 'GET', operationId: 'users.index');
-    $opWithoutId = OperationNodeFactory::makeOperation(pathUri: '/users', method: 'POST', operationId: null);
+    $opWithId = OperationNodeFactory::makeOperation(pathUri: '/users', operationId: 'users.index');
+    $opWithoutId = OperationNodeFactory::makeOperation(pathUri: '/users', method: HttpMethod::Post, operationId: null);
 
     $findings = [
         ...iterator_to_array($rule->checkOperation($opWithId, $context)),
         ...iterator_to_array($rule->checkOperation($opWithoutId, $context)),
     ];
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('POST');
 });

--- a/tests/Unit/Lint/Rules/RequestBodyOnGetOrDeleteTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyOnGetOrDeleteTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\RequestBodyOnGetOrDelete;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
@@ -16,7 +17,7 @@ it('has the correct rule id and level', function (): void {
 
 it(
     'emits a finding when a body-less verb has a request body',
-    function (string $method): void {
+    function (HttpMethod $method): void {
         $rule = new RequestBodyOnGetOrDelete();
         $operation = OperationNodeFactory::makeOperation(
             method: $method,
@@ -31,13 +32,13 @@ it(
         expect($findings)->toHaveCount(1)
             ->and($findings[0]->ruleId)->toBe('request-body.on-get-or-delete')
             ->and($findings[0]->level)->toBe(1)
-            ->and($findings[0]->message)->toContain($method);
+            ->and($findings[0]->message)->toContain($method->forDisplay());
     },
-)->with(['GET', 'DELETE']);
+)->with([HttpMethod::Get, HttpMethod::Delete]);
 
 it(
     'emits no findings when a body-carrying verb has a request body',
-    function (string $method): void {
+    function (HttpMethod $method): void {
         $rule = new RequestBodyOnGetOrDelete();
         $operation = OperationNodeFactory::makeOperation(
             method: $method,
@@ -51,11 +52,11 @@ it(
 
         expect($findings)->toBe([]);
     },
-)->with(['POST', 'PUT', 'PATCH']);
+)->with([HttpMethod::Post, HttpMethod::Put, HttpMethod::Patch]);
 
 it('emits no findings when GET has no request body', function (): void {
     $rule = new RequestBodyOnGetOrDelete();
-    $operation = OperationNodeFactory::makeOperation(method: 'GET', responses: []);
+    $operation = OperationNodeFactory::makeOperation(responses: []);
 
     $findings = iterator_to_array(
         $rule->checkOperation($operation, OperationNodeFactory::emptyContext()),

--- a/tests/Unit/Lint/Rules/ResponseNoErrorTest.php
+++ b/tests/Unit/Lint/Rules/ResponseNoErrorTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\ResponseNoError;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
@@ -17,7 +18,7 @@ it('reports its id and level', function (): void {
 
 it(
     'emits no finding when an operation has an error response',
-    function (string $method, array $statusCodes): void {
+    function (HttpMethod $method, array $statusCodes): void {
         $operation = makeResponseNoErrorOperation('/users', $method, $statusCodes);
 
         $findings = iterator_to_array(
@@ -27,13 +28,13 @@ it(
         expect($findings)->toBe([]);
     },
 )->with([
-    '4xx alongside success' => ['GET', [200, 404]],
-    '5xx alongside success' => ['GET', [200, 500]],
-    'mixed success + 4xx + 5xx' => ['POST', [201, 400, 422, 500]],
+    '4xx alongside success' => [HttpMethod::Get, [200, 404]],
+    '5xx alongside success' => [HttpMethod::Get, [200, 500]],
+    'mixed success + 4xx + 5xx' => [HttpMethod::Post, [201, 400, 422, 500]],
 ]);
 
 it('emits a finding when an operation has only success responses', function (): void {
-    $operation = makeResponseNoErrorOperation('/users', 'GET', [200]);
+    $operation = makeResponseNoErrorOperation('/users', HttpMethod::Get, [200]);
 
     $findings = iterator_to_array(
         new ResponseNoError()->checkOperation($operation, OperationNodeFactory::emptyContext()),
@@ -48,7 +49,7 @@ it('emits a finding when an operation has only success responses', function (): 
 });
 
 it('skips operations with no responses (caught by response.empty)', function (): void {
-    $operation = makeResponseNoErrorOperation('/empty', 'GET', []);
+    $operation = makeResponseNoErrorOperation('/empty', HttpMethod::Get, []);
 
     $findings = iterator_to_array(
         new ResponseNoError()->checkOperation($operation, OperationNodeFactory::emptyContext()),
@@ -59,8 +60,8 @@ it('skips operations with no responses (caught by response.empty)', function ():
 
 it('emits a finding per operation missing an error response', function (): void {
     $context = OperationNodeFactory::emptyContext();
-    $op1 = makeResponseNoErrorOperation('/things', 'GET', [200]);
-    $op2 = makeResponseNoErrorOperation('/stuff', 'POST', [201]);
+    $op1 = makeResponseNoErrorOperation('/things', HttpMethod::Get, [200]);
+    $op2 = makeResponseNoErrorOperation('/stuff', HttpMethod::Post, [201]);
 
     $findings = [
         ...iterator_to_array(new ResponseNoError()->checkOperation($op1, $context)),
@@ -74,8 +75,10 @@ it('emits a finding per operation missing an error response', function (): void 
 
 /**
  * @param list<int> $statusCodes
+ *
+ * @throws LogicException
  */
-function makeResponseNoErrorOperation(string $path, string $method, array $statusCodes): OperationNode
+function makeResponseNoErrorOperation(string $path, HttpMethod $method, array $statusCodes): OperationNode
 {
     return OperationNodeFactory::makeOperation(
         pathUri: $path,

--- a/tests/Unit/Lint/Rules/ResponseNoSuccessTest.php
+++ b/tests/Unit/Lint/Rules/ResponseNoSuccessTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\ResponseNoSuccess;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
@@ -17,7 +18,7 @@ it('reports its id and level', function (): void {
 
 it(
     'emits no finding when an operation has a success response',
-    function (string $method, array $statusCodes): void {
+    function (HttpMethod $method, array $statusCodes): void {
         $operation = makeResponseNoSuccessOperation('/users', $method, $statusCodes);
 
         $findings = iterator_to_array(
@@ -27,14 +28,14 @@ it(
         expect($findings)->toBe([]);
     },
 )->with([
-    '200' => ['GET', [200]],
-    '201' => ['POST', [201]],
-    '204' => ['DELETE', [204]],
-    'success + errors' => ['GET', [200, 401, 500]],
+    '200' => [HttpMethod::Get, [200]],
+    '201' => [HttpMethod::Post, [201]],
+    '204' => [HttpMethod::Delete, [204]],
+    'success + errors' => [HttpMethod::Get, [200, 401, 500]],
 ]);
 
 it('emits a finding when an operation has only error responses', function (): void {
-    $operation = makeResponseNoSuccessOperation('/users', 'GET', [401, 500]);
+    $operation = makeResponseNoSuccessOperation('/users', HttpMethod::Get, [401, 500]);
 
     $findings = iterator_to_array(
         new ResponseNoSuccess()->checkOperation($operation, OperationNodeFactory::emptyContext()),
@@ -49,7 +50,7 @@ it('emits a finding when an operation has only error responses', function (): vo
 });
 
 it('skips operations with no responses (caught by response.empty)', function (): void {
-    $operation = makeResponseNoSuccessOperation('/empty', 'GET', []);
+    $operation = makeResponseNoSuccessOperation('/empty', HttpMethod::Get, []);
 
     $findings = iterator_to_array(
         new ResponseNoSuccess()->checkOperation($operation, OperationNodeFactory::emptyContext()),
@@ -74,8 +75,8 @@ it('emits no finding when the only response is a default response', function ():
 
 it('emits a finding per operation missing a success response', function (): void {
     $context = OperationNodeFactory::emptyContext();
-    $op1 = makeResponseNoSuccessOperation('/things', 'GET', [404]);
-    $op2 = makeResponseNoSuccessOperation('/stuff', 'POST', [422]);
+    $op1 = makeResponseNoSuccessOperation('/things', HttpMethod::Get, [404]);
+    $op2 = makeResponseNoSuccessOperation('/stuff', HttpMethod::Post, [422]);
 
     $findings = [
         ...iterator_to_array(new ResponseNoSuccess()->checkOperation($op1, $context)),
@@ -89,8 +90,10 @@ it('emits a finding per operation missing a success response', function (): void
 
 /**
  * @param list<int> $statusCodes
+ *
+ * @throws LogicException
  */
-function makeResponseNoSuccessOperation(string $path, string $method, array $statusCodes): OperationNode
+function makeResponseNoSuccessOperation(string $path, HttpMethod $method, array $statusCodes): OperationNode
 {
     return OperationNodeFactory::makeOperation(
         pathUri: $path,

--- a/tests/Unit/Lint/Rules/ResponseStatusUnconventionalTest.php
+++ b/tests/Unit/Lint/Rules/ResponseStatusUnconventionalTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\ResponseStatusUnconventional;
 use Radiergummi\OpenApi\Lint\Tree\ResponseNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
@@ -17,7 +18,7 @@ it('reports its id and level', function (): void {
 
 it(
     'emits no finding when the operation declares a conventional status',
-    function (string $method, array $statusCodes, string $targetStatus): void {
+    function (HttpMethod $method, array $statusCodes, string $targetStatus): void {
         $response = makeResponseForStatusTest('/users', $method, $statusCodes, $targetStatus);
 
         $findings = iterator_to_array(
@@ -27,16 +28,16 @@ it(
         expect($findings)->toBe([]);
     },
 )->with([
-    'POST 201' => ['POST', ['201'], '201'],
-    'DELETE 204' => ['DELETE', ['204'], '204'],
-    'GET 200' => ['GET', ['200'], '200'],
-    'POST with both 200 and 201' => ['POST', ['200', '201'], '200'],
-    'DELETE with both 200 and 204' => ['DELETE', ['200', '204'], '200'],
+    'POST 201' => [HttpMethod::Post, ['201'], '201'],
+    'DELETE 204' => [HttpMethod::Delete, ['204'], '204'],
+    'GET 200' => [HttpMethod::Get, ['200'], '200'],
+    'POST with both 200 and 201' => [HttpMethod::Post, ['200', '201'], '200'],
+    'DELETE with both 200 and 204' => [HttpMethod::Delete, ['200', '204'], '200'],
 ]);
 
 it(
     'emits no finding when a 200 response carries a body schema for verbs that usually return 201 / 204',
-    function (string $method): void {
+    function (HttpMethod $method): void {
         $response = OperationNodeFactory::makeResponse(statusCode: '200', description: null, schemaRef: 'SomeResource');
         OperationNodeFactory::makeOperation(pathUri: '/users/1', method: $method, responses: [$response]);
 
@@ -47,13 +48,13 @@ it(
         expect($findings)->toBe([]);
     },
 )->with([
-    'DELETE returning the deleted resource' => ['DELETE'],
-    'POST returning the created resource' => ['POST'],
+    'DELETE returning the deleted resource' => [HttpMethod::Delete],
+    'POST returning the created resource' => [HttpMethod::Post],
 ]);
 
 it(
     'emits a finding when an operation only declares an unconventional 2xx status',
-    function (string $method, array $statusCodes, string $expectedConventional): void {
+    function (HttpMethod $method, array $statusCodes, string $expectedConventional): void {
         $response = makeResponseForStatusTest('/users', $method, $statusCodes, '200');
 
         $findings = iterator_to_array(
@@ -63,12 +64,12 @@ it(
         expect($findings)->toHaveCount(1)
             ->and($findings[0]->ruleId)->toBe('response.status-unconventional')
             ->and($findings[0]->level)->toBe(3)
-            ->and($findings[0]->message)->toContain($method)
+            ->and($findings[0]->message)->toContain($method->forDisplay())
             ->and($findings[0]->message)->toContain($expectedConventional);
     },
 )->with([
-    'POST 200 (expects 201)' => ['POST', ['200', '422'], '201'],
-    'DELETE 200 (expects 204)' => ['DELETE', ['200'], '204'],
+    'POST 200 (expects 201)' => [HttpMethod::Post, ['200', '422'], '201'],
+    'DELETE 200 (expects 204)' => [HttpMethod::Delete, ['200'], '204'],
 ]);
 
 /**
@@ -76,10 +77,12 @@ it(
  * matching `$targetStatus` (falling back to the first response).
  *
  * @param list<string> $statusCodes
+ *
+ * @throws LogicException
  */
 function makeResponseForStatusTest(
     string $pathUri,
-    string $method,
+    HttpMethod $method,
     array $statusCodes,
     string $targetStatus = '200',
 ): ResponseNode {

--- a/tests/Unit/Lint/Rules/ResponseSuccessEmptyBodyTest.php
+++ b/tests/Unit/Lint/Rules/ResponseSuccessEmptyBodyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\ResponseSuccessEmptyBody;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
@@ -16,7 +17,7 @@ it('reports its id and level', function (): void {
 
 it('emits a finding for a 200 response with no body schema', function (): void {
     $response = OperationNodeFactory::makeResponse(statusCode: 200, fields: [], schemaRef: null);
-    OperationNodeFactory::makeOperation(pathUri: '/users', method: 'GET', responses: [$response]);
+    OperationNodeFactory::makeOperation(pathUri: '/users', method: HttpMethod::Get, responses: [$response]);
 
     $findings = iterator_to_array(
         new ResponseSuccessEmptyBody()->checkResponse($response, OperationNodeFactory::emptyContext()),
@@ -31,7 +32,7 @@ it('emits a finding for a 200 response with no body schema', function (): void {
 it('does not flag a 200 response that has an inline schema', function (): void {
     $field = OperationNodeFactory::makeField(name: 'id', type: 'integer');
     $response = OperationNodeFactory::makeResponse(statusCode: 200, fields: [$field]);
-    OperationNodeFactory::makeOperation(pathUri: '/users/1', method: 'GET', responses: [$response]);
+    OperationNodeFactory::makeOperation(pathUri: '/users/1', method: HttpMethod::Get, responses: [$response]);
 
     $findings = iterator_to_array(
         new ResponseSuccessEmptyBody()->checkResponse($response, OperationNodeFactory::emptyContext()),
@@ -42,7 +43,7 @@ it('does not flag a 200 response that has an inline schema', function (): void {
 
 it('does not flag a 200 response that references a component schema', function (): void {
     $response = OperationNodeFactory::makeResponse(statusCode: 200, schemaRef: 'User');
-    OperationNodeFactory::makeOperation(pathUri: '/users/1', method: 'GET', responses: [$response]);
+    OperationNodeFactory::makeOperation(pathUri: '/users/1', method: HttpMethod::Get, responses: [$response]);
 
     $findings = iterator_to_array(
         new ResponseSuccessEmptyBody()->checkResponse($response, OperationNodeFactory::emptyContext()),
@@ -53,7 +54,7 @@ it('does not flag a 200 response that references a component schema', function (
 
 it('skips bodiless success codes', function (int $statusCode): void {
     $response = OperationNodeFactory::makeResponse(statusCode: $statusCode);
-    OperationNodeFactory::makeOperation(pathUri: '/things', method: 'DELETE', responses: [$response]);
+    OperationNodeFactory::makeOperation(pathUri: '/things', method: HttpMethod::Delete, responses: [$response]);
 
     $findings = iterator_to_array(
         new ResponseSuccessEmptyBody()->checkResponse($response, OperationNodeFactory::emptyContext()),
@@ -68,7 +69,7 @@ it('skips bodiless success codes', function (int $statusCode): void {
 
 it('skips non-2xx responses', function (int $statusCode): void {
     $response = OperationNodeFactory::makeResponse(statusCode: $statusCode);
-    OperationNodeFactory::makeOperation(pathUri: '/x', method: 'GET', responses: [$response]);
+    OperationNodeFactory::makeOperation(pathUri: '/x', method: HttpMethod::Get, responses: [$response]);
 
     $findings = iterator_to_array(
         new ResponseSuccessEmptyBody()->checkResponse($response, OperationNodeFactory::emptyContext()),
@@ -82,7 +83,7 @@ it('skips non-2xx responses', function (int $statusCode): void {
 
 it('skips HEAD responses (HEAD bodies are intentionally suppressed)', function (): void {
     $response = OperationNodeFactory::makeResponse(statusCode: 200);
-    OperationNodeFactory::makeOperation(pathUri: '/users', method: 'HEAD', responses: [$response]);
+    OperationNodeFactory::makeOperation(pathUri: '/users', method: HttpMethod::Head, responses: [$response]);
 
     $findings = iterator_to_array(
         new ResponseSuccessEmptyBody()->checkResponse($response, OperationNodeFactory::emptyContext()),

--- a/tests/Unit/Lint/Rules/WebhookDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/WebhookDescriptionMissingTest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Rules\WebhookDescriptionMissing;
 use Radiergummi\OpenApi\Lint\Tree\WebhookNode;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
 uses()->group('openapi', 'lint');
 
+/**
+ * @throws LogicException
+ */
 function makeWebhookForDescription(string $name, ?string $description): WebhookNode
 {
     $raw = new OA\Post([
@@ -20,7 +24,7 @@ function makeWebhookForDescription(string $name, ?string $description): WebhookN
 
     $operationNode = OperationNodeFactory::makeOperation(
         pathUri: $name,
-        method: 'POST',
+        method: HttpMethod::Post,
         operationId: 'webhook.test',
         description: $description,
         responses: [],
@@ -39,7 +43,8 @@ function makeWebhookForDescription(string $name, ?string $description): WebhookN
 it('has the correct rule id and level', function (): void {
     $rule = new WebhookDescriptionMissing();
 
-    expect($rule->id())->toBe('webhook.description-missing')
+    expect($rule->id())
+        ->toBe('webhook.description-missing')
         ->and($rule->level())->toBe(2);
 });
 
@@ -51,14 +56,15 @@ it('emits a finding when a webhook has a missing or blank description', function
         $rule->checkWebhook($webhook, OperationNodeFactory::emptyContext()),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('webhook.description-missing')
         ->and($findings[0]->level)->toBe(2)
         ->and($findings[0]->message)->toContain('orderCreated')
         ->and($findings[0]->location->jsonPointer)->toBe('#/webhooks/orderCreated');
 })->with([
-    'null'            => [null],
-    'empty string'    => [''],
+    'null' => [null],
+    'empty string' => [''],
     'whitespace only' => ['   '],
 ]);
 

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScopeTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScopeTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Plugins\SpatieData\Lint\Rules\FieldAttributeWrongScope;
 use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
@@ -25,15 +26,24 @@ function makeDirectOnlyScanner(): PayloadParameterScanner
 
 function makeWrongScopeOperation(string $method): OperationNode
 {
-    $descriptor = ActionDescriptorFactory::forControllerMethod(WrongScopeFixtureController::class, $method, '/fixture');
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        WrongScopeFixtureController::class,
+        $method,
+        '/fixture',
+    );
 
-    return OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    return OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
 }
 
 it('reports its id and level', function (): void {
     $rule = new FieldAttributeWrongScope(makeDirectOnlyScanner());
 
-    expect($rule->id())->toBe('field.attribute-wrong-scope')
+    expect($rule->id())
+        ->toBe('field.attribute-wrong-scope')
         ->and($rule->level())->toBe(1);
 });
 
@@ -45,7 +55,8 @@ it('flags RequestField on a route parameter', function (): void {
         ),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->ruleId)->toBe('field.attribute-wrong-scope')
         ->and($findings[0]->message)->toContain('#[RequestField]')
         ->and($findings[0]->fixHint)->toBe('Use #[PathParam] for a URI parameter.');
@@ -59,7 +70,8 @@ it('flags PathParam on a Data-class property', function (): void {
         ),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('#[PathParam]')
         ->and($findings[0]->fixHint)->toBe('Use #[RequestField] for a request-body field.');
 });
@@ -79,9 +91,18 @@ it('flags PathParam on a Data-class property injected through a Domain Action', 
     // WrongScopeFixtureData (carried by ActionWithWrongScopeData's constructor) has
     // a misplaced #[PathParam] on its $misplaced property. The scanner must descend
     // into the Action constructor to reach it.
-    $descriptor = ActionDescriptorFactory::forControllerMethod(ActionWithWrongScopeDataController::class, 'create', '/fixture', ['POST']);
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        ActionWithWrongScopeDataController::class,
+        'create',
+        '/fixture',
+        ['POST'],
+    );
 
-    $operation = OperationNodeFactory::forDescriptor($descriptor, method: 'POST', pathUri: '/api/v0/test');
+    $operation = OperationNodeFactory::forDescriptor(
+        $descriptor,
+        method: HttpMethod::Post,
+        pathUri: '/api/v0/test',
+    );
 
     // Scanner configured with Action::class as an indirection base so it descends
     // into ActionWithWrongScopeData's constructor and finds WrongScopeFixtureData.
@@ -93,7 +114,8 @@ it('flags PathParam on a Data-class property injected through a Domain Action', 
         ),
     );
 
-    expect($findings)->toHaveCount(1)
+    expect($findings)
+        ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('#[PathParam]')
         ->and($findings[0]->message)->toContain('WrongScopeFixtureData')
         ->and($findings[0]->fixHint)->toBe('Use #[RequestField] for a request-body field.');

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
+use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\ApiNode;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
@@ -53,7 +54,7 @@ function makeMultipartOperationNode(
 ): OperationNode {
     return new OperationNode(
         pathUri: $descriptor->route->uri(),
-        method: 'POST',
+        method: HttpMethod::Post,
         operationId: null,
         summary: null,
         description: null,


### PR DESCRIPTION
**Stack (merge bottom-up):** ① [#71 remove-copyright-headers] → ② [#72 plugin-namespace-reorg] → ③ **this**

> Based on #72 — review/merge that first.

Replaces ad-hoc HTTP-verb strings with a backed `HttpMethod` enum (lowercase values matching OpenAPI path-item keys; `forDisplay()` for the uppercase wire form). Threads it through the pipeline:

- `ActionDescriptor::httpMethod` accessor (single source for the route's verb)
- `OperationNode::method` / `FindingLocation::routeMethod` / `OperationContext::httpMethod` typed as `HttpMethod`
- operation construction routed through `OperationDescriptor::attachTo()`, keeping the method → operation-class → property mapping in one place

`HttpMethod::fromString()` resolves verbs case-insensitively, fixing a latent bug where `Route::methods()` (uppercase) vs the lowercase-backed enum made POST/PUT/PATCH detection silently fall back to GET.

CI green (PHPStan L8, Pint, 1542 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)