### PR TITLE
feat: close lint rule ↔ test coverage gap (#54)

### DIFF
--- a/tests/Unit/Lint/Rules/ErrorsResolverFailedTest.php
+++ b/tests/Unit/Lint/Rules/ErrorsResolverFailedTest.php
@@ -23,6 +23,10 @@ it('provides a non-empty description', function (): void {
     expect(new ErrorsResolverFailed()->description())->not->toBe('');
 });
 
-it('aliases the stage fix hint', function (): void {
-    expect(ErrorsResolverFailed::FIX_HINT)->toBe(ErrorResponseInferenceStage::RESOLVER_FAILED_FIX_HINT);
+it('exposes an actionable fix hint pointing at the resolver', function (): void {
+    // The hint is aliased from the stage; assert on its content so an accidental gutting of the
+    // message is caught (a plain `toBe` against the alias can never fail — PHP constants can't drift).
+    expect(ErrorsResolverFailed::FIX_HINT)
+        ->toBe(ErrorResponseInferenceStage::RESOLVER_FAILED_FIX_HINT)
+        ->toContain('ErrorResponseResolver');
 });

--- a/tests/Unit/Lint/Rules/ErrorsResolverFailedTest.php
+++ b/tests/Unit/Lint/Rules/ErrorsResolverFailedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Rules\ErrorsResolverFailed;
+use Radiergummi\OpenApi\Support\Generator\Stages\ErrorResponseInferenceStage;
+
+uses()->group('openapi', 'lint');
+
+// `errors.resolver-failed` is a registration stub — it has no visitor. The finding is emitted
+// by ErrorResponseInferenceStage (covered by ErrorResponseInferenceStageTest); these tests pin
+// the stub's registration contract so its identity stays stable.
+
+it('exposes the stable rule id', function (): void {
+    expect(new ErrorsResolverFailed()->id())->toBe('errors.resolver-failed');
+});
+
+it('reports a warning-level severity', function (): void {
+    expect(new ErrorsResolverFailed()->level())->toBe(2);
+});
+
+it('provides a non-empty description', function (): void {
+    expect(new ErrorsResolverFailed()->description())->not->toBe('');
+});
+
+it('aliases the stage fix hint', function (): void {
+    expect(ErrorsResolverFailed::FIX_HINT)->toBe(ErrorResponseInferenceStage::RESOLVER_FAILED_FIX_HINT);
+});

--- a/tests/Unit/Lint/Rules/HideExposeConflictTest.php
+++ b/tests/Unit/Lint/Rules/HideExposeConflictTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Rules\HideExposeConflict;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\HideExposeConflictController;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
+use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
+
+uses()->group('openapi', 'lint');
+
+function hideExposeConflictFindings(string $method): array
+{
+    return iterator_to_array(
+        new HideExposeConflict()->checkRoute(
+            ActionDescriptorFactory::forControllerMethod(HideExposeConflictController::class, $method),
+            OperationNodeFactory::emptyContext(),
+        ),
+    );
+}
+
+it('has the correct rule id and level', function (): void {
+    $rule = new HideExposeConflict();
+
+    expect($rule->id())->toBe('visibility.hide-expose-conflict')
+        ->and($rule->level())->toBe(1);
+});
+
+it('emits a finding when #[Hide] and #[Expose] both apply unconditionally', function (): void {
+    expect(hideExposeConflictFindings('both'))
+        ->toEmitFinding(ruleId: 'visibility.hide-expose-conflict', messageContains: 'both #[Hide] and #[Expose]');
+});
+
+it('emits a finding when env-scoped #[Hide]/#[Expose] overlap in the active environment', function (): void {
+    app()->detectEnvironment(fn(): string => 'production');
+
+    expect(hideExposeConflictFindings('envOverlap'))
+        ->toEmitFinding(ruleId: 'visibility.hide-expose-conflict', messageContains: 'production');
+});
+
+it('emits no finding when env-scoped attributes do not apply to the active environment', function (): void {
+    // envOverlap scopes both attributes to `production`; under the default `testing` env neither matches.
+    expect(hideExposeConflictFindings('envOverlap'))->toBe([]);
+});
+
+it('emits no finding when #[Hide] and #[Expose] env scopes are disjoint', function (): void {
+    expect(hideExposeConflictFindings('envDisjoint'))->toBe([]);
+});

--- a/tests/Unit/Lint/Rules/RequestEmptyTest.php
+++ b/tests/Unit/Lint/Rules/RequestEmptyTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Rules\RequestEmpty;
+
+uses()->group('openapi', 'lint');
+
+// `request.empty` is a registration stub — it has no visitor. The finding is emitted by
+// RequestBodyExtractor (covered by tests/Feature/Lint/RequestEmptyTest.php); these tests pin
+// the stub's registration contract so its identity stays stable.
+
+it('exposes the stable rule id', function (): void {
+    expect(new RequestEmpty()->id())->toBe('request.empty');
+});
+
+it('reports a warning-level severity', function (): void {
+    expect(new RequestEmpty()->level())->toBe(2);
+});
+
+it('provides a non-empty description', function (): void {
+    expect(new RequestEmpty()->description())->not->toBe('');
+});
+
+it('exposes the request-body fix hint', function (): void {
+    expect(RequestEmpty::FIX_HINT)->toContain('Data class or FormRequest');
+});

--- a/tests/Unit/Lint/Rules/VisibilityAttributeNoOpTest.php
+++ b/tests/Unit/Lint/Rules/VisibilityAttributeNoOpTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Rules\VisibilityAttributeNoOp;
+use Radiergummi\OpenApi\Support\Visibility\VisibilityMode;
+use Radiergummi\OpenApi\Support\Visibility\VisibilityResolver;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\VisibilityNoOpController;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
+use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
+
+uses()->group('openapi', 'lint');
+
+function visibilityNoOpFindings(VisibilityMode $mode, string $method): array
+{
+    return iterator_to_array(
+        new VisibilityAttributeNoOp(new VisibilityResolver($mode))->checkRoute(
+            ActionDescriptorFactory::forControllerMethod(VisibilityNoOpController::class, $method),
+            OperationNodeFactory::emptyContext(),
+        ),
+    );
+}
+
+it('has the correct rule id and level', function (): void {
+    $rule = new VisibilityAttributeNoOp(new VisibilityResolver(VisibilityMode::Public));
+
+    expect($rule->id())->toBe('visibility.attribute-no-op')
+        ->and($rule->level())->toBe(2);
+});
+
+it('flags an unconditional #[Expose] under public-default visibility', function (): void {
+    expect(visibilityNoOpFindings(VisibilityMode::Public, 'exposeInPublic'))
+        ->toEmitFinding(ruleId: 'visibility.attribute-no-op', messageContains: 'public-default');
+});
+
+it('flags an unconditional #[Hide] under hidden-default visibility', function (): void {
+    expect(visibilityNoOpFindings(VisibilityMode::Hidden, 'hideInHidden'))
+        ->toEmitFinding(ruleId: 'visibility.attribute-no-op', messageContains: 'hidden-default');
+});
+
+it('does not flag an env-scoped #[Expose] under public-default visibility', function (): void {
+    expect(visibilityNoOpFindings(VisibilityMode::Public, 'envScopedExposeInPublic'))->toBe([]);
+});
+
+it('does not flag an unconditional #[Hide] under public-default visibility', function (): void {
+    expect(visibilityNoOpFindings(VisibilityMode::Public, 'hideInHidden'))->toBe([]);
+});


### PR DESCRIPTION
Closes #54

Builds on the `toEmitFinding()` expectation from #52 (already merged via #79).

## What

Four concrete lint rules had no direct unit test. After this change, `src/Lint/Rules/*.php` vs `tests/Unit/Lint/Rules/*Test.php` has no gap (abstract bases `AbstractFieldRule`/`AbstractNamingRule` excluded; `SchemaAllOfTypeConflict` already covered — filename casing only).

**RouteRule shape — real `checkRoute()` visitors, violation + clean via existing `tests/Fixtures/Lint/` controllers:**
- `HideExposeConflict` (`visibility.hide-expose-conflict`, level 1) — unconditional `#[Hide]`+`#[Expose]` conflict; env-scoped overlap under `production`; clean when env scopes miss the active env or are disjoint.
- `VisibilityAttributeNoOp` (`visibility.attribute-no-op`, level 2) — unconditional `#[Expose]` (public default) and `#[Hide]` (hidden default) flagged; env-scoped expose and wrong-mode `#[Hide]` clean.

**Registration-stub shape — no visitor; finding emitted by a stage/extractor:**
- `ErrorsResolverFailed` (`errors.resolver-failed`) and `RequestEmpty` (`request.empty`) — pin the registration contract (`id`/`level`/`description`/`FIX_HINT`). Emission is already covered by `ErrorResponseInferenceStageTest` and `Feature/Lint/RequestEmptyTest`; these tests don't duplicate that, they lock the stub's stable identity.

## Verify
- `composer test` → 1583 passed
- `vendor/bin/pint --test` clean · `composer lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)