### PR TITLE
test: edge-case invariants — dup rule-id, YAML/JSON equivalence, Hide/Expose fall-through (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,15 @@ All notable changes to this project are documented here.
   `RouteSkipped` (alongside the existing `Visibility` and `SpecMembership`
   cases). Registers an inline `RouteFilter` via `openapi.filters` and asserts
   the event fires with the right reason and summary.
+- Edge-case coverage from the 2026-05-31 audit (#55): `tests/Unit/Lint/RuleRegistryTest.php`
+  pins the registry's current no-deduplication behaviour when two rules share an id (both are
+  kept, `forLevel` returns both, a severity override keyed by the id collapses both); a new
+  `OpenApiGeneratorTest` case asserts the YAML and JSON serialisers produce structurally
+  equivalent documents from one generation; and `VisibilityResolverTest` gains the fall-through
+  ordering cases where a present `#[Hide]` whose env scope misses defers to `#[Expose]`, then to
+  the configured default. (The audit's cyclic-schema and `RouteFilter`/`SpecStage` contract cases
+  were already covered by `SchemaFromDataClassTest`, `OpenApiGeneratorTest`, and
+  `PluginStageRegistrationTest`.)
 - Observability events. The generator and linter dispatch four Laravel events for use as
   read-only notification hooks (mutation still belongs to `OpenApiExtensions` transformers):
   `SpecGenerationStarted`, `SpecGenerationCompleted` (carries the assembled document and

--- a/tests/Unit/Lint/RuleRegistryTest.php
+++ b/tests/Unit/Lint/RuleRegistryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Lint\RuleRegistry;
+
+/** Builds a minimal {@see Rule} stub with the given id and level. */
+$rule = static fn(string $id, int $level): Rule => new readonly class ($id, $level) implements Rule {
+    public function __construct(private string $ruleId, private int $ruleLevel) {}
+
+    public function id(): string
+    {
+        return $this->ruleId;
+    }
+
+    public function level(): int
+    {
+        return max(0, $this->ruleLevel);
+    }
+
+    public function description(): string
+    {
+        return 'stub';
+    }
+};
+
+// The registry performs no duplicate-id detection; these tests pin the current observed
+// behaviour so a future change to that contract is a deliberate, visible one.
+
+it('keeps every rule when two share an id', function () use ($rule): void {
+    $registry = new RuleRegistry([$rule('fake.duplicate', 2), $rule('fake.duplicate', 4)]);
+
+    expect($registry->all())->toHaveCount(2)
+        ->and($registry->knownIds())->toBe(['fake.duplicate', 'fake.duplicate']);
+});
+
+it('returns both same-id rules from forLevel', function () use ($rule): void {
+    $registry = new RuleRegistry([$rule('fake.duplicate', 2), $rule('fake.duplicate', 4)]);
+
+    expect($registry->forLevel(4))->toHaveCount(2)
+        // The stricter of the two still passes a tighter level threshold.
+        ->and($registry->forLevel(2))->toHaveCount(1);
+});
+
+it('applies a severity override to every rule sharing the overridden id', function () use ($rule): void {
+    $registry = new RuleRegistry(
+        [$rule('fake.duplicate', 2), $rule('fake.duplicate', 4)],
+        ['fake.duplicate' => 0],
+    );
+
+    // The override is keyed by id, so both instances collapse to the remapped level.
+    expect($registry->effectiveLevelFor('fake.duplicate', 2))->toBe(0)
+        ->and($registry->maxLevel())->toBe(0);
+});

--- a/tests/Unit/Support/Generator/OpenApiGeneratorTest.php
+++ b/tests/Unit/Support/Generator/OpenApiGeneratorTest.php
@@ -50,6 +50,18 @@ it('serialises to both YAML and JSON', function (): void {
         ->toHaveKey('paths');
 });
 
+it('produces structurally equivalent YAML and JSON from a single generation', function (): void {
+    Route::get('/things', [SmokeController::class, 'plain']);
+
+    $spec = app(SpecRegistry::class)->default();
+    $document = app(OpenApiGenerator::class)->generate($spec, 'testing');
+
+    // Both serialisers must encode the same document; a divergence means one path mutates or
+    // drops state the other keeps.
+    expect(Yaml::parse($document->toYaml()))
+        ->toEqual(json_decode($document->toJson(), true));
+});
+
 it('does not leak component schemas between scopes', function (): void {
     // First run: register a route, generate the document, drop something into the registry.
     Route::get('/things', [SmokeController::class, 'plain']);

--- a/tests/Unit/Support/Visibility/VisibilityResolverTest.php
+++ b/tests/Unit/Support/Visibility/VisibilityResolverTest.php
@@ -7,6 +7,8 @@ use Radiergummi\OpenApi\Attributes\Hide;
 use Radiergummi\OpenApi\Support\Visibility\VisibilityMode;
 use Radiergummi\OpenApi\Support\Visibility\VisibilityResolver;
 
+uses()->group('openapi');
+
 $resolver = fn(VisibilityMode $mode = VisibilityMode::Public): VisibilityResolver => new VisibilityResolver($mode);
 
 it('returns visible in public default with no attributes', function () use ($resolver): void {

--- a/tests/Unit/Support/Visibility/VisibilityResolverTest.php
+++ b/tests/Unit/Support/Visibility/VisibilityResolverTest.php
@@ -49,3 +49,18 @@ it('lets Hide beat Expose when both apply', function () use ($resolver): void {
     expect($resolver()->isVisible([new Hide()], [new Expose()], 'production'))->toBeFalse()
         ->and($resolver(VisibilityMode::Hidden)->isVisible([new Hide()], [new Expose()], 'production'))->toBeFalse();
 });
+
+it('falls through to Expose when a present Hide misses the env', function () use ($resolver): void {
+    // Hide is present but scoped away from this env, so the next rule — Expose — decides; in the
+    // hidden default this is the only path to a visible route.
+    expect($resolver(VisibilityMode::Hidden)->isVisible([new Hide(only: ['local'])], [new Expose()], 'production'))
+        ->toBeTrue();
+});
+
+it('falls through to the default when both a present Hide and Expose miss the env', function () use ($resolver): void {
+    // Neither attribute applies in this env, so the configured default mode decides.
+    expect($resolver(VisibilityMode::Hidden)->isVisible([new Hide(only: ['local'])], [new Expose(only: ['staging'])], 'production'))
+        ->toBeFalse()
+        ->and($resolver()->isVisible([new Hide(only: ['local'])], [new Expose(only: ['staging'])], 'production'))
+        ->toBeTrue();
+});


### PR DESCRIPTION
Closes #55 (part of EPIC #70).

## Context — three of the five cases were already pinned

The codebase moved on since the 2026-05-31 audit that seeded #55. Investigation found three of the five listed cases already covered, so adding "dedicated" tests for them would only duplicate passing ones:

| Case | Status |
|------|--------|
| Cyclic / self-referential schema | ✅ `SchemaFromDataClassTest.php:133` (OAPI-008: `?self` → `$ref` to self; `CycleA→CycleB` indirect-cycle fixtures) |
| `RouteFilter` contract | ✅ `OpenApiGeneratorTest.php:71` (fake filter via `config('openapi.filters')` drops a route) |
| `SpecStage` contract | ✅ `PluginStageRegistrationTest.php` (fake stage mutates the document) |
| Duplicate rule id in `RuleRegistry` | ❌ genuine gap |
| YAML ↔ JSON equivalence | ⚠️ partial — both serialised, neither asserted equivalent |
| `#[Hide]`/`#[Expose]` precedence | ⚠️ missing the "present Hide whose env misses → fall through" ordering |

Per the maintainer's call, this PR fills only the genuine gaps (surgical, no duplication).

## Changes (test-only, Tier 0)

- **`tests/Unit/Lint/RuleRegistryTest.php`** (new) — pins the registry's current *no-deduplication* behaviour when two rules share an id: both are kept (`all()`/`knownIds()`), `forLevel` returns both, and a severity override keyed by the shared id collapses both. The registry has no dup-id detection today; this makes a future change to that contract deliberate and visible.
- **`OpenApiGeneratorTest.php`** — new case asserting `Yaml::parse(toYaml()) == json_decode(toJson(), true)` from one generation (the existing test only checked each had `paths`).
- **`VisibilityResolverTest.php`** — adds the two fall-through ordering cases: a present `#[Hide]` whose env scope misses defers to `#[Expose]`; when both miss, the configured default decides.
- **`CHANGELOG.md`** — `[Unreleased]` entry under Added.

## Acceptance

- `composer test` → 1571 passed · `vendor/bin/pint --test` passed · `composer lint` (PHPStan L8) no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)