### PR TITLE
feat: custom toEmitFinding() Pest expectation (#52)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -62,6 +62,13 @@ parameters:
             identifier: method.notFound
             paths:
                 - tests/
+        # `toEmitFinding()` is a custom expectation registered via `expect()->extend()` in
+        # tests/Pest.php; PHPStan can't see macros added to Pest's generic Expectation at runtime.
+        -
+            message: '#Call to an undefined method Pest\\Expectation<.+>::toEmitFinding\(\)#'
+            identifier: method.notFound
+            paths:
+                - tests/
         # Test fixtures exist to exercise the introspector and lint rules; demanding full
         # generic array shapes on every fixture controller method drowns the signal.
         -

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,12 +2,59 @@
 
 declare(strict_types=1);
 
+use Pest\Expectation;
+use PHPUnit\Framework\Assert;
+use Radiergummi\OpenApi\Lint\Finding;
 use Radiergummi\OpenApi\Support\Generator\OpenApiGenerator;
 use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
 use Radiergummi\OpenApi\Tests\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
 uses(TestCase::class)->in('Unit', 'Feature');
+
+/**
+ * Asserts that a rule emitted at least one {@see Finding} matching the given criteria.
+ *
+ * The value under expectation is the iterable of findings a rule produced — typically a
+ * visitor method's return (a Generator). It is normalised to an array and searched for a
+ * finding whose `ruleId` equals `$ruleId` and, when `$messageContains` is given, whose
+ * `message` contains that substring. On failure every emitted finding is listed so the
+ * mismatch is obvious.
+ *
+ *     expect($rule->checkField($field, $context))
+ *         ->toEmitFinding(ruleId: 'field.description-missing', messageContains: 'status');
+ */
+expect()->extend('toEmitFinding', function (string $ruleId, ?string $messageContains = null): Expectation {
+    /** @var iterable<Finding> $value */
+    $value = $this->value;
+    $findings = is_array($value)
+        ? array_values($value)
+        : array_values(iterator_to_array($value));
+
+    $matched = array_filter(
+        $findings,
+        static fn(Finding $finding): bool => $finding->ruleId === $ruleId
+            && ($messageContains === null || str_contains($finding->message, $messageContains)),
+    );
+
+    $criteria = $messageContains === null
+        ? "rule ID '{$ruleId}'"
+        : "rule ID '{$ruleId}' with a message containing '{$messageContains}'";
+
+    $emitted = $findings === []
+        ? 'no findings were emitted'
+        : "the findings emitted were:\n  - " . implode("\n  - ", array_map(
+            static fn(Finding $finding): string => "{$finding->ruleId}: {$finding->message}",
+            $findings,
+        ));
+
+    Assert::assertNotEmpty(
+        $matched,
+        "Failed asserting that a finding with {$criteria} was emitted; {$emitted}.",
+    );
+
+    return $this;
+});
 
 /**
  * Resolves a named parameter of a closure to its ReflectionParameter.

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -27,11 +27,9 @@ uses(TestCase::class)->in('Unit', 'Feature');
 expect()->extend('toEmitFinding', function (string $ruleId, ?string $messageContains = null): Expectation {
     /** @var iterable<Finding> $value */
     $value = $this->value;
-    $findings = is_array($value)
-        ? array_values($value)
-        : array_values(iterator_to_array($value));
+    $findings = is_array($value) ? $value : iterator_to_array($value);
 
-    $matched = array_filter(
+    $matched = array_any(
         $findings,
         static fn(Finding $finding): bool => $finding->ruleId === $ruleId
             && ($messageContains === null || str_contains($finding->message, $messageContains)),
@@ -48,7 +46,7 @@ expect()->extend('toEmitFinding', function (string $ruleId, ?string $messageCont
             $findings,
         ));
 
-    Assert::assertNotEmpty(
+    Assert::assertTrue(
         $matched,
         "Failed asserting that a finding with {$criteria} was emitted; {$emitted}.",
     );

--- a/tests/Unit/Lint/Rules/FieldDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/FieldDescriptionMissingTest.php
@@ -37,14 +37,8 @@ it('emits a finding when a field has a missing or blank description', function (
     $rule = new FieldDescriptionMissing();
     $field = makeFieldForDescription($description);
 
-    $findings = iterator_to_array(
-        $rule->checkField($field, OperationNodeFactory::emptyContext()),
-    );
-
-    expect($findings)->toHaveCount(1)
-        ->and($findings[0]->ruleId)->toBe('field.description-missing')
-        ->and($findings[0]->level)->toBe(2)
-        ->and($findings[0]->message)->toContain('status');
+    expect($rule->checkField($field, OperationNodeFactory::emptyContext()))
+        ->toEmitFinding(ruleId: 'field.description-missing', messageContains: 'status');
 })->with([
     'null'            => [null],
     'empty string'    => [''],

--- a/tests/Unit/Lint/Rules/ParameterDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/ParameterDescriptionMissingTest.php
@@ -32,14 +32,8 @@ it('emits a finding when a parameter has a missing or blank description', functi
     $rule = new ParameterDescriptionMissing();
     $parameter = makeParameterForDescription($description);
 
-    $findings = iterator_to_array(
-        $rule->checkParameter($parameter, OperationNodeFactory::emptyContext()),
-    );
-
-    expect($findings)->toHaveCount(1)
-        ->and($findings[0]->ruleId)->toBe('parameter.description-missing')
-        ->and($findings[0]->level)->toBe(2)
-        ->and($findings[0]->message)->toContain('filter');
+    expect($rule->checkParameter($parameter, OperationNodeFactory::emptyContext()))
+        ->toEmitFinding(ruleId: 'parameter.description-missing', messageContains: 'filter');
 })->with([
     'null'            => [null],
     'empty string'    => [''],

--- a/tests/Unit/Lint/Rules/SchemaDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaDescriptionMissingTest.php
@@ -21,14 +21,8 @@ it('emits a finding when a component schema has a missing or blank description',
         description: $description,
     );
 
-    $findings = iterator_to_array(
-        $rule->checkComponentSchema($schema, OperationNodeFactory::emptyContext()),
-    );
-
-    expect($findings)->toHaveCount(1)
-        ->and($findings[0]->ruleId)->toBe('schema.description-missing')
-        ->and($findings[0]->level)->toBe(2)
-        ->and($findings[0]->message)->toContain('ProjectResource');
+    expect($rule->checkComponentSchema($schema, OperationNodeFactory::emptyContext()))
+        ->toEmitFinding(ruleId: 'schema.description-missing', messageContains: 'ProjectResource');
 })->with([
     'null'            => [null],
     'empty string'    => [''],

--- a/tests/Unit/Lint/ToEmitFindingExpectationTest.php
+++ b/tests/Unit/Lint/ToEmitFindingExpectationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\AssertionFailedError;
+use Radiergummi\OpenApi\Lint\Finding;
+
+uses()->group('openapi', 'lint');
+
+it('passes when a matching finding was emitted', function (): void {
+    $findings = [new Finding(ruleId: 'field.description-missing', level: 2, message: 'Field "status" has no description.')];
+
+    expect($findings)->toEmitFinding(ruleId: 'field.description-missing', messageContains: 'status');
+});
+
+it('normalises a generator without a manual iterator_to_array call', function (): void {
+    $findings = (static function (): Generator {
+        yield new Finding(ruleId: 'operation.id-missing', level: 1, message: 'GET /users has no operationId.');
+    })();
+
+    expect($findings)->toEmitFinding(ruleId: 'operation.id-missing');
+});
+
+it('fails listing the emitted findings when no rule id matches', function (): void {
+    $findings = [new Finding(ruleId: 'other.rule', level: 1, message: 'something else')];
+
+    expect(function () use ($findings): void {
+        expect($findings)->toEmitFinding(ruleId: 'field.description-missing');
+    })->toThrow(AssertionFailedError::class, "rule ID 'field.description-missing'");
+});
+
+it('fails when the rule id matches but the message substring does not', function (): void {
+    $findings = [new Finding(ruleId: 'field.description-missing', level: 2, message: 'no relevant token here')];
+
+    expect(function () use ($findings): void {
+        expect($findings)->toEmitFinding(ruleId: 'field.description-missing', messageContains: 'status');
+    })->toThrow(AssertionFailedError::class, 'status');
+});
+
+it('reports that no findings were emitted when the iterable is empty', function (): void {
+    expect(function (): void {
+        expect([])->toEmitFinding(ruleId: 'field.description-missing');
+    })->toThrow(AssertionFailedError::class, 'no findings were emitted');
+});


### PR DESCRIPTION
Closes #52

## Plan

Lint-rule tests repeat the same dance ~326 times across ~80 files: build a node, call the rule's visitor, `iterator_to_array(...)`, then dig into the emitted `Finding` to check `ruleId` + message. This adds a custom Pest expectation that collapses the common case to one line.

### Steps
1. Register `toEmitFinding(ruleId:, messageContains:)` in `tests/Pest.php`.
   - Accepts the iterable a rule's visitor produces (normalises a `Traversable` via `iterator_to_array`).
   - Asserts at least one `Finding` matches `ruleId` (and, if given, `message` contains `messageContains`).
   - On failure, lists every finding actually emitted (`ruleId: message`) so the failure is debuggable.
   - Lean signature — only `ruleId` + `messageContains`, the dominant case.
2. Migrate ≥3 rule test files under `tests/Unit/Lint/Rules` as a POC (model: `FieldDescriptionMissingTest.php`).

### Verify
- `composer test` green
- Pint clean (`vendor/bin/pint --test`), PHPStan clean (`composer lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)