### PR TITLE
refactor: is_undefined/is_defined helpers for the UNDEFINED sentinel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
     "autoload": {
         "psr-4": {
             "Radiergummi\\OpenApi\\": "src/"
-        }
+        },
+        "files": [ "src/functions.php" ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Lint/AnnotationWalker.php
+++ b/src/Lint/AnnotationWalker.php
@@ -10,6 +10,8 @@ use Radiergummi\OpenApi\Enums\ComponentType;
 
 use function is_array;
 use function property_exists;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function spl_object_id;
 
 /**
@@ -59,7 +61,7 @@ final class AnnotationWalker
 
             $value = $annotation->{$propertyName} ?? Generator::UNDEFINED;
 
-            if (Generator::isDefault($value)) {
+            if (is_undefined($value)) {
                 continue;
             }
 
@@ -87,7 +89,7 @@ final class AnnotationWalker
     {
         $components = $spec->components;
 
-        if (Generator::isDefault($components) || $components === null) {
+        if (is_undefined($components) || $components === null) {
             return [];
         }
 
@@ -105,7 +107,7 @@ final class AnnotationWalker
             }
 
             foreach ($items as $item) {
-                if (Generator::isDefault($item)) {
+                if (is_undefined($item)) {
                     continue;
                 }
 
@@ -126,31 +128,31 @@ final class AnnotationWalker
     public static function extractComponentName(object $item, ComponentType $type): ?string
     {
         return match ($type) {
-            ComponentType::Schemas => $item instanceof OA\Schema && !Generator::isDefault($item->schema)
+            ComponentType::Schemas => $item instanceof OA\Schema && is_defined($item->schema)
                 ? $item->schema
                 : null,
-            ComponentType::Responses => $item instanceof OA\Response && !Generator::isDefault($item->response)
+            ComponentType::Responses => $item instanceof OA\Response && is_defined($item->response)
                 ? (string) $item->response
                 : null,
-            ComponentType::Parameters => $item instanceof OA\Parameter && !Generator::isDefault($item->parameter)
+            ComponentType::Parameters => $item instanceof OA\Parameter && is_defined($item->parameter)
                 ? $item->parameter
                 : null,
-            ComponentType::Examples => $item instanceof OA\Examples && !Generator::isDefault($item->example)
+            ComponentType::Examples => $item instanceof OA\Examples && is_defined($item->example)
                 ? $item->example
                 : null,
-            ComponentType::RequestBodies => $item instanceof OA\RequestBody && !Generator::isDefault($item->request)
+            ComponentType::RequestBodies => $item instanceof OA\RequestBody && is_defined($item->request)
                 ? $item->request
                 : null,
-            ComponentType::Headers => $item instanceof OA\Header && !Generator::isDefault($item->header)
+            ComponentType::Headers => $item instanceof OA\Header && is_defined($item->header)
                 ? $item->header
                 : null,
-            ComponentType::SecuritySchemes => $item instanceof OA\SecurityScheme && !Generator::isDefault($item->securityScheme)
+            ComponentType::SecuritySchemes => $item instanceof OA\SecurityScheme && is_defined($item->securityScheme)
                 ? $item->securityScheme
                 : null,
-            ComponentType::Links => $item instanceof OA\Link && !Generator::isDefault($item->link)
+            ComponentType::Links => $item instanceof OA\Link && is_defined($item->link)
                 ? $item->link
                 : null,
-            ComponentType::Callbacks => $item instanceof OA\PathItem && !Generator::isDefault($item->path)
+            ComponentType::Callbacks => $item instanceof OA\PathItem && is_defined($item->path)
                 ? $item->path
                 : null,
             // PathItems is not a named component type; it represents inline callback constructs

--- a/src/Lint/LintRunner.php
+++ b/src/Lint/LintRunner.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 use Laravel\Passport\Passport;
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Radiergummi\OpenApi\Console\LintCommand;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Rules\MetaSuppressionStale;
@@ -46,6 +45,7 @@ use function in_array;
 use function is_array;
 use function ltrim;
 use function max;
+use function Radiergummi\OpenApi\is_defined;
 
 /**
  * Orchestrates one lint run against the application's routes.
@@ -416,7 +416,7 @@ final readonly class LintRunner
                 array_filter(
                     $document->paths,
                     static fn(OA\PathItem $p): bool
-                        => !Generator::isDefault($p->path)
+                        => is_defined($p->path)
                         && isset($allowedUris[$p->path]),
                 ),
             );

--- a/src/Lint/Rules/DiscriminatorInvalidMapping.php
+++ b/src/Lint/Rules/DiscriminatorInvalidMapping.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -17,6 +16,8 @@ use Radiergummi\OpenApi\Lint\Visitors\Finalizable;
 use Radiergummi\OpenApi\Lint\Visitors\Resettable;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
@@ -64,15 +65,15 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
         }
 
         // Index this schema for use in finalize()
-        if (!Generator::isDefault($schema->schema) && $schema->schema !== null) {
+        if (is_defined($schema->schema) && $schema->schema !== null) {
             $this->schemaMap[$schema->schema] = $schema;
         }
 
         // Queue schemas with discriminators for the finalize pass
         if (
-            !Generator::isDefault($schema->discriminator)
+            is_defined($schema->discriminator)
             && $schema->discriminator !== null
-            && !Generator::isDefault($schema->discriminator->propertyName)
+            && is_defined($schema->discriminator->propertyName)
             && is_array($schema->discriminator->mapping)
         ) {
             $this->pending[] = $schema;
@@ -99,7 +100,7 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
     {
         $discriminator = $schema->discriminator;
         $propertyName = $discriminator->propertyName;
-        $baseSchemaName = !Generator::isDefault($schema->schema) ? $schema->schema : '(unknown)';
+        $baseSchemaName = is_defined($schema->schema) ? $schema->schema : '(unknown)';
 
         foreach ($discriminator->mapping as $discriminatorValue => $ref) {
             if (!is_string($ref)) {
@@ -211,12 +212,12 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
     ): bool {
         if (is_array($schema->properties)) {
             foreach ($schema->properties as $property) {
-                if (Generator::isDefault($property)) {
+                if (is_undefined($property)) {
                     continue;
                 }
 
                 if (
-                    !Generator::isDefault($property->property)
+                    is_defined($property->property)
                     && $property->property === $propertyName
                 ) {
                     return true;
@@ -229,14 +230,14 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
         }
 
         foreach ($schema->allOf as $sub) {
-            if (Generator::isDefault($sub)) {
+            if (is_undefined($sub)) {
                 continue;
             }
 
             // If this allOf entry is a $ref, resolve it to the actual schema first
             $ref = $sub->ref;
 
-            if (!Generator::isDefault($ref) && is_string($ref)) {
+            if (is_defined($ref) && is_string($ref)) {
                 $refName = $this->resolveRefToSchemaName($ref);
 
                 if ($refName !== null) {
@@ -261,7 +262,7 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
             }
 
             // Inline allOf sub-schema (no $ref) — recurse directly
-            $subName = !Generator::isDefault($sub->schema) ? $sub->schema : null;
+            $subName = is_defined($sub->schema) ? $sub->schema : null;
 
             if ($subName !== null) {
                 if (isset($visited[$subName])) {

--- a/src/Lint/Rules/InfoDescriptionMissing.php
+++ b/src/Lint/Rules/InfoDescriptionMissing.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -14,6 +13,7 @@ use Radiergummi\OpenApi\Lint\Tree\ApiNode;
 use Radiergummi\OpenApi\Lint\Visitors\ApiRule as ApiRuleVisitor;
 
 use function is_string;
+use function Radiergummi\OpenApi\is_undefined;
 use function trim;
 
 /**
@@ -33,7 +33,7 @@ final class InfoDescriptionMissing implements Rule, ApiRuleVisitor
         $info = $context->rawSpec->info;
 
         // info itself may be UNDEFINED if the spec is incomplete
-        if (Generator::isDefault($info) || $info === null) {
+        if (is_undefined($info) || $info === null) {
             yield new Finding(
                 ruleId: $this->id(),
                 level: $this->level(),
@@ -48,7 +48,7 @@ final class InfoDescriptionMissing implements Rule, ApiRuleVisitor
         $description = $info->description;
 
         if (
-            Generator::isDefault($description)
+            is_undefined($description)
             || !is_string($description)
             || trim($description) === ''
         ) {

--- a/src/Lint/Rules/InfoMetadataIncomplete.php
+++ b/src/Lint/Rules/InfoMetadataIncomplete.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -14,6 +13,7 @@ use Radiergummi\OpenApi\Lint\Tree\ApiNode;
 use Radiergummi\OpenApi\Lint\Visitors\ApiRule as ApiRuleVisitor;
 
 use function implode;
+use function Radiergummi\OpenApi\is_undefined;
 
 /**
  * Reports documents whose info object is missing a contact and/or license.
@@ -31,17 +31,17 @@ final class InfoMetadataIncomplete implements Rule, ApiRuleVisitor
     {
         $info = $context->rawSpec->info;
 
-        if (Generator::isDefault($info) || $info === null) {
+        if (is_undefined($info) || $info === null) {
             return;
         }
 
         $missing = [];
 
-        if (Generator::isDefault($info->contact) || $info->contact === null) {
+        if (is_undefined($info->contact) || $info->contact === null) {
             $missing[] = 'contact';
         }
 
-        if (Generator::isDefault($info->license) || $info->license === null) {
+        if (is_undefined($info->license) || $info->license === null) {
             $missing[] = 'license';
         }
 

--- a/src/Lint/Rules/OperationSecurityMissing.php
+++ b/src/Lint/Rules/OperationSecurityMissing.php
@@ -13,6 +13,7 @@ use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -78,7 +79,7 @@ final class OperationSecurityMissing implements Rule, OperationRuleVisitor
     {
         $security = $operation->raw->security;
 
-        if (Generator::isDefault($security)) {
+        if (is_undefined($security)) {
             return false;
         }
 

--- a/src/Lint/Rules/ParameterExampleConflict.php
+++ b/src/Lint/Rules/ParameterExampleConflict.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -12,6 +11,7 @@ use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\ParameterNode;
 use Radiergummi\OpenApi\Lint\Visitors\ParameterRule as ParameterRuleVisitor;
 
+use function Radiergummi\OpenApi\is_defined;
 use function sprintf;
 
 /**
@@ -33,8 +33,8 @@ final class ParameterExampleConflict implements Rule, ParameterRuleVisitor
             return;
         }
 
-        $hasSingular = !Generator::isDefault($parameter->raw->example);
-        $hasPlural = !Generator::isDefault($parameter->raw->examples);
+        $hasSingular = is_defined($parameter->raw->example);
+        $hasPlural = is_defined($parameter->raw->examples);
 
         if (!$hasSingular || !$hasPlural) {
             return;

--- a/src/Lint/Rules/ParameterExampleMissing.php
+++ b/src/Lint/Rules/ParameterExampleMissing.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -13,6 +12,7 @@ use Radiergummi\OpenApi\Lint\Tree\ParameterNode;
 use Radiergummi\OpenApi\Lint\Visitors\ParameterRule as ParameterRuleVisitor;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_defined;
 use function sprintf;
 
 /**
@@ -33,10 +33,10 @@ final class ParameterExampleMissing implements Rule, ParameterRuleVisitor
             return;
         }
 
-        $hasExample = !Generator::isDefault($parameter->raw->example)
+        $hasExample = is_defined($parameter->raw->example)
             && $parameter->raw->example !== null;
 
-        $hasExamples = !Generator::isDefault($parameter->raw->examples)
+        $hasExamples = is_defined($parameter->raw->examples)
             && is_array($parameter->raw->examples)
             && $parameter->raw->examples !== [];
 

--- a/src/Lint/Rules/RefBroken.php
+++ b/src/Lint/Rules/RefBroken.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Enums\ComponentType;
@@ -19,6 +18,7 @@ use Radiergummi\OpenApi\Lint\Visitors\ApiRule as ApiRuleVisitor;
 use function is_string;
 use function preg_match;
 use function property_exists;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -50,7 +50,7 @@ final class RefBroken implements Rule, ApiRuleVisitor
 
             $ref = $annotation->ref;
 
-            if (Generator::isDefault($ref) || !is_string($ref)) {
+            if (is_undefined($ref) || !is_string($ref)) {
                 return;
             }
 

--- a/src/Lint/Rules/SchemaAllOfTypeConflict.php
+++ b/src/Lint/Rules/SchemaAllOfTypeConflict.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -19,6 +18,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_string;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -65,13 +65,13 @@ final class SchemaAllOfTypeConflict implements Rule, ComponentSchemaRuleVisitor
         $types = [];
 
         foreach ($allOf as $subSchema) {
-            if (Generator::isDefault($subSchema)) {
+            if (is_undefined($subSchema)) {
                 continue;
             }
 
             $type = $subSchema->type;
 
-            if (Generator::isDefault($type) || $type === null) {
+            if (is_undefined($type) || $type === null) {
                 continue;
             }
 

--- a/src/Lint/Rules/SchemaConstraintsMissing.php
+++ b/src/Lint/Rules/SchemaConstraintsMissing.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -19,6 +18,7 @@ use Radiergummi\OpenApi\Lint\Visitors\FieldRule as FieldRuleVisitor;
 use function array_find;
 use function is_array;
 use function is_string;
+use function Radiergummi\OpenApi\is_defined;
 use function sprintf;
 
 /**
@@ -84,7 +84,7 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
                 return;
             }
 
-            if (!Generator::isDefault($raw->maxLength)) {
+            if (is_defined($raw->maxLength)) {
                 return;
             }
 
@@ -100,7 +100,7 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
         }
 
         if ($type === 'array') {
-            if (!Generator::isDefault($raw->maxItems)) {
+            if (is_defined($raw->maxItems)) {
                 return;
             }
 
@@ -117,8 +117,8 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
 
         if ($type === 'integer' || $type === 'number') {
             if (
-                !Generator::isDefault($raw->minimum)
-                || !Generator::isDefault($raw->maximum)
+                is_defined($raw->minimum)
+                || is_defined($raw->maximum)
             ) {
                 return;
             }
@@ -159,7 +159,7 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
             return;
         }
 
-        $rawType = !Generator::isDefault($schema->type) ? $schema->type : null;
+        $rawType = is_defined($schema->type) ? $schema->type : null;
 
         if (is_array($rawType)) {
             $type = array_find($rawType, static fn(string $t): bool => $t !== 'null');
@@ -168,8 +168,8 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
         } else {
             $type = null;
         }
-        $format = !Generator::isDefault($schema->format) ? $schema->format : null;
-        $enum = !Generator::isDefault($schema->enum) && is_array($schema->enum)
+        $format = is_defined($schema->format) ? $schema->format : null;
+        $enum = is_defined($schema->enum) && is_array($schema->enum)
             ? $schema->enum
             : null;
 

--- a/src/Lint/Rules/SchemaEnumEmpty.php
+++ b/src/Lint/Rules/SchemaEnumEmpty.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -16,6 +15,7 @@ use Radiergummi\OpenApi\Lint\Visitors\ComponentSchemaRule as ComponentSchemaRule
 use Radiergummi\OpenApi\Lint\Visitors\FieldRule as FieldRuleVisitor;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_undefined;
 
 /**
  * Reports schemas that declare an empty `enum` array, which makes the schema unsatisfiable — no
@@ -80,7 +80,7 @@ final class SchemaEnumEmpty implements Rule, FieldRuleVisitor, ComponentSchemaRu
 
         $enum = $raw->enum;
 
-        if (Generator::isDefault($enum) || !is_array($enum)) {
+        if (is_undefined($enum) || !is_array($enum)) {
             return;
         }
 

--- a/src/Lint/Rules/SchemaExampleMissing.php
+++ b/src/Lint/Rules/SchemaExampleMissing.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -14,6 +13,7 @@ use Radiergummi\OpenApi\Lint\Tree\ComponentSchemaNode;
 use Radiergummi\OpenApi\Lint\Visitors\ComponentSchemaRule as ComponentSchemaRuleVisitor;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_defined;
 use function sprintf;
 
 /**
@@ -40,15 +40,15 @@ final class SchemaExampleMissing implements Rule, ComponentSchemaRuleVisitor
             return;
         }
 
-        $hasExample = !Generator::isDefault($schema->example) && $schema->example !== null;
+        $hasExample = is_defined($schema->example) && $schema->example !== null;
 
         $hasExamples
-            = !Generator::isDefault($schema->examples)
+            = is_defined($schema->examples)
             && is_array($schema->examples)
             && $schema->examples !== [];
 
         $hasEnum
-            = !Generator::isDefault($schema->enum)
+            = is_defined($schema->enum)
             && is_array($schema->enum)
             && $schema->enum !== [];
 

--- a/src/Lint/Rules/SchemaNullableViaDeprecatedKeyword.php
+++ b/src/Lint/Rules/SchemaNullableViaDeprecatedKeyword.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -32,7 +31,7 @@ final class SchemaNullableViaDeprecatedKeyword implements Rule, FieldRuleVisitor
             return;
         }
 
-        if (Generator::isDefault($raw->nullable) || $raw->nullable !== true) {
+        if ($raw->nullable !== true) {
             return;
         }
 

--- a/src/Lint/Rules/SchemaRequiredWithoutProperty.php
+++ b/src/Lint/Rules/SchemaRequiredWithoutProperty.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -18,6 +17,8 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function preg_match;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -42,7 +43,7 @@ final class SchemaRequiredWithoutProperty implements Rule, ComponentSchemaRuleVi
 
         $required = $schema->required;
 
-        if (Generator::isDefault($required) || !is_array($required)) {
+        if (is_undefined($required) || !is_array($required)) {
             return;
         }
 
@@ -108,8 +109,8 @@ final class SchemaRequiredWithoutProperty implements Rule, ComponentSchemaRuleVi
         if (is_array($properties)) {
             foreach ($properties as $property) {
                 if (
-                    !Generator::isDefault($property)
-                    && !Generator::isDefault($property->property)
+                    is_defined($property)
+                    && is_defined($property->property)
                 ) {
                     $names[] = $property->property;
                 }
@@ -123,7 +124,7 @@ final class SchemaRequiredWithoutProperty implements Rule, ComponentSchemaRuleVi
         }
 
         foreach ($allOf as $sub) {
-            if (Generator::isDefault($sub)) {
+            if (is_undefined($sub)) {
                 continue;
             }
 

--- a/src/Lint/Rules/SecuritySchemeUndefined.php
+++ b/src/Lint/Rules/SecuritySchemeUndefined.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -16,6 +15,8 @@ use Radiergummi\OpenApi\Lint\Visitors\Resettable;
 
 use function in_array;
 use function is_array;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -79,25 +80,25 @@ final class SecuritySchemeUndefined implements Rule, OperationRuleVisitor, Reset
     {
         $components = $spec->components;
 
-        if (Generator::isDefault($components) || $components === null) {
+        if (is_undefined($components) || $components === null) {
             return [];
         }
 
         $schemes = $components->securitySchemes;
 
-        if (Generator::isDefault($schemes) || !is_array($schemes)) {
+        if (is_undefined($schemes) || !is_array($schemes)) {
             return [];
         }
 
         $names = [];
 
         foreach ($schemes as $scheme) {
-            if (Generator::isDefault($scheme)) {
+            if (is_undefined($scheme)) {
                 continue;
             }
 
             if (
-                !Generator::isDefault($scheme->securityScheme)
+                is_defined($scheme->securityScheme)
                 && $scheme->securityScheme !== null
             ) {
                 $names[] = $scheme->securityScheme;

--- a/src/Lint/Rules/ServerInvalidUrl.php
+++ b/src/Lint/Rules/ServerInvalidUrl.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -16,6 +15,7 @@ use function filter_var;
 use function is_array;
 use function is_string;
 use function preg_replace;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 use function str_starts_with;
 
@@ -38,7 +38,7 @@ final class ServerInvalidUrl implements Rule, ApiRuleVisitor
         foreach ($servers as $server) {
             $url = $server->url;
 
-            if (Generator::isDefault($url) || !is_string($url)) {
+            if (is_undefined($url) || !is_string($url)) {
                 continue;
             }
 

--- a/src/Lint/Rules/ServerVariableUndeclared.php
+++ b/src/Lint/Rules/ServerVariableUndeclared.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations\ServerVariable;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -17,6 +16,8 @@ use function array_key_exists;
 use function is_array;
 use function is_string;
 use function preg_match_all;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 final class ServerVariableUndeclared implements Rule, ApiRuleVisitor
@@ -36,7 +37,7 @@ final class ServerVariableUndeclared implements Rule, ApiRuleVisitor
         foreach ($servers as $server) {
             $url = $server->url;
 
-            if (Generator::isDefault($url) || !is_string($url)) {
+            if (is_undefined($url) || !is_string($url)) {
                 continue;
             }
 
@@ -52,7 +53,7 @@ final class ServerVariableUndeclared implements Rule, ApiRuleVisitor
 
             if (is_array($variables)) {
                 foreach ($variables as $key => $variable) {
-                    if ($variable instanceof ServerVariable && !Generator::isDefault($variable->serverVariable)) {
+                    if ($variable instanceof ServerVariable && is_defined($variable->serverVariable)) {
                         $declaredKeys[$variable->serverVariable] = true;
                     } else {
                         $declaredKeys[(string) $key] = true;

--- a/src/Lint/Rules/StreamingNoContentType.php
+++ b/src/Lint/Rules/StreamingNoContentType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Override;
 use Radiergummi\OpenApi\Attributes\Operation;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
@@ -16,6 +15,8 @@ use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
 use ReflectionAttribute;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -79,29 +80,29 @@ final class StreamingNoContentType implements Rule, OperationRuleVisitor
     {
         $responses = $operation->responses;
 
-        if (Generator::isDefault($responses) || !is_array($responses)) {
+        if (is_undefined($responses) || !is_array($responses)) {
             return false;
         }
 
         foreach ($responses as $response) {
-            if (Generator::isDefault($response)) {
+            if (is_undefined($response)) {
                 continue;
             }
 
             $content = $response->content;
 
-            if (Generator::isDefault($content) || !is_array($content)) {
+            if (is_undefined($content) || !is_array($content)) {
                 continue;
             }
 
             foreach ($content as $mediaType) {
-                if (Generator::isDefault($mediaType)) {
+                if (is_undefined($mediaType)) {
                     continue;
                 }
 
                 if (
                     $mediaType instanceof OA\MediaType
-                    && !Generator::isDefault($mediaType->mediaType)
+                    && is_defined($mediaType->mediaType)
                     && $mediaType->mediaType === 'text/event-stream'
                 ) {
                     return true;

--- a/src/Lint/Tree/SchemaAccessor.php
+++ b/src/Lint/Tree/SchemaAccessor.php
@@ -12,6 +12,8 @@ use function in_array;
 use function is_array;
 use function is_string;
 use function preg_match;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 
 /**
  * Stateless accessors that translate swagger-php's `Generator::UNDEFINED` sentinels into
@@ -25,14 +27,14 @@ final class SchemaAccessor
      */
     public static function extractRef(OA\Schema|array|string|null $schema): ?string
     {
-        if ($schema === null || Generator::isDefault($schema)) {
+        if ($schema === null || is_undefined($schema)) {
             return null;
         }
 
         $ref = $schema->ref ?? Generator::UNDEFINED;
 
         if (
-            Generator::isDefault($ref)
+            is_undefined($ref)
             || $ref === null // @phpstan-ignore identical.alwaysFalse (defensive; swagger-php may emit null at runtime)
             || !is_string($ref)
         ) {
@@ -48,7 +50,7 @@ final class SchemaAccessor
 
     public static function extractSchemaType(mixed $schema): ?string
     {
-        if ($schema === null || Generator::isDefault($schema)) {
+        if ($schema === null || is_undefined($schema)) {
             return null;
         }
 
@@ -58,7 +60,7 @@ final class SchemaAccessor
 
         $type = $schema->type;
 
-        if (Generator::isDefault($type) || $type === null) {
+        if (is_undefined($type) || $type === null) {
             return null;
         }
 
@@ -80,7 +82,7 @@ final class SchemaAccessor
 
     public static function extractSchemaPattern(mixed $schema): ?string
     {
-        if ($schema === null || Generator::isDefault($schema)) {
+        if ($schema === null || is_undefined($schema)) {
             return null;
         }
 
@@ -92,7 +94,7 @@ final class SchemaAccessor
         $pattern = $schema->pattern ?? Generator::UNDEFINED;
 
         if (
-            Generator::isDefault($pattern)
+            is_undefined($pattern)
             || $pattern === null // @phpstan-ignore identical.alwaysFalse (defensive; pattern may be null at runtime)
         ) {
             return null;
@@ -106,7 +108,7 @@ final class SchemaAccessor
      */
     public static function extractSchemaEnum(mixed $schema): ?array
     {
-        if ($schema === null || Generator::isDefault($schema)) {
+        if ($schema === null || is_undefined($schema)) {
             return null;
         }
 
@@ -116,7 +118,7 @@ final class SchemaAccessor
 
         $enum = $schema->enum;
 
-        if (Generator::isDefault($enum) || !is_array($enum)) {
+        if (is_undefined($enum) || !is_array($enum)) {
             return null;
         }
 
@@ -127,7 +129,7 @@ final class SchemaAccessor
     {
         // OAS 3.0 style
         if (
-            !Generator::isDefault($schema->nullable)
+            is_defined($schema->nullable)
             && $schema->nullable === true
         ) {
             return true;
@@ -141,7 +143,7 @@ final class SchemaAccessor
 
     public static function undefinedToNull(mixed $value): ?string
     {
-        if (Generator::isDefault($value) || $value === null) {
+        if (is_undefined($value) || $value === null) {
             return null;
         }
 

--- a/src/Lint/Tree/SpecTreeBuilder.php
+++ b/src/Lint/Tree/SpecTreeBuilder.php
@@ -17,20 +17,18 @@ use function array_values;
 use function in_array;
 use function is_array;
 use function is_string;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function strtoupper;
 
 /**
  * Transforms the raw `OA\OpenApi` annotation graph into a clean, typed domain tree.
- *
- * This is the single place that handles `Generator::UNDEFINED` sentinels, normalizes
- * annotation quirks, and correlates operations with ActionDescriptors.
  */
 final class SpecTreeBuilder
 {
     /**
      * Component schemas indexed by name — populated at the start of {@see build()} so
-     * {@see buildFields()} can resolve `allOf: [{$ref: …}]` branches to the underlying
-     * properties.
+     * {@see buildFields()} can resolve `allOf: [{$ref: …}]` branches to the underlying properties.
      *
      * @var array<string, OA\Schema>
      */
@@ -96,13 +94,13 @@ final class SpecTreeBuilder
     {
         $components = $spec->components;
 
-        if ($components === null || Generator::isDefault($components)) {
+        if ($components === null || is_undefined($components)) {
             return [];
         }
 
         $schemas = $components->schemas;
 
-        if (!is_array($schemas) || Generator::isDefault($schemas)) {
+        if (!is_array($schemas) || is_undefined($schemas)) {
             return [];
         }
 
@@ -111,12 +109,12 @@ final class SpecTreeBuilder
         foreach ($schemas as $schema) {
             if (
                 !$schema instanceof OA\Schema
-                || Generator::isDefault($schema)
+                || is_undefined($schema)
             ) {
                 continue;
             }
 
-            if (Generator::isDefault($schema->schema)) {
+            if (is_undefined($schema->schema)) {
                 continue;
             }
 
@@ -169,19 +167,19 @@ final class SpecTreeBuilder
         }
 
         foreach ($paths as $path) {
-            if (Generator::isDefault($path)) {
+            if (is_undefined($path)) {
                 continue;
             }
 
             $pathUri
-                = !Generator::isDefault($path->path)
+                = is_defined($path->path)
                 ? $path->path
                 : '(unknown)';
 
             foreach (HttpMethod::cases() as $method) {
                 $oaOperation = $path->{$method->value} ?? null;
 
-                if ($oaOperation === null || Generator::isDefault($oaOperation)) {
+                if ($oaOperation === null || is_undefined($oaOperation)) {
                     continue;
                 }
 
@@ -225,8 +223,7 @@ final class SpecTreeBuilder
             operationId: SchemaAccessor::undefinedToNull($oaOperation->operationId),
             summary: SchemaAccessor::undefinedToNull($oaOperation->summary),
             description: SchemaAccessor::undefinedToNull($oaOperation->description),
-            deprecated: !Generator::isDefault($oaOperation->deprecated)
-            && $oaOperation->deprecated === true,
+            deprecated: $oaOperation->deprecated === true,
             parameters: $parameters,
             queryParameters: $queryParameters,
             requestBody: $requestBody,
@@ -267,18 +264,18 @@ final class SpecTreeBuilder
     {
         $params = $operation->parameters;
 
-        if (!is_array($params) || Generator::isDefault($params)) {
+        if (!is_array($params) || is_undefined($params)) {
             return [];
         }
 
         $result = [];
 
         foreach ($params as $param) {
-            if (Generator::isDefault($param)) {
+            if (is_undefined($param)) {
                 continue;
             }
 
-            $in = !Generator::isDefault($param->in) ? $param->in : null;
+            $in = is_defined($param->in) ? $param->in : null;
 
             if ($in !== 'path') {
                 continue;
@@ -286,15 +283,15 @@ final class SpecTreeBuilder
 
             $examples = $this->buildExamplesFromParameter($param);
             $node = new ParameterNode(
-                name: !Generator::isDefault($param->name)
+                name: is_defined($param->name)
                     ? $param->name
                     : '(unknown)',
-                required: !Generator::isDefault($param->required)
+                required: is_defined($param->required)
                 && $param->required === true,
-                // @phpstan-ignore nullCoalesce.property (defensive; $schema may be unset at runtime)
+                // @phpstan-ignore nullCoalesce.property ($schema may be unset at runtime)
                 schema: SchemaAccessor::extractSchemaType($param->schema ?? null),
                 description: SchemaAccessor::undefinedToNull($param->description),
-                // @phpstan-ignore nullCoalesce.property (defensive; $schema may be unset at runtime)
+                // @phpstan-ignore nullCoalesce.property ($schema may be unset at runtime)
                 pattern: SchemaAccessor::extractSchemaPattern($param->schema ?? null),
                 examples: $examples,
                 raw: $param,
@@ -311,23 +308,23 @@ final class SpecTreeBuilder
     }
 
     /**
-     * Build examples from a parameter's examples array.
+     * Build examples from a parameter's `examples` array.
      *
      * @return list<ExampleNode>
      */
     private function buildExamplesFromParameter(OA\Parameter $param): array
     {
-        // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
         $examples = $param->examples ?? Generator::UNDEFINED;
 
-        if (!is_array($examples) || Generator::isDefault($examples)) {
+        if (!is_array($examples) || is_undefined($examples)) {
             return [];
         }
 
         $result = [];
 
         foreach ($examples as $example) {
-            if (Generator::isDefault($example)) {
+            if (is_undefined($example)) {
                 continue;
             }
 
@@ -342,10 +339,10 @@ final class SpecTreeBuilder
     private function buildExampleNode(OA\Examples $example): ExampleNode
     {
         return new ExampleNode(
-            name: !Generator::isDefault($example->example)
+            name: is_defined($example->example)
                 ? $example->example
                 : null,
-            value: !Generator::isDefault($example->value)
+            value: is_defined($example->value)
                 ? $example->value
                 : null,
             summary: SchemaAccessor::undefinedToNull($example->summary),
@@ -365,35 +362,36 @@ final class SpecTreeBuilder
     {
         $params = $operation->parameters;
 
-        if (!is_array($params) || Generator::isDefault($params)) {
+        if (!is_array($params) || is_undefined($params)) {
             return [];
         }
 
         $result = [];
 
         foreach ($params as $param) {
-            if (Generator::isDefault($param)) {
+            if (is_undefined($param)) {
                 continue;
             }
 
-            $in = !Generator::isDefault($param->in) ? $param->in : null;
+            $in = is_defined($param->in) ? $param->in : null;
 
             if ($in !== 'query') {
                 continue;
             }
 
             $examples = $this->buildExamplesFromParameter($param);
-            $schema = $param->schema ?? null; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
+            $schema = $param->schema ?? null;
             $node = new QueryParameterNode(
-                name: !Generator::isDefault($param->name)
+                name: is_defined($param->name)
                     ? $param->name
                     : '(unknown)',
-                required: !Generator::isDefault($param->required)
+                required: is_defined($param->required)
                 && $param->required === true,
                 type: SchemaAccessor::extractSchemaType($schema),
-                hasSchema: $schema !== null && !Generator::isDefault($schema),
+                hasSchema: $schema !== null && is_defined($schema),
                 style: SchemaAccessor::undefinedToNull($param->style),
-                explode: !Generator::isDefault($param->explode)
+                explode: is_defined($param->explode)
                     ? (bool) $param->explode
                     : null,
                 description: SchemaAccessor::undefinedToNull($param->description),
@@ -419,7 +417,7 @@ final class SpecTreeBuilder
     {
         $requestBody = $operation->requestBody;
 
-        if ($requestBody === null || Generator::isDefault($requestBody)) {
+        if ($requestBody === null || is_undefined($requestBody)) {
             return null;
         }
 
@@ -428,25 +426,24 @@ final class SpecTreeBuilder
         $examples = [];
         $schemaRef = null;
         $description = SchemaAccessor::undefinedToNull($requestBody->description);
-        $required
-            = !Generator::isDefault($requestBody->required) && $requestBody->required === true;
+        $required = $requestBody->required === true;
 
         $content = $requestBody->content;
 
-        if (is_array($content) && !Generator::isDefault($content)) {
+        if (is_array($content) && is_defined($content)) {
             foreach ($content as $mediaType) {
-                if (Generator::isDefault($mediaType)) {
+                if (is_undefined($mediaType)) {
                     continue;
                 }
 
-                if ($mediaType instanceof OA\MediaType && !Generator::isDefault($mediaType->mediaType)) {
+                if ($mediaType instanceof OA\MediaType && is_defined($mediaType->mediaType)) {
                     $contentTypes[] = $mediaType->mediaType;
                 }
 
                 if ($fields === [] && $schemaRef === null) {
                     $schema = $mediaType->schema ?? null;
 
-                    if ($schema !== null && !is_array($schema) && !Generator::isDefault($schema)) {
+                    if ($schema !== null && !is_array($schema) && is_defined($schema)) {
                         $ref = SchemaAccessor::extractRef($schema);
 
                         if ($ref !== null) {
@@ -459,9 +456,9 @@ final class SpecTreeBuilder
 
                 $mediaTypeExamples = $mediaType->examples ?? Generator::UNDEFINED;
 
-                if (is_array($mediaTypeExamples) && !Generator::isDefault($mediaTypeExamples)) {
+                if (is_array($mediaTypeExamples) && is_defined($mediaTypeExamples)) {
                     foreach ($mediaTypeExamples as $mediaTypeExample) {
-                        if (Generator::isDefault($mediaTypeExample)) {
+                        if (is_undefined($mediaTypeExample)) {
                             continue;
                         }
 
@@ -497,18 +494,16 @@ final class SpecTreeBuilder
      * Recursively build field nodes from JSON Schema properties.
      *
      * Resolves `allOf` composition: a schema written as
-     * `allOf: [{$ref: '#/components/schemas/Base'}, {properties: {…}}]`
-     * exposes both the inherited properties from the `$ref` branch and any
-     * properties declared on the local schema. The `required` list is merged
-     * the same way. `oneOf` / `anyOf` are intentionally left untouched —
-     * they represent alternatives, not composition. Cycles in the `$ref`
-     * graph (`A`'s `allOf` references `B` whose `allOf` references `A`) are
-     * broken with a visited-set guard keyed by component name; the local
-     * declarations on each visited schema still contribute, but the chain
-     * stops as soon as the same component is encountered a second time.
+     * `allOf: [{$ref: '#/components/schemas/Base'}, {properties: {…}}]` exposes both the inherited
+     * properties from the `$ref` branch and any properties declared on the local schema.
+     * The `required` list is merged the same way. `oneOf` / `anyOf` are intentionally left
+     * untouched — they represent alternatives, not composition. Cycles in the `$ref` graph (`A`'s
+     * `allOf` references `B` whose `allOf` references `A`) are broken with a visited-set guard
+     * keyed by component name; the local declarations on each visited schema still contribute, but
+     * the chain stops as soon as the same component is encountered a second time.
      *
-     * @param array<string, true> $visited Component names already merged in
-     *                                     the current resolution chain.
+     * @param array<string, true> $visited Component names already merged in the current
+     *                                     resolution chain.
      *
      * @return list<FieldNode>
      *
@@ -518,7 +513,7 @@ final class SpecTreeBuilder
     {
         if (
             $schema === null
-            || Generator::isDefault($schema)
+            || is_undefined($schema)
         ) {
             return [];
         }
@@ -542,7 +537,7 @@ final class SpecTreeBuilder
                 nullable: SchemaAccessor::isNullable($property),
                 description: SchemaAccessor::undefinedToNull($property->description),
                 format: SchemaAccessor::undefinedToNull($property->format),
-                example: !Generator::isDefault($property->example)
+                example: is_defined($property->example)
                     ? $property->example
                     : null,
                 enum: SchemaAccessor::extractSchemaEnum($property),
@@ -568,13 +563,12 @@ final class SpecTreeBuilder
     }
 
     /**
-     * Collect the merged `(name => Property, list<string> required)` pair for a schema,
-     * walking each `allOf` branch and following `$ref`s into the component-schema index
-     * with a cycle guard.
+     * Collect the merged `(name => Property, list<string> required)` pair for a schema, walking
+     * each `allOf` branch and following `$ref`s into the component-schema index with a cycle guard.
      *
-     * Property collisions resolve to the inline declaration on the schema being walked
-     * — local declarations override allOf-inherited ones (last-writer-wins via array
-     * merge order). The `required` list is unioned.
+     * Property collisions resolve to the inline declaration on the schema being walked — local
+     * declarations override allOf-inherited ones (last-writer-wins via array merge order).
+     * The `required` list is union-ed.
      *
      * @param array<string, true> $visited
      *
@@ -590,10 +584,7 @@ final class SpecTreeBuilder
 
         if (is_array($allOf)) {
             foreach ($allOf as $branch) {
-                if (
-                    !$branch instanceof OA\Schema
-                    || Generator::isDefault($branch)
-                ) {
+                if (!$branch instanceof OA\Schema || is_undefined($branch)) {
                     continue;
                 }
 
@@ -626,7 +617,10 @@ final class SpecTreeBuilder
                     continue;
                 }
 
-                [$inherited, $branchRequired] = $this->collectComposedProperties($branch, $visited);
+                [$inherited, $branchRequired] = $this->collectComposedProperties(
+                    $branch,
+                    $visited,
+                );
 
                 foreach ($inherited as $name => $property) {
                     $properties[$name] = $property;
@@ -642,14 +636,11 @@ final class SpecTreeBuilder
 
         if (is_array($localProperties)) {
             foreach ($localProperties as $property) {
-                if (
-                    !$property instanceof OA\Property
-                    || Generator::isDefault($property)
-                ) {
+                if (!$property instanceof OA\Property || is_undefined($property)) {
                     continue;
                 }
 
-                $name = !Generator::isDefault($property->property)
+                $name = is_defined($property->property)
                     ? $property->property
                     : '(unknown)';
 
@@ -657,7 +648,7 @@ final class SpecTreeBuilder
             }
         }
 
-        if (is_array($schema->required) && !Generator::isDefault($schema->required)) {
+        if (is_array($schema->required) && is_defined($schema->required)) {
             foreach ($schema->required as $name) {
                 $required[] = $name;
             }
@@ -673,16 +664,17 @@ final class SpecTreeBuilder
      */
     private function buildExamplesFromSchema(OA\Schema $schema): array
     {
-        $examples = $schema->examples ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
+        $examples = $schema->examples ?? Generator::UNDEFINED;
 
-        if (!is_array($examples) || Generator::isDefault($examples)) {
+        if (!is_array($examples) || is_undefined($examples)) {
             return [];
         }
 
         $result = [];
 
         foreach ($examples as $example) {
-            if (Generator::isDefault($example)) {
+            if (is_undefined($example)) {
                 continue;
             }
 
@@ -703,19 +695,19 @@ final class SpecTreeBuilder
     {
         $responses = $operation->responses;
 
-        if (!is_array($responses) || Generator::isDefault($responses)) {
+        if (!is_array($responses) || is_undefined($responses)) {
             return [];
         }
 
         $result = [];
 
         foreach ($responses as $response) {
-            if (Generator::isDefault($response)) {
+            if (is_undefined($response)) {
                 continue;
             }
 
             $statusCode
-                = !Generator::isDefault($response->response)
+                = is_defined($response->response)
                 ? $response->response
                 : 'default';
 
@@ -726,11 +718,12 @@ final class SpecTreeBuilder
             $headers = [];
             $links = [];
 
-            $content = $response->content ?? Generator::UNDEFINED; // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
+            $content = $response->content ?? Generator::UNDEFINED;
 
-            if (is_array($content) && !Generator::isDefault($content)) {
+            if (is_array($content) && is_defined($content)) {
                 foreach ($content as $mediaType) {
-                    if (Generator::isDefault($mediaType)) {
+                    if (is_undefined($mediaType)) {
                         continue;
                     }
 
@@ -740,7 +733,7 @@ final class SpecTreeBuilder
                         if (
                             $schema !== null
                             && !is_array($schema)
-                            && !Generator::isDefault($schema)
+                            && is_defined($schema)
                         ) {
                             $ref = SchemaAccessor::extractRef($schema);
 
@@ -756,10 +749,10 @@ final class SpecTreeBuilder
 
                     if (
                         is_array($mediaTypeExamples)
-                        && !Generator::isDefault($mediaTypeExamples)
+                        && is_defined($mediaTypeExamples)
                     ) {
                         foreach ($mediaTypeExamples as $mediaTypeExample) {
-                            if (Generator::isDefault($mediaTypeExample)) {
+                            if (is_undefined($mediaTypeExample)) {
                                 continue;
                             }
 
@@ -769,12 +762,12 @@ final class SpecTreeBuilder
                 }
             }
 
-            // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
             $oaHeaders = $response->headers ?? Generator::UNDEFINED;
 
-            if (is_array($oaHeaders) && !Generator::isDefault($oaHeaders)) {
+            if (is_array($oaHeaders) && is_defined($oaHeaders)) {
                 foreach ($oaHeaders as $header) {
-                    if (Generator::isDefault($header)) {
+                    if (is_undefined($header)) {
                         continue;
                     }
 
@@ -782,12 +775,12 @@ final class SpecTreeBuilder
                 }
             }
 
-            // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
             $oaLinks = $response->links ?? Generator::UNDEFINED;
 
-            if (is_array($oaLinks) && !Generator::isDefault($oaLinks)) {
+            if (is_array($oaLinks) && is_defined($oaLinks)) {
                 foreach ($oaLinks as $link) {
-                    if (Generator::isDefault($link)) {
+                    if (is_undefined($link)) {
                         continue;
                     }
 
@@ -832,13 +825,13 @@ final class SpecTreeBuilder
     private function buildHeader(OA\Header $header): HeaderNode
     {
         return new HeaderNode(
-            name: !Generator::isDefault($header->header)
+            name: is_defined($header->header)
                 ? $header->header
                 : '(unknown)',
-            // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
             schema: SchemaAccessor::extractSchemaType($header->schema ?? null),
             description: SchemaAccessor::undefinedToNull($header->description),
-            required: !Generator::isDefault($header->required)
+            required: is_defined($header->required)
             && $header->required === true,
             raw: $header,
         );
@@ -849,7 +842,7 @@ final class SpecTreeBuilder
         $parameters = [];
         $oaParams = $link->parameters;
 
-        if (is_array($oaParams) && !Generator::isDefault($oaParams)) {
+        if (is_array($oaParams) && is_defined($oaParams)) {
             foreach ($oaParams as $key => $value) {
                 if (is_string($key) && is_string($value)) {
                     $parameters[$key] = $value;
@@ -858,7 +851,7 @@ final class SpecTreeBuilder
         }
 
         return new LinkNode(
-            name: !Generator::isDefault($link->link)
+            name: is_defined($link->link)
                 ? $link->link
                 : '(unnamed)',
             operationId: SchemaAccessor::undefinedToNull($link->operationId),
@@ -876,21 +869,21 @@ final class SpecTreeBuilder
     {
         $security = $operation->security;
 
-        if (!is_array($security) || Generator::isDefault($security)) {
+        if (!is_array($security) || is_undefined($security)) {
             return [];
         }
 
         $result = [];
 
         foreach ($security as $requirement) {
-            if (Generator::isDefault($requirement)) {
+            if (is_undefined($requirement)) {
                 continue;
             }
 
             // OA\SecurityScheme annotation — varies by swagger-php version
             if ($requirement instanceof OA\SecurityScheme) {
                 $scheme
-                    = !Generator::isDefault($requirement->securityScheme)
+                    = is_defined($requirement->securityScheme)
                     ? $requirement->securityScheme
                     : '(unknown)';
                 $result[] = ['scheme' => $scheme, 'scopes' => []];
@@ -899,7 +892,7 @@ final class SpecTreeBuilder
                     $result[] = [
                         'scheme' => (string) $scheme,
                         'scopes' => is_array($scopes)
-                            ? array_values(array_map('strval', $scopes))
+                            ? array_values(array_map(strval(...), $scopes))
                             : [],
                     ];
                 }
@@ -916,14 +909,14 @@ final class SpecTreeBuilder
     {
         $tags = $operation->tags;
 
-        if (!is_array($tags) || Generator::isDefault($tags)) {
+        if (!is_array($tags) || is_undefined($tags)) {
             return [];
         }
 
         return array_values(
             array_filter(
                 $tags,
-                // @phpstan-ignore function.alreadyNarrowedType (defensive; OA\Operation::$tags may contain non-strings at runtime)
+                // @phpstan-ignore function.alreadyNarrowedType (OA\Operation::$tags may contain non-strings at runtime)
                 static fn($tag): bool => is_string($tag),
             ),
         );
@@ -938,25 +931,25 @@ final class SpecTreeBuilder
     {
         $components = $spec->components;
 
-        if ($components === null || Generator::isDefault($components)) {
+        if ($components === null || is_undefined($components)) {
             return [];
         }
 
         $schemas = $components->schemas;
 
-        if (!is_array($schemas) || Generator::isDefault($schemas)) {
+        if (!is_array($schemas) || is_undefined($schemas)) {
             return [];
         }
 
         $result = [];
 
         foreach ($schemas as $schema) {
-            if (Generator::isDefault($schema)) {
+            if (is_undefined($schema)) {
                 continue;
             }
 
             $name
-                = !Generator::isDefault($schema->schema)
+                = is_defined($schema->schema)
                 ? $schema->schema
                 : '(unknown)';
 
@@ -988,31 +981,31 @@ final class SpecTreeBuilder
      */
     private function buildWebhooks(OA\OpenApi $spec): array
     {
-        // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
         $webhooks = $spec->webhooks ?? Generator::UNDEFINED;
 
-        if (!is_array($webhooks) || Generator::isDefault($webhooks)) {
+        if (!is_array($webhooks) || is_undefined($webhooks)) {
             return [];
         }
 
         $result = [];
 
         foreach ($webhooks as $name => $pathItem) {
-            if (Generator::isDefault($pathItem)) {
+            if (is_undefined($pathItem)) {
                 continue;
             }
 
             $webhookName = is_string($name) ? $name : '(unknown)';
 
             $description = SchemaAccessor::undefinedToNull(
-                // @phpstan-ignore nullCoalesce.property (defensive; swagger-php may leave property unset at runtime)
+                // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
                 $pathItem->description ?? Generator::UNDEFINED,
             );
 
             foreach (HttpMethod::cases() as $method) {
                 $oaOperation = $pathItem->{$method->value} ?? null;
 
-                if ($oaOperation === null || Generator::isDefault($oaOperation)) {
+                if ($oaOperation === null || is_undefined($oaOperation)) {
                     continue;
                 }
 
@@ -1046,7 +1039,7 @@ final class SpecTreeBuilder
     {
         $tags = $spec->tags;
 
-        if (!is_array($tags) || Generator::isDefault($tags)) {
+        if (!is_array($tags) || is_undefined($tags)) {
             return [[], []];
         }
 
@@ -1054,11 +1047,11 @@ final class SpecTreeBuilder
         $descriptions = [];
 
         foreach ($tags as $tag) {
-            if (Generator::isDefault($tag)) {
+            if (is_undefined($tag)) {
                 continue;
             }
 
-            $name = !Generator::isDefault($tag->name) ? $tag->name : null;
+            $name = is_defined($tag->name) ? $tag->name : null;
 
             if ($name === null) {
                 continue;
@@ -1066,7 +1059,7 @@ final class SpecTreeBuilder
 
             $names[] = $name;
             $desc
-                = !Generator::isDefault($tag->description)
+                = is_defined($tag->description)
                 ? $tag->description
                 : null;
 

--- a/src/Lint/TreeIndex.php
+++ b/src/Lint/TreeIndex.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Radiergummi\OpenApi\Lint\Tree\ApiNode;
 use Radiergummi\OpenApi\Lint\Tree\ComponentSchemaNode;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
@@ -13,6 +12,7 @@ use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use function is_string;
 use function preg_match;
 use function property_exists;
+use function Radiergummi\OpenApi\is_undefined;
 use function strtoupper;
 
 /**
@@ -119,7 +119,7 @@ final readonly class TreeIndex
 
             $ref = $annotation->ref;
 
-            if (Generator::isDefault($ref) || $ref === null || !is_string($ref)) {
+            if (is_undefined($ref) || $ref === null || !is_string($ref)) {
                 return;
             }
 

--- a/src/Plugins/Core/Support/SchemaFromFormRequest.php
+++ b/src/Plugins/Core/Support/SchemaFromFormRequest.php
@@ -7,7 +7,6 @@ namespace Radiergummi\OpenApi\Plugins\Core\Support;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Foundation\Http\FormRequest;
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Psr\Log\LoggerInterface;
 use Radiergummi\OpenApi\Attributes\FieldAttribute;
 use Radiergummi\OpenApi\Lint\Finding;
@@ -27,6 +26,8 @@ use function array_any;
 use function array_key_exists;
 use function class_basename;
 use function is_string;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 use function sprintf;
 
 /**
@@ -164,12 +165,12 @@ final readonly class SchemaFromFormRequest
             // #[RequestField] attribute on a PARAM_* constant) rather than the rules-derived
             // descriptor values — otherwise a type change in the override produces a wrong-typed
             // example.
-            if (Generator::isDefault($property->example)) {
-                if (is_string($property->type) && !Generator::isDefault($property->type)) {
+            if (is_undefined($property->example)) {
+                if (is_string($property->type) && is_defined($property->type)) {
                     $descriptor->type = $property->type;
                 }
 
-                if (is_string($property->format) && !Generator::isDefault($property->format)) {
+                if (is_string($property->format) && is_defined($property->format)) {
                     $descriptor->format = $property->format;
                 }
 

--- a/src/Plugins/SpatieData/Support/SchemaFromDataClass.php
+++ b/src/Plugins/SpatieData/Support/SchemaFromDataClass.php
@@ -57,6 +57,7 @@ use function is_float;
 use function is_int;
 use function is_string;
 use function preg_match;
+use function Radiergummi\OpenApi\is_defined;
 use function sprintf;
 
 /**
@@ -628,7 +629,7 @@ final class SchemaFromDataClass implements FilePropertyChecker
         foreach ($allowlist as $field) {
             $value = $schema->{$field};
 
-            if (!Generator::isDefault($value)) {
+            if (is_defined($value)) {
                 $props[$field] = $value;
             }
         }
@@ -798,16 +799,16 @@ final class SchemaFromDataClass implements FilePropertyChecker
      */
     private function synthesiseExample(string $wireName, OA\Property $property): void
     {
-        if (!Generator::isDefault($property->example)) {
+        if (is_defined($property->example)) {
             return;
         }
 
         // Composed or referenced schemas — Faker has nothing useful to contribute.
         if (
-            !Generator::isDefault($property->ref)
-            || !Generator::isDefault($property->oneOf)
-            || !Generator::isDefault($property->allOf)
-            || !Generator::isDefault($property->anyOf)
+            is_defined($property->ref)
+            || is_defined($property->oneOf)
+            || is_defined($property->allOf)
+            || is_defined($property->anyOf)
         ) {
             return;
         }
@@ -816,7 +817,7 @@ final class SchemaFromDataClass implements FilePropertyChecker
         // `Generator::UNDEFINED` is itself a string sentinel, so `is_string()` is not enough —
         // we must reject the sentinel explicitly or it leaks into the descriptor as a literal
         // value (and silently bypasses the byFieldName guard which only fires for `null`/'string').
-        $type = (is_string($property->type) && !Generator::isDefault($property->type))
+        $type = (is_string($property->type) && is_defined($property->type))
             ? $property->type
             : null;
 
@@ -826,7 +827,7 @@ final class SchemaFromDataClass implements FilePropertyChecker
 
         $descriptor = new FieldDescriptor();
         $descriptor->type = $type;
-        $descriptor->format = (is_string($property->format) && !Generator::isDefault($property->format))
+        $descriptor->format = (is_string($property->format) && is_defined($property->format))
             ? $property->format
             : null;
 

--- a/src/Support/Extraction/FieldDescriptor.php
+++ b/src/Support/Extraction/FieldDescriptor.php
@@ -10,6 +10,8 @@ use OpenApi\Generator;
 use function in_array;
 use function is_array;
 use function is_string;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 
 /**
  * Mutable accumulator for the JSON Schema fields derived from a single Laravel validation field's
@@ -121,34 +123,34 @@ final class FieldDescriptor
         // pass and must not be clobbered by the validation-rules pass (e.g. Spatie Data emits
         // type:'array' for nested Data classes even though the resolved schema is a $ref-in-oneOf).
         $alreadyComposed = !$overwrite
-            && (!Generator::isDefault($target->oneOf)
-                || !Generator::isDefault($target->allOf)
-                || !Generator::isDefault($target->anyOf));
+            && (is_defined($target->oneOf)
+                || is_defined($target->allOf)
+                || is_defined($target->anyOf));
 
-        if (!$alreadyComposed && $this->type !== null && ($overwrite || Generator::isDefault($target->type))) {
+        if (!$alreadyComposed && $this->type !== null && ($overwrite || is_undefined($target->type))) {
             $target->type = $this->type;
 
             // swagger-php requires every `type: array` schema to carry an `items` annotation.
             // Inject an empty fallback when no items has been set by the type-resolution pass or
             // a foo.* wildcard rule. This covers both OA\Property and OA\Items targets.
-            if ($this->type === 'array' && Generator::isDefault($target->items)) {
+            if ($this->type === 'array' && is_undefined($target->items)) {
                 $target->items = new OA\Items([]);
             }
         }
 
-        if ($this->format !== null && ($overwrite || Generator::isDefault($target->format))) {
+        if ($this->format !== null && ($overwrite || is_undefined($target->format))) {
             $target->format = $this->format;
         }
 
-        if ($this->enum !== null && ($overwrite || Generator::isDefault($target->enum))) {
+        if ($this->enum !== null && ($overwrite || is_undefined($target->enum))) {
             $target->enum = $this->enum;
         }
 
-        if ($this->pattern !== null && ($overwrite || Generator::isDefault($target->pattern))) {
+        if ($this->pattern !== null && ($overwrite || is_undefined($target->pattern))) {
             $target->pattern = $this->pattern;
         }
 
-        if ($this->description !== null && ($overwrite || Generator::isDefault($target->description))) {
+        if ($this->description !== null && ($overwrite || is_undefined($target->description))) {
             $target->description = $this->description;
         }
 
@@ -188,28 +190,28 @@ final class FieldDescriptor
         // - Already composed (oneOf/allOf/anyOf already set by the type-resolution pass): skip —
         //   the nullable wrapping was already applied upstream (e.g. via NullableSchema::wrap).
         if ($this->nullable && !$alreadyComposed) {
-            if (is_string($target->type) && !Generator::isDefault($target->type)) {
+            if (is_string($target->type) && is_defined($target->type)) {
                 if (in_array($target->type, ['array', 'object'], strict: true)) {
                     // Structured type: pull type (and structured keywords if present) into a oneOf
                     // inner schema so the outer schema carries oneOf and the inner keeps the type.
                     $inner = new OA\Schema(['type' => $target->type]);
 
-                    if (!Generator::isDefault($target->items)) {
+                    if (is_defined($target->items)) {
                         $inner->items = $target->items;
                         $target->items = Generator::UNDEFINED; // @phpstan-ignore assign.propertyType (clearing the property; swagger-php uses the UNDEFINED sentinel string here)
                     }
 
-                    if (!Generator::isDefault($target->properties)) {
+                    if (is_defined($target->properties)) {
                         $inner->properties = $target->properties;
                         $target->properties = Generator::UNDEFINED; // @phpstan-ignore assign.propertyType (clearing the property; swagger-php uses the UNDEFINED sentinel string here)
                     }
 
-                    if (!Generator::isDefault($target->additionalProperties)) {
+                    if (is_defined($target->additionalProperties)) {
                         $inner->additionalProperties = $target->additionalProperties;
                         $target->additionalProperties = Generator::UNDEFINED; // @phpstan-ignore assign.propertyType (clearing the property; swagger-php uses the UNDEFINED sentinel string here)
                     }
 
-                    if (!Generator::isDefault($target->required)) {
+                    if (is_defined($target->required)) {
                         $inner->required = $target->required;
                         $target->required = Generator::UNDEFINED; // @phpstan-ignore assign.propertyType (clearing the property; swagger-php uses the UNDEFINED sentinel string here)
                     }
@@ -225,7 +227,7 @@ final class FieldDescriptor
                 }
             } elseif (is_array($target->type) && !in_array('null', $target->type, strict: true)) {
                 $target->type = [...$target->type, 'null'];
-            } elseif (Generator::isDefault($target->type)) {
+            } elseif (is_undefined($target->type)) {
                 $target->type = ['null'];
             }
         }

--- a/src/Support/Generator/NullableSchema.php
+++ b/src/Support/Generator/NullableSchema.php
@@ -10,6 +10,8 @@ use OpenApi\Generator;
 use function in_array;
 use function is_array;
 use function is_string;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
 
 /**
  * OAS 3.1-compatible nullable schema wrapping.
@@ -49,7 +51,7 @@ final class NullableSchema
     {
 
         // $ref branch: extra fields alongside $ref are ignored by validators in OAS 3.1.
-        if (!Generator::isDefault($schema->ref) && is_string($schema->ref)) {
+        if (is_defined($schema->ref) && is_string($schema->ref)) {
             return new OA\Schema([
                 'oneOf' => [
                     new OA\Schema(['ref' => $schema->ref]),
@@ -60,7 +62,7 @@ final class NullableSchema
 
         // Scalar plain-type branch: widen to a type array that includes 'null'.
         if (
-            !Generator::isDefault($schema->type)
+            is_defined($schema->type)
             && is_string($schema->type)
             && in_array($schema->type, self::SCALAR_TYPES, strict: true)
         ) {
@@ -72,7 +74,7 @@ final class NullableSchema
 
         // Already a type array (caller passed a pre-widened scalar schema): add 'null' if absent.
         // Only safe when all existing types are scalars (no 'array' or 'object' mixed in).
-        if (!Generator::isDefault($schema->type) && is_array($schema->type)) {
+        if (is_defined($schema->type) && is_array($schema->type)) {
             $hasStructured = false;
 
             foreach ($schema->type as $type) {
@@ -120,11 +122,11 @@ final class NullableSchema
     public static function applyTo(OA\Schema $target): void
     {
 
-        if (is_string($target->type) && !Generator::isDefault($target->type)) {
+        if (is_string($target->type) && is_defined($target->type)) {
             if (in_array($target->type, ['array', 'object'], strict: true)) {
                 $inner = new OA\Schema(['type' => $target->type]);
 
-                if (!Generator::isDefault($target->items)) {
+                if (is_defined($target->items)) {
                     $inner->items = $target->items;
                     $target->items = Generator::UNDEFINED; // @phpstan-ignore assign.propertyType (clearing the property; swagger-php uses the UNDEFINED sentinel string here)
                 }
@@ -140,7 +142,7 @@ final class NullableSchema
             }
         } elseif (is_array($target->type) && !in_array('null', $target->type, strict: true)) {
             $target->type = [...$target->type, 'null'];
-        } elseif (Generator::isDefault($target->type)) {
+        } elseif (is_undefined($target->type)) {
             $target->type = ['null'];
         }
     }

--- a/src/Support/Generator/Stages/OverridesStage.php
+++ b/src/Support/Generator/Stages/OverridesStage.php
@@ -6,7 +6,6 @@ namespace Radiergummi\OpenApi\Support\Generator\Stages;
 
 use Illuminate\Container\Attributes\Scoped;
 use OpenApi\Annotations as OA;
-use OpenApi\Generator;
 use Radiergummi\OpenApi\Contracts\Generator\SpecStage;
 use Radiergummi\OpenApi\Enums\HttpMethod;
 use Radiergummi\OpenApi\Generator\GenerationContext;
@@ -14,6 +13,7 @@ use Radiergummi\OpenApi\Support\Generator\OverrideMatcher;
 use Radiergummi\OpenApi\Support\Generator\SpecPipeline;
 
 use function is_array;
+use function Radiergummi\OpenApi\is_undefined;
 use function str_starts_with;
 use function substr;
 
@@ -43,7 +43,7 @@ final readonly class OverridesStage implements SpecStage
         }
 
         foreach ($document->paths as $pathItem) {
-            if (!$pathItem instanceof OA\PathItem || Generator::isDefault($pathItem->path)) {
+            if (!$pathItem instanceof OA\PathItem || is_undefined($pathItem->path)) {
                 continue;
             }
 
@@ -75,7 +75,7 @@ final readonly class OverridesStage implements SpecStage
     {
         foreach ($fields as $field => $value) {
             if (str_starts_with($field, 'x-')) {
-                $x = Generator::isDefault($operation->x) ? [] : $operation->x;
+                $x = is_undefined($operation->x) ? [] : $operation->x;
                 $x[substr($field, 2)] = $value;
                 $operation->x = $x;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi;
+
+use OpenApi\Generator;
+
+/**
+ * Whether a swagger-php annotation value is still the {@see Generator::UNDEFINED} sentinel.
+ *
+ * swagger-php leaves unset annotation fields as the magic string `Generator::UNDEFINED` rather
+ * than `null`. Comparing that sentinel against a property whose declared type does not include
+ * it makes PHPStan report `identical.alwaysFalse`; routing the check through this `mixed`-typed
+ * predicate keeps the comparison out of static analysis' reach, so call sites stay clean.
+ *
+ * @internal
+ */
+function is_undefined(mixed $value): bool
+{
+    return Generator::isDefault($value);
+}
+
+/**
+ * Whether a swagger-php annotation value is set — i.e. not the {@see Generator::UNDEFINED} sentinel.
+ *
+ * The inverse of {@see is_undefined()}.
+ *
+ * @internal
+ */
+function is_defined(mixed $value): bool
+{
+    return !Generator::isDefault($value);
+}


### PR DESCRIPTION
Stacked on #73.

## Why
`$x === Generator::UNDEFINED` compares swagger-php's string sentinel against typed properties, which PHPStan flags as `identical.alwaysFalse`. The noise was being suppressed with inline `@phpstan-ignore identical.alwaysFalse` comments and a `$undefined = Generator::UNDEFINED;` local-alias hack.

## What
- New `src/functions.php` (autoloaded via `composer.json` `autoload.files`) with two `@internal` namespaced helpers:
  - `is_undefined(mixed $value): bool` → `Generator::isDefault($value)`
  - `is_defined(mixed $value): bool` → `!Generator::isDefault($value)`

  Routing the check through a `mixed`-typed predicate keeps it out of static analysis' reach, so call sites need no inline ignores.
- Swept all ~180 comparison sites onto the helpers; dropped the redundant `@phpstan-ignore` comments and the local-alias trick.
- Removed three dead `is_defined()/is_undefined()` clauses (`SpecTreeBuilder` `required`/`deprecated`, `SchemaNullableViaDeprecatedKeyword`) where a sibling `=== true`/`!== true` already excludes the string sentinel — behaviour-preserving.

## Not included
Two pre-existing reuse duplications (`SchemaConstraintsMissing`, `SchemaEnumEmpty` open-coding `SchemaAccessor` normalization) — left alone; their fix is behaviour-sensitive (`array_values` reindex) and out of scope here.

## Verification
- `vendor/bin/pint --test` — passed
- `composer lint` (PHPStan level 8) — No errors
- `composer test` — 1542 passed (3937 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)