### PR TITLE
feat: Eloquent model → response schema (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- Response schemas are now derived from Eloquent model metadata when a controller returns a model
+  (or a `Collection<Model>`) directly. The schema is built by reflection from `$casts`, the model's
+  `@property`/`@property-read` docblock, typed `$appends` accessors, and `$hidden`/`$visible`;
+  `@property-read` model relations become `$ref`s to nested component schemas. Document computed
+  fields with `@property-read` (or a typed legacy accessor) to include them. (#18)
 - `openapi:lint --fix` and `--check`: auto-fix for the mechanical, unambiguous lint findings. `--fix` rewrites the offending PHP source in place (then lists the modified files so you can run your formatter, e.g. `vendor/bin/pint --dirty`); `--check` is a CI-safe dry run that writes nothing and exits `1` when any fix is pending (like `vendor/bin/pint --test`). Both compose with `--only` / `--skip` / `--level` / `--path` / `--spec`. Phase 1 covers the Tier A removals — `tag.duplicate`, `queryparam.duplicate`, `response.duplicate-status`, `link.duplicate-name`, and `field.no-effect` — by deleting the redundant or no-op attribute via `nikic/php-parser` (now an explicit dependency); a rule opts in by implementing `Lint\Fix\FixableRule`. Findings without an owning fixable rule are reported, never rewritten. See [Linting → Auto-fixing findings](docs/linting.md#auto-fixing-findings).
 - `openapi.overrides` config key: a spec-only escape hatch to set operation-level fields (`operationId`, `summary`, `description`, `tags`, `deprecated`, and any `x-*` extension) per route name or URI glob, without touching controller code. Applied as a late pipeline stage (always loaded, independent of any plugin). Overrides beat plugin contributions and convention-derived values; a code-based `transformDocument()` callback still wins. URI globs match by specificity (literal-character count, ties broken by declaration order); an exact route-name key wins over any glob. See [Configuration → Operation overrides](docs/config.md#operation-overrides).
 - Lint rules `overrides.unknown-field` (flags an override field outside the allowlist) and `overrides.unused` (flags an override key matching no route name or URI). Both are level 3 and severity-overridable.

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -147,7 +147,7 @@ Article:
   properties:
     id:           { type: integer }
     name:         { type: string }
-    bio:          { type: string, nullable: true }
+    bio:          { type: [string, 'null'] }   # OAS 3.1 nullable idiom (the `nullable` keyword is gone)
     published:    { type: boolean }            # from $casts
     created_at:   { type: string, format: date-time }
     category:     { $ref: '#/components/schemas/Category' }  # Model relation, built recursively

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -12,6 +12,7 @@ source.
 | `operationId` | Route name (sanitised to a codegen-safe identifier — `:`/`{}` and other disallowed characters become `_`, while `.`/`-`/`_` are kept), or `{method}_{sanitized_path}`. |
 | Path parameters | Action signature. Type hints, `Route::whereUuid()` / `whereNumber()` / `where(...)` constraints, and route-model-binding heuristics drive type and format. |
 | Request body | Spatie Data class on the action (or on a configured payload-indirection object); `FormRequest` is supported natively. Schema is built from PHP types and validation rules. |
+| Response body | Spatie Data class or `DataCollection<…>` return type → component `$ref`. `JsonResource` subclass → component schema (fields declared via `#[ResourceField]`). Eloquent `Model` subclass → component schema built from `$casts`, `@property`/`@property-read` annotations, typed `$appends` accessors, and `$hidden`/`$visible`. See [Eloquent model response schemas](#eloquent-model-response-schemas). |
 | Security | `auth:*` / `scope:*` middleware → a per-operation `security` requirement against the derived scheme(s): Passport's OAuth2 flows, a `sanctum` http/bearer scheme when any route uses `auth:sanctum`, or `openapi.security_schemes`. When the route is authed but no scheme is derivable, `security` is omitted (not `[]`, which means *public*) and `operation.security-missing` flags it. |
 | Error responses | `@throws ExceptionClass` → status codes; `auth`/`scope`/`throttle` middleware → 401 / 403 / 429. |
 | Validation constraints | `Data::rules()` and Spatie validation attributes → `maxLength`, `minLength`, `pattern`, `enum`, `format`, `minimum`/`maximum`, `minItems`/`maxItems`. |
@@ -65,6 +66,131 @@ produces an operation with:
 `#[Tag]` is optional if the namespace-derived tag is acceptable; no other
 attributes are required here.
 
+## Eloquent model response schemas
+
+When a controller action's return type is an Eloquent `Model` subclass, the
+generator builds a component schema from the model's class-level metadata and
+emits a `200 application/json` response pointing to it. The same applies when
+the return type is `Illuminate\Support\Collection` or
+`Illuminate\Database\Eloquent\Collection` annotated with a `@return
+Collection<MyModel>` generic — the response schema becomes
+`{type: array, items: {$ref: '#/components/schemas/MyModel'}}`.
+
+Everything is derived from the class by reflection; no database connection or
+query is required.
+
+### Property sources and precedence
+
+The property set is the union of `$casts` keys, `$fillable`, `$appends`, and
+`@property`/`@property-read` names in the class docblock, filtered through
+`$hidden` (excluded) and `$visible` (when non-empty, acts as an allow-list).
+
+For each property, the type is resolved in this order:
+
+1. **`$casts`** — the cast value drives the schema type. `datetime` / `date` → `string` (format `date-time` / `date`); `decimal:N` → `string`; `array` / `json` / `object` / `collection` → object; a backed-enum class-string → inline `enum` schema listing the enum's cases.
+2. **`@property` / `@property-read` docblock** — scalar types (`int`, `bool`, `float`, `string`) are mapped directly; `?T` marks the property as nullable. A class type that is itself a `Model` subclass becomes a `$ref` to that model's component schema (built recursively; cycles are guarded).
+3. **`$appends` accessor return type** — a legacy-style accessor (`getReadingTimeAttribute(): int`) contributes its return type for an appended attribute.
+4. **Unknown** — if none of the above supply a type, an unconstrained schema with no `type` is emitted.
+
+### `required`
+
+A property appears in `required` only when it has a non-nullable
+`@property` or `@property-read` annotation. Properties known only from
+`$casts`, `$fillable`, or `$appends` are never required — they may be absent
+at runtime and the generator has no way to prove otherwise.
+
+### Example
+
+```php
+/**
+ * @property-read int          $id
+ * @property      string       $name
+ * @property      string|null  $bio
+ * @property-read Carbon       $created_at
+ * @property-read Category     $category   Eager-loaded relation.
+ */
+class Article extends Model
+{
+    protected $casts = [
+        'name'       => 'string',
+        'published'  => 'boolean',
+    ];
+
+    protected $hidden = ['password'];
+
+    public function getReadingTimeAttribute(): int
+    {
+        return (int) ceil(str_word_count($this->body) / 200);
+    }
+
+    protected $appends = ['reading_time'];
+}
+```
+
+```php
+class ArticleController extends Controller
+{
+    public function show(Article $article): Article
+    {
+        return $article;
+    }
+}
+```
+
+The generator emits a `200 application/json` response with
+`$ref: '#/components/schemas/Article'` and a component schema along these lines:
+
+```yaml
+Article:
+  type: object
+  required: [id, name, created_at, category]   # every non-nullable @property / @property-read
+  properties:
+    id:           { type: integer }
+    name:         { type: string }
+    bio:          { type: string, nullable: true }
+    published:    { type: boolean }            # from $casts
+    created_at:   { type: string, format: date-time }
+    category:     { $ref: '#/components/schemas/Category' }  # Model relation, built recursively
+    reading_time: { type: integer }            # from typed legacy accessor
+```
+
+`password` is absent because it is in `$hidden`.
+
+### Documenting computed fields
+
+A field in `$appends` without a typed legacy accessor falls back to an
+unconstrained schema. Document it with `@property-read` or use a typed
+legacy accessor:
+
+```php
+/** @property-read string $slug  URL-safe slug derived from the title. */
+class Post extends Model
+{
+    protected $appends = ['slug'];
+
+    // typed legacy accessor — return type also works without the docblock:
+    public function getSlugAttribute(): string
+    {
+        return Str::slug($this->title);
+    }
+}
+```
+
+> [!NOTE]
+> New-style `Attribute::get()` accessors (`public function slug(): Attribute`)
+> do not expose their value type via reflection. An `$appends` entry backed only
+> by a new-style accessor falls back to an unconstrained schema — use a typed
+> legacy accessor or `@property-read` to include the type.
+
+### Known limitations
+
+- **Method-body inference is not done.** `Model::find()` / `findOrFail()` return
+  statements are not read (Tier-1, tracked as [#97](https://github.com/radiergummi/laravel-openapi/issues/97)).
+  Type your action's return type explicitly to get a response schema.
+- **`JsonResource` wrapping a model** is documented by the ApiResources plugin
+  separately (tracked as [#98](https://github.com/radiergummi/laravel-openapi/issues/98));
+  the model schema and the resource schema are currently independent.
+
 ## What if convention isn't enough?
 
 Authoring attributes live in `Radiergummi\OpenApi\Attributes`. Pick the
@@ -76,6 +202,7 @@ one matching the override you need:
 | Document an ad-hoc query parameter | [`#[QueryParam]`](recipes.md#document-an-ad-hoc-query-parameter) |
 | Add an error response not in `@throws` | [`#[Response]`](recipes.md#add-an-error-response-that-isnt-in-throws) |
 | Enrich a request- or response-body field | [`#[RequestField]` / `#[ResponseField]`](recipes.md#enrich-a-request-body-field) |
+| Document a computed / virtual Eloquent model field | `@property-read` docblock annotation or a typed legacy accessor (`getXAttribute(): T`) |
 | Force a response resource the generator can't infer | [`#[ResponseResource]`](recipes.md#force-the-response-resource) |
 | Hide an endpoint from production docs | [`#[Hide]`](recipes.md#hide-an-endpoint-from-production-docs) |
 | Document a polymorphic response | [`#[Discriminator]`](recipes.md#document-a-polymorphic-response-with-a-discriminator) |

--- a/examples/vanilla/Http/TypedFlightController.php
+++ b/examples/vanilla/Http/TypedFlightController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Examples\Vanilla\Http;
+
+use Examples\Shared\Models\Flight;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Radiergummi\OpenApi\Attributes\Tag;
+
+/**
+ * Demonstrates model-typed returns: the response schema is derived from the Flight
+ * model's metadata ($casts + @property), with no #[Response] override needed.
+ */
+#[Tag('Flights')]
+final class TypedFlightController
+{
+    /**
+     * List flights.
+     *
+     * Returns all flights. The response schema is inferred from the Flight model.
+     *
+     * @return Collection<int, Flight>
+     */
+    public function index(): Collection
+    {
+        return Flight::query()->orderBy('departs_at')->get();
+    }
+
+    /**
+     * Show a single flight.
+     *
+     * @throws ModelNotFoundException When the flight does not exist.
+     */
+    public function show(string $flight): Flight
+    {
+        return Flight::query()->findOrFail($flight);
+    }
+}

--- a/examples/vanilla/openapi.yaml
+++ b/examples/vanilla/openapi.yaml
@@ -200,7 +200,81 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       security: []
+  /api/typed/flights:
+    get:
+      tags:
+        - Vanilla
+        - Flights
+      summary: 'List flights.'
+      description: 'Returns all flights. The response schema is inferred from the Flight model.'
+      operationId: get_api_typed_flights
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Flight'
+      security: []
+  '/api/typed/flights/{flight}':
+    get:
+      tags:
+        - Vanilla
+        - Flights
+      summary: 'Show a single flight.'
+      operationId: get_api_typed_flights_flight_
+      parameters:
+        -
+          name: flight
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Flight'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security: []
 components:
+  schemas:
+    Flight:
+      required:
+        - departs_at
+        - arrives_at
+        - aircraft_type
+        - destination
+        - id
+        - number
+        - origin
+        - status
+      properties:
+        departs_at:
+          type: string
+          format: date-time
+        arrives_at:
+          type: string
+          format: date-time
+        aircraft_type:
+          type: string
+        destination:
+          type: string
+        id:
+          type: string
+        number:
+          type: string
+        origin:
+          type: string
+        status:
+          type: string
+      type: object
   responses:
     ValidationFailed:
       description: 'Validation failed'

--- a/examples/vanilla/routes/api.php
+++ b/examples/vanilla/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Examples\Vanilla\Http\BookingController;
 use Examples\Vanilla\Http\FlightController;
+use Examples\Vanilla\Http\TypedFlightController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/flights', [FlightController::class, 'index']);
@@ -15,3 +16,6 @@ Route::delete('/flights/{flight}', [FlightController::class, 'destroy']);
 Route::get('/flights/{flight}/bookings', [BookingController::class, 'index']);
 Route::post('/flights/{flight}/bookings', [BookingController::class, 'store']);
 Route::delete('/bookings/{booking}', [BookingController::class, 'destroy']);
+
+Route::get('/typed/flights', [TypedFlightController::class, 'index']);
+Route::get('/typed/flights/{flight}', [TypedFlightController::class, 'show']);

--- a/src/Plugins/Core/CorePlugin.php
+++ b/src/Plugins/Core/CorePlugin.php
@@ -15,6 +15,7 @@ use Radiergummi\OpenApi\Plugins\Core\Lint\RuleInvalidEnumValue;
 use Radiergummi\OpenApi\Plugins\Core\Lint\RuleUnknown;
 use Radiergummi\OpenApi\Plugins\Core\Lint\ThrowsUnmapped;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\CoreQueryParameterResolver;
+use Radiergummi\OpenApi\Plugins\Core\Resolvers\EloquentModelResponseResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\FormRequestRequestSchemaResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\PaginatorResponseResolver;
 use Radiergummi\OpenApi\Registry\OpenApiRegistry;
@@ -45,6 +46,7 @@ final class CorePlugin implements Plugin
         $registry->addRequestSchemaResolver(FormRequestRequestSchemaResolver::class);
         $registry->addQueryParameterResolver(CoreQueryParameterResolver::class);
         $registry->addPrimaryResponseResolver(PaginatorResponseResolver::class);
+        $registry->addPrimaryResponseResolver(EloquentModelResponseResolver::class);
 
         // Error-response inference contributors; the registration order is important: Throws
         // first (most specific), Middleware second, Validation last (most implicit). The stage that

--- a/src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php
+++ b/src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php
@@ -82,7 +82,7 @@ final readonly class EloquentModelResponseResolver implements PrimaryResponseRes
             /** @var class-string<Model> $modelClass */
             $modelClass = $typeName;
 
-            return $this->jsonResponse($this->refSchema($modelClass));
+            return $this->jsonResponse(new OA\Schema(['ref' => $this->refKey($modelClass)]));
         }
 
         if (is_a($typeName, Collection::class, true)) {
@@ -95,7 +95,7 @@ final readonly class EloquentModelResponseResolver implements PrimaryResponseRes
             /** @var class-string<Model> $modelClass */
             $modelClass = $itemClass;
 
-            $items = new OA\Items(['ref' => $this->registry->qualifyKey($this->modelToSchema->build($modelClass))]);
+            $items = new OA\Items(['ref' => $this->refKey($modelClass)]);
 
             return $this->jsonResponse(new OA\Schema(['type' => 'array', 'items' => $items]));
         }
@@ -104,11 +104,14 @@ final readonly class EloquentModelResponseResolver implements PrimaryResponseRes
     }
 
     /**
+     * Builds (once, cycle-guarded) the model's component schema and returns the qualified `$ref`
+     * key pointing at it — shared by the single-model and collection-item paths.
+     *
      * @param class-string<Model> $modelClass
      */
-    private function refSchema(string $modelClass): OA\Schema
+    private function refKey(string $modelClass): string
     {
-        return new OA\Schema(['ref' => $this->registry->qualifyKey($this->modelToSchema->build($modelClass))]);
+        return $this->registry->qualifyKey($this->modelToSchema->build($modelClass));
     }
 
     private function jsonResponse(OA\Schema $schema): OA\Response

--- a/src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php
+++ b/src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Plugins\Core\Resolvers;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use OpenApi\Annotations as OA;
 use Psr\Log\LoggerInterface;
 use Radiergummi\OpenApi\Contracts\Registry\PrimaryResponseResolver;
@@ -12,21 +13,26 @@ use Radiergummi\OpenApi\Enums\MediaType;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Routing\ReturnTypeExtractor;
 use ReflectionNamedType;
 use Throwable;
 
+use function class_exists;
 use function is_a;
 use function sprintf;
 
 /**
- * Resolves a direct Eloquent model return type into a `200 OK` response whose schema is a
- * `$ref` pointing at the model's component schema.
+ * Resolves a direct Eloquent model return type — or a typed Collection of models — into a
+ * `200 OK` response whose schema is a `$ref` (single model) or an array of `$ref` items
+ * (collection).
  *
  * Registered AFTER `PaginatorResponseResolver` so paginator return types are claimed first and
- * this resolver only sees bare `Model` subclass returns. Returns null for any non-Model return
- * type, deferring to the next resolver or the bare-200 fallback.
+ * this resolver only sees bare `Model` subclass or `Collection<*, Model>` returns. Returns null
+ * for any non-Model return type, deferring to the next resolver or the bare-200 fallback.
  *
- * Nullable model return types (e.g. `?Model`) are `ReflectionUnionType` and are not resolved.
+ * A nullable model return (`?Model`) is a `ReflectionNamedType` with allowsNull(); it is
+ * accepted and the nullable modifier is not reflected in the emitted schema, consistent
+ * with the other primary-response resolvers.
  *
  * @internal
  */
@@ -36,6 +42,7 @@ final readonly class EloquentModelResponseResolver implements PrimaryResponseRes
         private EloquentModelToSchema $modelToSchema,
         private ComponentSchemaRegistry $registry,
         private LoggerInterface $logger,
+        private ReturnTypeExtractor $returnTypeExtractor,
     ) {}
 
     public function resolvePrimaryResponse(ActionDescriptor $descriptor): ?OA\Response
@@ -71,16 +78,41 @@ final readonly class EloquentModelResponseResolver implements PrimaryResponseRes
 
         $typeName = $returnType->getName();
 
-        if (!is_a($typeName, Model::class, true)) {
-            return null;
+        if (is_a($typeName, Model::class, true)) {
+            /** @var class-string<Model> $modelClass */
+            $modelClass = $typeName;
+
+            return $this->jsonResponse($this->refSchema($modelClass));
         }
 
-        /** @var class-string<Model> $modelClass */
-        $modelClass = $typeName;
+        if (is_a($typeName, Collection::class, true)) {
+            $itemClass = $this->returnTypeExtractor->genericArgument($reflector);
 
-        $key = $this->modelToSchema->build($modelClass);
-        $schema = new OA\Schema(['ref' => $this->registry->qualifyKey($key)]);
+            if ($itemClass === null || !class_exists($itemClass) || !is_a($itemClass, Model::class, true)) {
+                return null;
+            }
 
+            /** @var class-string<Model> $modelClass */
+            $modelClass = $itemClass;
+
+            $items = new OA\Items(['ref' => $this->registry->qualifyKey($this->modelToSchema->build($modelClass))]);
+
+            return $this->jsonResponse(new OA\Schema(['type' => 'array', 'items' => $items]));
+        }
+
+        return null;
+    }
+
+    /**
+     * @param class-string<Model> $modelClass
+     */
+    private function refSchema(string $modelClass): OA\Schema
+    {
+        return new OA\Schema(['ref' => $this->registry->qualifyKey($this->modelToSchema->build($modelClass))]);
+    }
+
+    private function jsonResponse(OA\Schema $schema): OA\Response
+    {
         return new OA\Response([
             'response' => '200',
             'description' => 'OK',

--- a/src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php
+++ b/src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Core\Resolvers;
+
+use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Contracts\Registry\PrimaryResponseResolver;
+use Radiergummi\OpenApi\Enums\MediaType;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use ReflectionNamedType;
+use Throwable;
+
+use function is_a;
+use function sprintf;
+
+/**
+ * Resolves a direct Eloquent model return type into a `200 OK` response whose schema is a
+ * `$ref` pointing at the model's component schema.
+ *
+ * Registered AFTER `PaginatorResponseResolver` so paginator return types are claimed first and
+ * this resolver only sees bare `Model` subclass returns. Returns null for any non-Model return
+ * type, deferring to the next resolver or the bare-200 fallback.
+ *
+ * Nullable model return types (e.g. `?Model`) are `ReflectionUnionType` and are not resolved.
+ *
+ * @internal
+ */
+final readonly class EloquentModelResponseResolver implements PrimaryResponseResolver
+{
+    public function __construct(
+        private EloquentModelToSchema $modelToSchema,
+        private ComponentSchemaRegistry $registry,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function resolvePrimaryResponse(ActionDescriptor $descriptor): ?OA\Response
+    {
+        try {
+            return $this->resolve($descriptor);
+        } catch (Throwable $exception) {
+            $this->logger->warning(
+                sprintf(
+                    'EloquentModelResponseResolver failed for route %s: %s',
+                    $descriptor->route->uri(),
+                    $exception->getMessage(),
+                ),
+            );
+
+            return null;
+        }
+    }
+
+    private function resolve(ActionDescriptor $descriptor): ?OA\Response
+    {
+        $reflector = $descriptor->actionReflector;
+
+        if ($reflector === null) {
+            return null;
+        }
+
+        $returnType = $reflector->getReturnType();
+
+        if (!$returnType instanceof ReflectionNamedType || $returnType->isBuiltin()) {
+            return null;
+        }
+
+        $typeName = $returnType->getName();
+
+        if (!is_a($typeName, Model::class, true)) {
+            return null;
+        }
+
+        /** @var class-string<Model> $modelClass */
+        $modelClass = $typeName;
+
+        $key = $this->modelToSchema->build($modelClass);
+        $schema = new OA\Schema(['ref' => $this->registry->qualifyKey($key)]);
+
+        return new OA\Response([
+            'response' => '200',
+            'description' => 'OK',
+            'content' => [MediaType::Json->schema($schema)],
+        ]);
+    }
+}

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -272,6 +272,9 @@ final class EloquentModelToSchema
     {
         $inner = $this->typeNodeResolver->unwrapNullable($node);
 
+        // GenericTypeNode (e.g. Collection<Tag>) and ArrayTypeNode (e.g. array<string,mixed>)
+        // are intentionally not descended into — Tier-0 doesn't parse deep generics. The caller
+        // will fall through to the unconstrained empty-property fallback (see docs/auto-derivation.md).
         return $inner instanceof IdentifierTypeNode ? $inner : null;
     }
 

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -12,12 +12,11 @@ use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
-use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Psr\Log\LoggerInterface;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
+use Radiergummi\OpenApi\Support\Generator\NullableSchema;
 use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
 use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
 use ReflectionClass;
@@ -179,7 +178,7 @@ final class EloquentModelToSchema
         foreach ($names as $name) {
             $tag = $propertyTags[$name] ?? null;
 
-            if ($tag !== null && ! $this->isNullable($tag->type)) {
+            if ($tag !== null && ! $this->typeNodeResolver->isNullable($tag->type)) {
                 $required[] = $name;
             }
         }
@@ -194,15 +193,9 @@ final class EloquentModelToSchema
     }
 
     /**
-     * Builds an OA\Property from a docblock type node.
-     *
-     * Precedence:
-     * 1. Scalar keyword → inline type definition.
-     * 2. Eloquent Model class → `$ref` to the related model's component schema (recursive, cycle-guarded).
-     * 3. Non-model class (e.g. Carbon, UuidInterface) → schema via JsonSchemaFromType::fromType.
-     * 4. Unresolvable node → returns null, caller falls through to the empty fallback.
-     *
-     * Nullability is preserved on all paths.
+     * Builds a named OA\Property from a docblock type node, applying nullability via the
+     * OAS 3.1 idiom ({@see NullableSchema}). Returns null when the node is unresolvable, so the
+     * caller falls through to the empty-property fallback.
      *
      * @param ReflectionClass<Model> $reflection
      *
@@ -210,25 +203,45 @@ final class EloquentModelToSchema
      */
     private function propertyFromTag(string $name, TypeNode $node, ReflectionClass $reflection): ?OA\Property
     {
-        $identifier = $this->unwrapToIdentifier($node);
+        $schema = $this->schemaFromTagType($node, $reflection, $name);
 
-        if ($identifier === null) {
+        if ($schema === null) {
             return null;
         }
 
-        $definition = $this->scalarTypeDefinition($identifier->name);
-
-        if ($definition !== null) {
-            $property = new OA\Property(['property' => $name, ...$definition]);
-
-            if ($this->isNullable($node)) {
-                $property->nullable = true;
-            }
-
-            return $property;
+        if ($this->typeNodeResolver->isNullable($node)) {
+            $schema = NullableSchema::wrap($schema);
         }
 
-        // Not a scalar — try to resolve the identifier as a class name.
+        return $this->propertyFromSchema($name, $schema);
+    }
+
+    /**
+     * Builds the type schema for a docblock node — scalar keyword, related-model `$ref`, or a
+     * non-model class via {@see JsonSchemaFromType} — or returns null when the node is a generic,
+     * array, or otherwise unresolvable type (caller falls through to the empty-property fallback).
+     *
+     * Nullability is applied by the caller; this method only shapes the underlying type.
+     *
+     * @param ReflectionClass<Model> $reflection
+     *
+     * @throws ReflectionException
+     */
+    private function schemaFromTagType(TypeNode $node, ReflectionClass $reflection, string $name): ?OA\Schema
+    {
+        // GenericTypeNode (e.g. Collection<Tag>) and ArrayTypeNode are intentionally not descended
+        // into — Tier-0 doesn't parse deep generics (see docs/auto-derivation.md). The scalar
+        // fast-path peeks at the unwrapped identifier before the class path is tried.
+        $inner = $this->typeNodeResolver->unwrapNullable($node);
+
+        if ($inner instanceof IdentifierTypeNode) {
+            $definition = $this->scalarKeywordToDefinition($inner->name);
+
+            if ($definition !== null) {
+                return new OA\Schema($definition);
+            }
+        }
+
         $className = $this->typeNodeResolver->resolveClassName($node, $reflection);
 
         if ($className === null || ! class_exists($className)) {
@@ -243,69 +256,19 @@ final class EloquentModelToSchema
 
         if (is_a($className, Model::class, allow_string: true)) {
             /** @var class-string<Model> $className */
-            $key = $this->build($className);
-            $schema = new OA\Schema(['ref' => $this->registry->qualifyKey($key)]);
-        } else {
-            $schema = $this->jsonSchemaFromType->fromType(Type::object($className));
+            return new OA\Schema(['ref' => $this->registry->qualifyKey($this->build($className))]);
         }
 
-        $property = $this->propertyFromSchema($name, $schema);
-
-        if ($this->isNullable($node)) {
-            $property->nullable = true;
-        }
-
-        return $property;
+        return $this->jsonSchemaFromType->fromType(Type::object($className));
     }
 
     /**
-     * Unwraps a nullable or union-with-null wrapper to reach the inner
-     * IdentifierTypeNode. Returns null for compound/generic/array nodes.
-     *
-     * Uses {@see TypeNodeResolver::unwrapNullable()} as the shared primitive for
-     * the nullable-descend step.
-     *
-     * Scalar fast-path: yields the bare IdentifierTypeNode so the scalar keyword check
-     * can run before resolveClassName() (class path) is tried on the original node.
-     */
-    private function unwrapToIdentifier(TypeNode $node): ?IdentifierTypeNode
-    {
-        $inner = $this->typeNodeResolver->unwrapNullable($node);
-
-        // GenericTypeNode (e.g. Collection<Tag>) and ArrayTypeNode (e.g. array<string,mixed>)
-        // are intentionally not descended into — Tier-0 doesn't parse deep generics. The caller
-        // will fall through to the unconstrained empty-property fallback (see docs/auto-derivation.md).
-        return $inner instanceof IdentifierTypeNode ? $inner : null;
-    }
-
-    /**
-     * Returns true when the type node represents a nullable type
-     * (NullableTypeNode or a union containing a `null` identifier).
-     */
-    private function isNullable(TypeNode $node): bool
-    {
-        if ($node instanceof NullableTypeNode) {
-            return true;
-        }
-
-        if ($node instanceof UnionTypeNode) {
-            foreach ($node->types as $member) {
-                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Maps a scalar PHPDoc keyword to an OpenAPI type definition array,
+     * Maps a scalar PHPDoc/cast keyword to an OpenAPI type definition array,
      * or returns null for class names and non-scalar keywords.
      *
      * @return null|array<string, string>
      */
-    private function scalarTypeDefinition(string $keyword): ?array
+    private function scalarKeywordToDefinition(string $keyword): ?array
     {
         return match (strtolower($keyword)) {
             'int', 'integer'        => ['type' => 'integer'],
@@ -363,23 +326,26 @@ final class EloquentModelToSchema
     }
 
     /**
-     * Converts an OA\Schema into an OA\Property by copying non-UNDEFINED JSON-Schema fields.
+     * Converts an OA\Schema into a named OA\Property by copying every defined JSON-Schema field.
+     *
+     * OA\Property extends OA\Schema, so the field set is identical; swagger-php internals are
+     * underscore-prefixed and skipped, as is the component-key `schema` field.
      */
     private function propertyFromSchema(string $name, OA\Schema $schema): OA\Property
     {
-        $props = ['property' => $name];
+        $property = new OA\Property(['property' => $name]);
 
-        // The fields JsonSchemaFromType / fromBackedEnumClass actually emit. Extend this
-        // list if those methods start producing additional schema keywords.
-        foreach (['type', 'format', 'enum', 'description', 'items', 'ref', 'oneOf', 'nullable'] as $field) {
-            $value = $schema->{$field};
+        foreach (get_object_vars($schema) as $field => $value) {
+            if ($field === 'property' || $field === 'schema' || $field[0] === '_') {
+                continue;
+            }
 
             if ($value !== Generator::UNDEFINED) {
-                $props[$field] = $value;
+                $property->{$field} = $value;
             }
         }
 
-        return new OA\Property($props);
+        return $property;
     }
 
     /**
@@ -393,14 +359,12 @@ final class EloquentModelToSchema
             str_contains($cast, ':') ? explode(':', $cast, 2)[0] : $cast,
         );
 
-        $definition = match ($normalised) {
-            'int', 'integer'
-                => ['type' => 'integer'],
-            'real', 'float', 'double'
+        // Shared scalar keywords (int/float/string/bool) resolve via the common map; the cast-only
+        // keywords (decimal/date/datetime/array/…) are handled here.
+        $definition = $this->scalarKeywordToDefinition($normalised) ?? match ($normalised) {
+            'real'
                 => ['type' => 'number'],
-            'bool', 'boolean'
-                => ['type' => 'boolean'],
-            'string', 'decimal', 'hashed', 'encrypted'
+            'decimal', 'hashed', 'encrypted'
                 => ['type' => 'string'],
             'date'
                 => ['type' => 'string', 'format' => 'date'],

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Extraction;
+
+use Illuminate\Container\Attributes\Scoped;
+use Illuminate\Database\Eloquent\Model;
+use OpenApi\Annotations as OA;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
+use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
+use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
+use ReflectionClass;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+
+use function array_diff;
+use function array_keys;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function explode;
+use function in_array;
+use function ltrim;
+use function str_contains;
+use function strtolower;
+
+/**
+ * Builds an OpenAPI schema for an Eloquent model from its metadata:
+ * cast keys, fillable fields, appends, and docblock @property names.
+ *
+ * @internal
+ */
+#[Scoped]
+final class EloquentModelToSchema
+{
+    public function __construct(
+        private readonly ComponentSchemaRegistry $registry,
+        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
+        private readonly JsonSchemaFromType $jsonSchemaFromType,
+        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
+        private readonly TypeResolver $typeResolver,
+        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
+        private readonly TypeNodeResolver $typeNodeResolver,
+        private readonly DocBlockParser $docBlockParser,
+        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later relation/logging tasks)
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Registers the model's schema and returns the component key.
+     *
+     * @param class-string<Model> $modelClass
+     */
+    public function build(string $modelClass): string
+    {
+        return $this->registry->buildOnce($modelClass, fn(): OA\Schema => $this->schemaFor($modelClass));
+    }
+
+    /**
+     * @param class-string<Model> $modelClass
+     */
+    private function schemaFor(string $modelClass): OA\Schema
+    {
+        $model = new $modelClass();
+
+        $casts = $model->getCasts();
+        $hidden = $model->getHidden();
+        $visible = $model->getVisible();
+        $fillable = $model->getFillable();
+
+        $appends = $model->getAppends();
+
+        $reflection = new ReflectionClass($modelClass);
+        $docComment = $reflection->getDocComment();
+        $docPropertyNames = [];
+
+        if ($docComment !== false) {
+            $parsed = $this->docBlockParser->parse($docComment);
+
+            foreach ($parsed->tagValues('@property') as $tag) {
+                if ($tag instanceof PropertyTagValueNode) {
+                    $docPropertyNames[] = ltrim($tag->propertyName, '$');
+                }
+            }
+
+            foreach ($parsed->tagValues('@property-read') as $tag) {
+                if ($tag instanceof PropertyTagValueNode) {
+                    $docPropertyNames[] = ltrim($tag->propertyName, '$');
+                }
+            }
+        }
+
+        // Union of all known property names.
+        $allNames = array_unique(array_merge(
+            array_keys($casts),
+            $fillable,
+            $appends,
+            $docPropertyNames,
+        ));
+
+        // Apply visibility/hidden filters.
+        if ($visible !== []) {
+            $allNames = array_values(array_filter(
+                $allNames,
+                static fn(string $name): bool => in_array($name, $visible, strict: true),
+            ));
+        }
+
+        $names = array_values(array_diff($allNames, $hidden));
+
+        $properties = [];
+
+        foreach ($names as $name) {
+            $castString = $casts[$name] ?? null;
+            $properties[] = $castString !== null
+                ? ($this->castToProperty($name, $castString) ?? new OA\Property(['property' => $name]))
+                : new OA\Property(['property' => $name]);
+        }
+
+        return new OA\Schema([
+            'type' => 'object',
+            'properties' => $properties,
+        ]);
+    }
+
+    /**
+     * Maps an Eloquent cast string to an OA\Property with the given name,
+     * or returns null when the cast type is not recognised.
+     */
+    private function castToProperty(string $name, string $cast): ?OA\Property
+    {
+        // Normalise: take the part before `:` (e.g. `decimal:2` → `decimal`) and lowercase.
+        $normalised = strtolower(
+            str_contains($cast, ':') ? explode(':', $cast, 2)[0] : $cast,
+        );
+
+        $definition = match ($normalised) {
+            'int', 'integer'
+                => ['type' => 'integer'],
+            'real', 'float', 'double'
+                => ['type' => 'number'],
+            'bool', 'boolean'
+                => ['type' => 'boolean'],
+            'string', 'decimal', 'hashed', 'encrypted'
+                => ['type' => 'string'],
+            'date'
+                => ['type' => 'string', 'format' => 'date'],
+            'datetime', 'immutable_date', 'immutable_datetime', 'timestamp', 'custom_datetime'
+                => ['type' => 'string', 'format' => 'date-time'],
+            'array', 'json', 'object', 'collection'
+                => ['type' => 'object'],
+            default => null,
+        };
+
+        if ($definition === null) {
+            return null;
+        }
+
+        return new OA\Property(['property' => $name, ...$definition]);
+    }
+}

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -8,6 +8,10 @@ use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Database\Eloquent\Model;
 use OpenApi\Annotations as OA;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Psr\Log\LoggerInterface;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
@@ -17,6 +21,7 @@ use ReflectionClass;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 
 use function array_diff;
+use function array_filter;
 use function array_keys;
 use function array_merge;
 use function array_unique;
@@ -75,20 +80,22 @@ final class EloquentModelToSchema
 
         $reflection = new ReflectionClass($modelClass);
         $docComment = $reflection->getDocComment();
-        $docPropertyNames = [];
+
+        /** @var array<string, PropertyTagValueNode> $propertyTags */
+        $propertyTags = [];
 
         if ($docComment !== false) {
             $parsed = $this->docBlockParser->parse($docComment);
 
             foreach ($parsed->tagValues('@property') as $tag) {
                 if ($tag instanceof PropertyTagValueNode) {
-                    $docPropertyNames[] = ltrim($tag->propertyName, '$');
+                    $propertyTags[ltrim($tag->propertyName, '$')] = $tag;
                 }
             }
 
             foreach ($parsed->tagValues('@property-read') as $tag) {
                 if ($tag instanceof PropertyTagValueNode) {
-                    $docPropertyNames[] = ltrim($tag->propertyName, '$');
+                    $propertyTags[ltrim($tag->propertyName, '$')] = $tag;
                 }
             }
         }
@@ -98,7 +105,7 @@ final class EloquentModelToSchema
             array_keys($casts),
             $fillable,
             $appends,
-            $docPropertyNames,
+            array_keys($propertyTags),
         ));
 
         // Apply visibility/hidden filters.
@@ -115,15 +122,150 @@ final class EloquentModelToSchema
 
         foreach ($names as $name) {
             $castString = $casts[$name] ?? null;
-            $properties[] = $castString !== null
-                ? ($this->castToProperty($name, $castString) ?? new OA\Property(['property' => $name]))
-                : new OA\Property(['property' => $name]);
+
+            if ($castString !== null) {
+                $properties[] = $this->castToProperty($name, $castString) ?? new OA\Property(['property' => $name]);
+
+                continue;
+            }
+
+            $tag = $propertyTags[$name] ?? null;
+
+            if ($tag !== null) {
+                $property = $this->propertyFromTag($name, $tag->type);
+
+                if ($property !== null) {
+                    $properties[] = $property;
+
+                    continue;
+                }
+            }
+
+            $properties[] = new OA\Property(['property' => $name]);
         }
 
-        return new OA\Schema([
-            'type' => 'object',
-            'properties' => $properties,
-        ]);
+        // A property is required when it has a @property/@property-read annotation whose
+        // type is non-nullable — regardless of whether the schema type came from a cast.
+        $required = [];
+
+        foreach ($names as $name) {
+            $tag = $propertyTags[$name] ?? null;
+
+            if ($tag !== null && ! $this->isNullable($tag->type)) {
+                $required[] = $name;
+            }
+        }
+
+        $schemaArgs = ['type' => 'object', 'properties' => $properties];
+
+        if ($required !== []) {
+            $schemaArgs['required'] = $required;
+        }
+
+        return new OA\Schema($schemaArgs);
+    }
+
+    /**
+     * Builds an OA\Property from a docblock type node for scalar types.
+     * Returns null when the type is a class, generic, array, or otherwise
+     * not a recognised scalar keyword — those fall through to the empty fallback.
+     */
+    private function propertyFromTag(string $name, TypeNode $node): ?OA\Property
+    {
+        $identifier = $this->unwrapToIdentifier($node);
+
+        if ($identifier === null) {
+            return null;
+        }
+
+        $definition = $this->scalarTypeDefinition($identifier->name);
+
+        if ($definition === null) {
+            return null;
+        }
+
+        $property = new OA\Property(['property' => $name, ...$definition]);
+
+        if ($this->isNullable($node)) {
+            $property->nullable = true;
+        }
+
+        return $property;
+    }
+
+    /**
+     * Unwraps a nullable or union-with-null wrapper to reach the inner
+     * IdentifierTypeNode. Returns null for compound/generic/array nodes.
+     */
+    private function unwrapToIdentifier(TypeNode $node): ?IdentifierTypeNode
+    {
+        if ($node instanceof IdentifierTypeNode) {
+            return $node;
+        }
+
+        if ($node instanceof NullableTypeNode) {
+            return $this->unwrapToIdentifier($node->type);
+        }
+
+        if ($node instanceof UnionTypeNode) {
+            $nonNull = null;
+
+            foreach ($node->types as $member) {
+                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
+                    continue;
+                }
+
+                if ($nonNull !== null) {
+                    // More than one non-null member — not a simple nullable scalar.
+                    return null;
+                }
+
+                $nonNull = $member;
+            }
+
+            return $nonNull instanceof IdentifierTypeNode ? $nonNull : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true when the type node represents a nullable type
+     * (NullableTypeNode or a union containing a `null` identifier).
+     */
+    private function isNullable(TypeNode $node): bool
+    {
+        if ($node instanceof NullableTypeNode) {
+            return true;
+        }
+
+        if ($node instanceof UnionTypeNode) {
+            foreach ($node->types as $member) {
+                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Maps a scalar PHPDoc keyword to an OpenAPI type definition array,
+     * or returns null for class names and non-scalar keywords.
+     *
+     * @return null|array<string, string>
+     */
+    private function scalarTypeDefinition(string $keyword): ?array
+    {
+        return match (strtolower($keyword)) {
+            'int', 'integer'        => ['type' => 'integer'],
+            'float', 'double'       => ['type' => 'number'],
+            'string'                => ['type' => 'string'],
+            'bool', 'boolean',
+            'true', 'false'         => ['type' => 'boolean'],
+            default                 => null,
+        };
     }
 
     /**

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\Extraction;
 
+use BackedEnum;
 use Illuminate\Container\Attributes\Scoped;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
@@ -18,6 +21,9 @@ use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
 use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
 use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
+use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 
 use function array_diff;
@@ -26,11 +32,15 @@ use function array_keys;
 use function array_merge;
 use function array_unique;
 use function array_values;
+use function enum_exists;
 use function explode;
 use function in_array;
+use function is_a;
 use function ltrim;
 use function str_contains;
+use function str_replace;
 use function strtolower;
+use function ucwords;
 
 /**
  * Builds an OpenAPI schema for an Eloquent model from its metadata:
@@ -43,9 +53,7 @@ final class EloquentModelToSchema
 {
     public function __construct(
         private readonly ComponentSchemaRegistry $registry,
-        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
         private readonly JsonSchemaFromType $jsonSchemaFromType,
-        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
         private readonly TypeResolver $typeResolver,
         // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
         private readonly TypeNodeResolver $typeNodeResolver,
@@ -66,6 +74,8 @@ final class EloquentModelToSchema
 
     /**
      * @param class-string<Model> $modelClass
+     *
+     * @throws ReflectionException
      */
     private function schemaFor(string $modelClass): OA\Schema
     {
@@ -124,6 +134,13 @@ final class EloquentModelToSchema
             $castString = $casts[$name] ?? null;
 
             if ($castString !== null) {
+                // Enum-class cast takes priority: produce an inline enum schema.
+                if (enum_exists($castString) && is_a($castString, BackedEnum::class, allow_string: true)) {
+                    $properties[] = $this->propertyFromSchema($name, $this->jsonSchemaFromType->fromBackedEnumClass($castString));
+
+                    continue;
+                }
+
                 $properties[] = $this->castToProperty($name, $castString) ?? new OA\Property(['property' => $name]);
 
                 continue;
@@ -133,6 +150,17 @@ final class EloquentModelToSchema
 
             if ($tag !== null) {
                 $property = $this->propertyFromTag($name, $tag->type);
+
+                if ($property !== null) {
+                    $properties[] = $property;
+
+                    continue;
+                }
+            }
+
+            // For appended attributes not typed via @property, try the accessor method.
+            if (in_array($name, $appends, strict: true)) {
+                $property = $this->propertyFromAccessor($reflection, $name);
 
                 if ($property !== null) {
                     $properties[] = $property;
@@ -266,6 +294,71 @@ final class EloquentModelToSchema
             'true', 'false'         => ['type' => 'boolean'],
             default                 => null,
         };
+    }
+
+    /**
+     * Resolves the return type of an accessor method to an OA\Property, or returns null when
+     * no reflectable typed accessor exists for the property name.
+     *
+     * Checks the new-style studly-cased method (e.g. `readingTime`) and the legacy
+     * `getReadingTimeAttribute` form. If the return type is `Attribute` (the new
+     * `Attribute::get(...)` style), the value type is not reflectable so null is returned.
+     *
+     * @param ReflectionClass<Model> $reflection
+     *
+     * @throws ReflectionException
+     */
+    private function propertyFromAccessor(ReflectionClass $reflection, string $name): ?OA\Property
+    {
+        $studly = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
+        $candidates = [$studly, 'get' . $studly . 'Attribute'];
+
+        foreach ($candidates as $methodName) {
+            if (! $reflection->hasMethod($methodName)) {
+                continue;
+            }
+
+            $returnType = $reflection->getMethod($methodName)->getReturnType();
+
+            if (! $returnType instanceof ReflectionNamedType) {
+                continue;
+            }
+
+            // New-style Attribute::get() accessors don't expose the value type.
+            if ($returnType->getName() === Attribute::class) {
+                continue;
+            }
+
+            try {
+                $type = $this->typeResolver->resolve($returnType);
+            } catch (UnsupportedException) {
+                continue;
+            }
+
+            return $this->propertyFromSchema($name, $this->jsonSchemaFromType->fromType($type));
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts an OA\Schema into an OA\Property by copying non-UNDEFINED JSON-Schema fields.
+     */
+    private function propertyFromSchema(string $name, OA\Schema $schema): OA\Property
+    {
+        $props = ['property' => $name];
+
+        // The fields JsonSchemaFromType / fromBackedEnumClass actually emit. Extend this
+        // list if those methods start producing additional schema keywords.
+        foreach (['type', 'format', 'enum', 'description', 'items', 'ref', 'oneOf', 'nullable'] as $field) {
+            $value = $schema->{$field};
+
+            if ($value !== Generator::UNDEFINED) {
+                $props[$field] = $value;
+            }
+        }
+
+        return new OA\Property($props);
     }
 
     /**

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -24,6 +24,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
+use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 
 use function array_diff;
@@ -32,6 +33,7 @@ use function array_keys;
 use function array_merge;
 use function array_unique;
 use function array_values;
+use function class_exists;
 use function enum_exists;
 use function explode;
 use function in_array;
@@ -55,10 +57,8 @@ final class EloquentModelToSchema
         private readonly ComponentSchemaRegistry $registry,
         private readonly JsonSchemaFromType $jsonSchemaFromType,
         private readonly TypeResolver $typeResolver,
-        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later @property/relation tasks)
         private readonly TypeNodeResolver $typeNodeResolver,
         private readonly DocBlockParser $docBlockParser,
-        // @phpstan-ignore property.onlyWritten (injected now for constructor stability; used by later relation/logging tasks)
         private readonly LoggerInterface $logger,
     ) {}
 
@@ -149,7 +149,7 @@ final class EloquentModelToSchema
             $tag = $propertyTags[$name] ?? null;
 
             if ($tag !== null) {
-                $property = $this->propertyFromTag($name, $tag->type);
+                $property = $this->propertyFromTag($name, $tag->type, $reflection);
 
                 if ($property !== null) {
                     $properties[] = $property;
@@ -194,11 +194,21 @@ final class EloquentModelToSchema
     }
 
     /**
-     * Builds an OA\Property from a docblock type node for scalar types.
-     * Returns null when the type is a class, generic, array, or otherwise
-     * not a recognised scalar keyword — those fall through to the empty fallback.
+     * Builds an OA\Property from a docblock type node.
+     *
+     * Precedence:
+     * 1. Scalar keyword → inline type definition.
+     * 2. Eloquent Model class → `$ref` to the related model's component schema (recursive, cycle-guarded).
+     * 3. Non-model class (e.g. Carbon, UuidInterface) → schema via JsonSchemaFromType::fromType.
+     * 4. Unresolvable node → returns null, caller falls through to the empty fallback.
+     *
+     * Nullability is preserved on all paths.
+     *
+     * @param ReflectionClass<Model> $reflection
+     *
+     * @throws ReflectionException
      */
-    private function propertyFromTag(string $name, TypeNode $node): ?OA\Property
+    private function propertyFromTag(string $name, TypeNode $node, ReflectionClass $reflection): ?OA\Property
     {
         $identifier = $this->unwrapToIdentifier($node);
 
@@ -208,11 +218,38 @@ final class EloquentModelToSchema
 
         $definition = $this->scalarTypeDefinition($identifier->name);
 
-        if ($definition === null) {
+        if ($definition !== null) {
+            $property = new OA\Property(['property' => $name, ...$definition]);
+
+            if ($this->isNullable($node)) {
+                $property->nullable = true;
+            }
+
+            return $property;
+        }
+
+        // Not a scalar — try to resolve the identifier as a class name.
+        $className = $this->typeNodeResolver->resolveClassName($node, $reflection);
+
+        if ($className === null || ! class_exists($className)) {
+            $this->logger->warning('EloquentModelToSchema: unresolvable @property type, using empty fallback', [
+                'model' => $reflection->getName(),
+                'property' => $name,
+                'type' => (string) $node,
+            ]);
+
             return null;
         }
 
-        $property = new OA\Property(['property' => $name, ...$definition]);
+        if (is_a($className, Model::class, allow_string: true)) {
+            /** @var class-string<Model> $className */
+            $key = $this->build($className);
+            $schema = new OA\Schema(['ref' => $this->registry->qualifyKey($key)]);
+        } else {
+            $schema = $this->jsonSchemaFromType->fromType(Type::object($className));
+        }
+
+        $property = $this->propertyFromSchema($name, $schema);
 
         if ($this->isNullable($node)) {
             $property->nullable = true;
@@ -224,37 +261,18 @@ final class EloquentModelToSchema
     /**
      * Unwraps a nullable or union-with-null wrapper to reach the inner
      * IdentifierTypeNode. Returns null for compound/generic/array nodes.
+     *
+     * Uses {@see TypeNodeResolver::unwrapNullable()} as the shared primitive for
+     * the nullable-descend step.
+     *
+     * Scalar fast-path: yields the bare IdentifierTypeNode so the scalar keyword check
+     * can run before resolveClassName() (class path) is tried on the original node.
      */
     private function unwrapToIdentifier(TypeNode $node): ?IdentifierTypeNode
     {
-        if ($node instanceof IdentifierTypeNode) {
-            return $node;
-        }
+        $inner = $this->typeNodeResolver->unwrapNullable($node);
 
-        if ($node instanceof NullableTypeNode) {
-            return $this->unwrapToIdentifier($node->type);
-        }
-
-        if ($node instanceof UnionTypeNode) {
-            $nonNull = null;
-
-            foreach ($node->types as $member) {
-                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
-                    continue;
-                }
-
-                if ($nonNull !== null) {
-                    // More than one non-null member — not a simple nullable scalar.
-                    return null;
-                }
-
-                $nonNull = $member;
-            }
-
-            return $nonNull instanceof IdentifierTypeNode ? $nonNull : null;
-        }
-
-        return null;
+        return $inner instanceof IdentifierTypeNode ? $inner : null;
     }
 
     /**

--- a/src/Support/Generator/JsonSchemaFromType.php
+++ b/src/Support/Generator/JsonSchemaFromType.php
@@ -14,7 +14,9 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use OpenApi\Annotations as OA;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
+use ReflectionEnum;
 use ReflectionEnumBackedCase;
+use ReflectionException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
@@ -51,6 +53,9 @@ final readonly class JsonSchemaFromType
         private LoggerInterface $logger,
     ) {}
 
+    /**
+     * @throws ReflectionException
+     */
     public function fromType(Type $type): OA\Schema
     {
         // NullableType MUST come before UnionType (it extends it).
@@ -70,26 +75,8 @@ final readonly class JsonSchemaFromType
         if ($type instanceof BackedEnumType) {
             /** @var class-string<BackedEnum> $className */
             $className = $type->getClassName();
-            $isInt = $type->getBackingType()->getTypeIdentifier() === TypeIdentifier::INT;
 
-            $props = [
-                'type' => $isInt ? 'integer' : 'string',
-                'enum' => array_map(
-                    static fn(BackedEnum $case): int|string
-                        => $isInt
-                        ? (int) $case->value
-                        : (string) $case->value,
-                    $className::cases(),
-                ),
-            ];
-
-            $caseDescription = $this->enumCaseDescription($className);
-
-            if ($caseDescription !== null) {
-                $props['description'] = $caseDescription;
-            }
-
-            return new OA\Schema($props);
+            return $this->fromBackedEnumClass($className);
         }
 
         if ($type instanceof EnumType) {
@@ -118,6 +105,41 @@ final readonly class JsonSchemaFromType
             'type' => 'string',
             'description' => sprintf('Unmapped type: %s', $type::class),
         ]);
+    }
+
+    /**
+     * Builds an inline enum schema from a backed-enum class-string.
+     *
+     * Determines integer-vs-string backing via reflection so the caller does not need a
+     * symfony/type-info {@see BackedEnumType} in hand — useful when the enum class name
+     * comes from a cast string rather than a resolved type tree.
+     *
+     * @param class-string<BackedEnum> $enumClass
+     *
+     * @throws ReflectionException
+     */
+    public function fromBackedEnumClass(string $enumClass): OA\Schema
+    {
+        $isInt = (new ReflectionEnum($enumClass))->getBackingType()?->getName() === 'int';
+
+        $props = [
+            'type' => $isInt ? 'integer' : 'string',
+            'enum' => array_map(
+                static fn(BackedEnum $case): int|string
+                    => $isInt
+                    ? (int) $case->value
+                    : (string) $case->value,
+                $enumClass::cases(),
+            ),
+        ];
+
+        $caseDescription = $this->enumCaseDescription($enumClass);
+
+        if ($caseDescription !== null) {
+            $props['description'] = $caseDescription;
+        }
+
+        return new OA\Schema($props);
     }
 
     /**

--- a/src/Support/Generator/JsonSchemaFromType.php
+++ b/src/Support/Generator/JsonSchemaFromType.php
@@ -14,9 +14,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use OpenApi\Annotations as OA;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
-use ReflectionEnum;
 use ReflectionEnumBackedCase;
-use ReflectionException;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\BackedEnumType;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
@@ -31,6 +29,7 @@ use function array_map;
 use function explode;
 use function implode;
 use function is_a;
+use function is_int;
 use function ltrim;
 use function preg_replace;
 use function sprintf;
@@ -53,9 +52,6 @@ final readonly class JsonSchemaFromType
         private LoggerInterface $logger,
     ) {}
 
-    /**
-     * @throws ReflectionException
-     */
     public function fromType(Type $type): OA\Schema
     {
         // NullableType MUST come before UnionType (it extends it).
@@ -115,12 +111,11 @@ final readonly class JsonSchemaFromType
      * comes from a cast string rather than a resolved type tree.
      *
      * @param class-string<BackedEnum> $enumClass
-     *
-     * @throws ReflectionException
      */
     public function fromBackedEnumClass(string $enumClass): OA\Schema
     {
-        $isInt = (new ReflectionEnum($enumClass))->getBackingType()?->getName() === 'int';
+        $cases = $enumClass::cases();
+        $isInt = $cases !== [] && is_int($cases[0]->value);
 
         $props = [
             'type' => $isInt ? 'integer' : 'string',

--- a/src/Support/Types/TypeNodeResolver.php
+++ b/src/Support/Types/TypeNodeResolver.php
@@ -22,6 +22,7 @@ use Throwable;
 use function array_key_exists;
 use function array_key_last;
 use function ltrim;
+use function strtolower;
 
 /**
  * Resolves phpstan/phpdoc-parser type nodes to FQCNs, using symfony/type-info to
@@ -101,6 +102,34 @@ final class TypeNodeResolver
         }
 
         return null;
+    }
+
+    /**
+     * Resolves the FQCN (no leading backslash) of a type node that denotes a single
+     * class — unwrapping a leading `?` or a `T|null` union first. Returns null for
+     * scalar keywords, generics, arrays, or unresolvable identifiers.
+     */
+    public function resolveClassName(TypeNode $node, Reflector $context): ?string
+    {
+        if ($node instanceof NullableTypeNode) {
+            return $this->resolveClassName($node->type, $context);
+        }
+
+        if ($node instanceof UnionTypeNode) {
+            foreach ($node->types as $member) {
+                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
+                    continue;
+                }
+
+                return $this->resolveClassName($member, $context);
+            }
+
+            return null;
+        }
+
+        return $node instanceof IdentifierTypeNode
+            ? $this->resolveClass($node, $context)
+            : null;
     }
 
     private function resolveClass(IdentifierTypeNode $node, Reflector $context): ?string

--- a/src/Support/Types/TypeNodeResolver.php
+++ b/src/Support/Types/TypeNodeResolver.php
@@ -143,6 +143,27 @@ final class TypeNodeResolver
     }
 
     /**
+     * Returns true when the type node represents a nullable type: a {@see NullableTypeNode}
+     * (`?T`) or a {@see UnionTypeNode} containing a bare `null` identifier (`T|null`).
+     */
+    public function isNullable(TypeNode $node): bool
+    {
+        if ($node instanceof NullableTypeNode) {
+            return true;
+        }
+
+        if ($node instanceof UnionTypeNode) {
+            foreach ($node->types as $member) {
+                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Resolves the FQCN (no leading backslash) of a type node that denotes a single
      * class — unwrapping a leading `?` or a `T|null` union first. Returns null for
      * scalar keywords, generics, arrays, or unresolvable identifiers.

--- a/src/Support/Types/TypeNodeResolver.php
+++ b/src/Support/Types/TypeNodeResolver.php
@@ -13,6 +13,7 @@ use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use ReflectionClass;
 use ReflectionMethod;
 use Reflector;
+use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\TypeContext\TypeContext;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
@@ -105,26 +106,58 @@ final class TypeNodeResolver
     }
 
     /**
+     * Descends through a single nullable wrapper to reach the inner type node:
+     * - `?T`       → `T`
+     * - `T|null`   → `T`  (only when there is exactly one non-null member)
+     * - anything else → returned unchanged
+     *
+     * Shared by {@see resolveClassName()} and {@see EloquentModelToSchema} so the
+     * null-unwrap logic has a single canonical implementation.
+     */
+    public function unwrapNullable(TypeNode $node): TypeNode
+    {
+        if ($node instanceof NullableTypeNode) {
+            return $node->type;
+        }
+
+        if ($node instanceof UnionTypeNode) {
+            $nonNull = null;
+
+            foreach ($node->types as $member) {
+                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
+                    continue;
+                }
+
+                if ($nonNull !== null) {
+                    // Multi-class union — not a simple nullable; return unchanged.
+                    return $node;
+                }
+
+                $nonNull = $member;
+            }
+
+            return $nonNull ?? $node;
+        }
+
+        return $node;
+    }
+
+    /**
      * Resolves the FQCN (no leading backslash) of a type node that denotes a single
      * class — unwrapping a leading `?` or a `T|null` union first. Returns null for
      * scalar keywords, generics, arrays, or unresolvable identifiers.
      */
     public function resolveClassName(TypeNode $node, Reflector $context): ?string
     {
-        if ($node instanceof NullableTypeNode) {
-            return $this->resolveClassName($node->type, $context);
-        }
+        $inner = $this->unwrapNullable($node);
 
-        if ($node instanceof UnionTypeNode) {
-            foreach ($node->types as $member) {
-                if ($member instanceof IdentifierTypeNode && strtolower($member->name) === 'null') {
-                    continue;
-                }
-
-                return $this->resolveClassName($member, $context);
-            }
-
-            return null;
+        // If unwrapNullable returned the same node, it is either:
+        //   (a) a plain IdentifierTypeNode needing no unwrap — handled by the identifier check below, or
+        //   (b) a multi-member union that cannot resolve to a single class — the instanceof check returns null.
+        if ($inner !== $node) {
+            return $inner instanceof IdentifierTypeNode
+                ? $this->resolveClass($inner, $context)
+                : null;
         }
 
         return $node instanceof IdentifierTypeNode
@@ -154,9 +187,17 @@ final class TypeNodeResolver
             }
         }
 
-        return $type instanceof ObjectType
-            ? ltrim($type->getClassName(), '\\')
-            : null;
+        if ($type instanceof ObjectType) {
+            return ltrim($type->getClassName(), '\\');
+        }
+
+        // symfony/type-info wraps same-namespace class identifiers (no `use` import needed) in a
+        // CollectionType whose inner wrapped type is the ObjectType — unwrap one level.
+        if ($type instanceof CollectionType && $type->getWrappedType() instanceof ObjectType) {
+            return ltrim($type->getWrappedType()->getClassName(), '\\');
+        }
+
+        return null;
     }
 
     private function contextFor(Reflector $context): ?TypeContext

--- a/tests/Feature/Plugins/Core/EloquentModelResponseTest.php
+++ b/tests/Feature/Plugins/Core/EloquentModelResponseTest.php
@@ -17,6 +17,22 @@ class ModelResponseController extends Controller
     {
         throw new LogicException('Signature-only fixture; never invoked.');
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection<int, Article>
+     */
+    public function list(): \Illuminate\Database\Eloquent\Collection
+    {
+        throw new LogicException('Signature-only fixture; never invoked.');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Http\Request>
+     */
+    public function nonModelCollection(): \Illuminate\Database\Eloquent\Collection
+    {
+        throw new LogicException('Signature-only fixture; never invoked.');
+    }
 }
 
 it('emits a 200 with a $ref for a single model return type', function (): void {
@@ -33,6 +49,18 @@ it('emits a 200 with a $ref for a single model return type', function (): void {
         ->and($spec['components']['schemas']['Article']['properties'])->toHaveKey('title');
 });
 
+it('emits an array of $ref for a Collection<Model> return type', function (): void {
+    Route::get('/articles', [ModelResponseController::class, 'list']);
+
+    $spec = generateSpec();
+
+    $schema = $spec['paths']['/articles']['get']['responses']['200']['content']['application/json']['schema'] ?? null;
+
+    expect($schema)->not->toBeNull()
+        ->and($schema['type'])->toBe('array')
+        ->and($schema['items']['$ref'])->toBe('#/components/schemas/Article');
+});
+
 it('does not emit a $ref response schema for a non-model return type', function (): void {
     Route::get('/plain-status', fn(): string => 'ok');
 
@@ -41,4 +69,14 @@ it('does not emit a $ref response schema for a non-model return type', function 
     $schema = $spec['paths']['/plain-status']['get']['responses']['200']['content']['application/json']['schema'] ?? null;
 
     expect($schema['$ref'] ?? null)->toBeNull();
+});
+
+it('does not emit an array $ref for a Collection of non-models', function (): void {
+    Route::get('/requests', [ModelResponseController::class, 'nonModelCollection']);
+
+    $spec = generateSpec();
+
+    $schema = $spec['paths']['/requests']['get']['responses']['200']['content']['application/json']['schema'] ?? null;
+
+    expect($schema['items']['$ref'] ?? null)->toBeNull();
 });

--- a/tests/Feature/Plugins/Core/EloquentModelResponseTest.php
+++ b/tests/Feature/Plugins/Core/EloquentModelResponseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature\Plugins\Core;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Route;
+use LogicException;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+
+uses()->group('openapi');
+
+class ModelResponseController extends Controller
+{
+    public function single(): Article
+    {
+        throw new LogicException('Signature-only fixture; never invoked.');
+    }
+}
+
+it('emits a 200 with a $ref for a single model return type', function (): void {
+    Route::get('/articles/{article}', [ModelResponseController::class, 'single']);
+
+    $spec = generateSpec();
+
+    $response = $spec['paths']['/articles/{article}']['get']['responses']['200'] ?? null;
+
+    expect($response)->not->toBeNull()
+        ->and($response['description'])->toBe('OK')
+        ->and($response['content']['application/json']['schema']['$ref'])
+        ->toBe('#/components/schemas/Article')
+        ->and($spec['components']['schemas']['Article']['properties'])->toHaveKey('title');
+});
+
+it('does not emit a $ref response schema for a non-model return type', function (): void {
+    Route::get('/plain-status', fn(): string => 'ok');
+
+    $spec = generateSpec();
+
+    $schema = $spec['paths']['/plain-status']['get']['responses']['200']['content']['application/json']['schema'] ?? null;
+
+    expect($schema['$ref'] ?? null)->toBeNull();
+});

--- a/tests/Fixtures/Enums/ArticleStatus.php
+++ b/tests/Fixtures/Enums/ArticleStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Enums;
+
+enum ArticleStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+}

--- a/tests/Fixtures/Models/Article.php
+++ b/tests/Fixtures/Models/Article.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Radiergummi\OpenApi\Tests\Fixtures\Enums\ArticleStatus;
+
+/**
+ * @property      string        $id
+ * @property      string        $internal_notes
+ * @property      Carbon        $published_at
+ * @property      ArticleStatus $status
+ * @property      ?string       $subtitle
+ * @property      string        $title
+ * @property-read Author        $author
+ */
+class Article extends Model
+{
+    protected $guarded = [];
+
+    protected $hidden = ['internal_notes'];
+
+    protected $appends = ['reading_time'];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+        'status' => ArticleStatus::class,
+    ];
+
+    /**
+     * @return BelongsTo<Author, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(Author::class);
+    }
+
+    public function getReadingTimeAttribute(): int
+    {
+        return 5;
+    }
+}

--- a/tests/Fixtures/Models/Article.php
+++ b/tests/Fixtures/Models/Article.php
@@ -17,6 +17,7 @@ use Radiergummi\OpenApi\Tests\Fixtures\Enums\ArticleStatus;
  * @property      ?string       $subtitle
  * @property      string        $title
  * @property-read Author        $author
+ * @property-read ?Author       $editor
  */
 class Article extends Model
 {

--- a/tests/Fixtures/Models/Author.php
+++ b/tests/Fixtures/Models/Author.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $id
+ * @property string $name
+ */
+class Author extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Fixtures/Models/VisibleArticle.php
+++ b/tests/Fixtures/Models/VisibleArticle.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $secret
+ * @property string $title
+ */
+class VisibleArticle extends Model
+{
+    protected $guarded = [];
+
+    protected $visible = ['title', 'reading_time'];
+
+    protected $appends = ['reading_time'];
+
+    public function getReadingTimeAttribute(): int
+    {
+        return 5;
+    }
+}

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -62,3 +62,25 @@ it('includes $appends names in the property set', function (): void {
 
     expect($schema['properties'])->toHaveKey('reading_time');
 });
+
+it('types scalar @property fields and marks nullable ones', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['properties']['title']['type'])->toBe('string')
+        ->and($schema['properties']['subtitle']['type'])->toBe('string')
+        ->and($schema['properties']['subtitle']['nullable'] ?? false)->toBeTrue();
+});
+
+it('marks non-nullable @property fields required and omits nullable ones', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['required'] ?? [])->toContain('title')
+        ->and($schema['required'] ?? [])->not->toContain('subtitle')
+        ->and($schema['required'] ?? [])->not->toContain('internal_notes');
+});
+
+it('marks a cast-typed field required when its @property is non-nullable', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['required'] ?? [])->toContain('published_at');
+});

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -98,6 +98,14 @@ it('types an $appends accessor from its return type', function (): void {
     expect($schema['properties']['reading_time']['type'])->toBe('integer');
 });
 
+it('restricts the property set to $visible when the allow-list is non-empty', function (): void {
+    $schema = readModelSchema(\Radiergummi\OpenApi\Tests\Fixtures\Models\VisibleArticle::class);
+
+    expect(array_keys($schema['properties'] ?? []))->toContain('title')
+        ->and(array_keys($schema['properties'] ?? []))->toContain('reading_time')
+        ->and($schema['properties'] ?? [])->not->toHaveKey('secret');
+});
+
 it('emits a $ref for a @property-read model relation and registers the nested component', function (): void {
     $registry = new ComponentSchemaRegistry();
     $logger = new NullLogger();

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Support\Extraction;
+
+use OpenApi\Annotations as OA;
+use Psr\Log\NullLogger;
+use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
+use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
+use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+
+uses()->group('openapi');
+
+/**
+ * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
+ *
+ * @return array<string, mixed>
+ */
+function readModelSchema(string $modelClass): array
+{
+    $registry = new ComponentSchemaRegistry();
+    $logger = new NullLogger();
+
+    $reader = new EloquentModelToSchema(
+        registry: $registry,
+        jsonSchemaFromType: new JsonSchemaFromType($logger),
+        typeResolver: TypeResolver::create(),
+        typeNodeResolver: TypeNodeResolver::create(),
+        docBlockParser: DocBlockParser::create(),
+        logger: $logger,
+    );
+
+    $key = $reader->build($modelClass);
+
+    /** @var OA\Schema $schema */
+    $schema = collect($registry->all())->firstWhere('schema', $key);
+
+    return json_decode(json_encode($schema), associative: true);
+}
+
+it('maps datetime casts to string/date-time', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['type'])->toBe('object')
+        ->and($schema['properties']['published_at']['type'])->toBe('string')
+        ->and($schema['properties']['published_at']['format'])->toBe('date-time');
+});
+
+it('excludes $hidden fields', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['properties'])->not->toHaveKey('internal_notes');
+});
+
+it('includes $appends names in the property set', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['properties'])->toHaveKey('reading_time');
+});

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -97,3 +97,25 @@ it('types an $appends accessor from its return type', function (): void {
 
     expect($schema['properties']['reading_time']['type'])->toBe('integer');
 });
+
+it('emits a $ref for a @property-read model relation and registers the nested component', function (): void {
+    $registry = new ComponentSchemaRegistry();
+    $logger = new NullLogger();
+
+    $reader = new EloquentModelToSchema(
+        registry: $registry,
+        jsonSchemaFromType: new JsonSchemaFromType($logger),
+        typeResolver: TypeResolver::create(),
+        typeNodeResolver: TypeNodeResolver::create(),
+        docBlockParser: DocBlockParser::create(),
+        logger: $logger,
+    );
+
+    $reader->build(Article::class);
+
+    $article = json_decode(json_encode(collect($registry->all())->firstWhere('schema', 'Article')), true);
+    $authorRegistered = collect($registry->all())->firstWhere('schema', 'Author');
+
+    expect($article['properties']['author']['$ref'])->toBe('#/components/schemas/Author')
+        ->and($authorRegistered)->not->toBeNull();
+});

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -17,11 +17,14 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 uses()->group('openapi');
 
 /**
- * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
+ * Builds the model's schema and returns the live OA\Schema object. Assert on the object's
+ * properties to see the OAS 3.1 type unions (`type: ['…', 'null']`) — swagger-php's raw
+ * json_encode down-converts those to the 3.0 `nullable: true` form, so {@see readModelSchema()}
+ * (the array view) is only suitable for version-agnostic assertions.
  *
- * @return array<string, mixed>
+ * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
  */
-function readModelSchema(string $modelClass): array
+function buildModelSchema(string $modelClass): OA\Schema
 {
     $registry = new ComponentSchemaRegistry();
     $logger = new NullLogger();
@@ -40,7 +43,28 @@ function readModelSchema(string $modelClass): array
     /** @var OA\Schema $schema */
     $schema = collect($registry->all())->firstWhere('schema', $key);
 
-    return json_decode(json_encode($schema), associative: true);
+    return $schema;
+}
+
+/**
+ * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
+ *
+ * @return array<string, mixed>
+ */
+function readModelSchema(string $modelClass): array
+{
+    return json_decode(json_encode(buildModelSchema($modelClass)), associative: true);
+}
+
+/**
+ * Returns the named property object from a built model schema.
+ */
+function modelProperty(OA\Schema $schema, string $name): OA\Property
+{
+    /** @var OA\Property $property */
+    $property = collect($schema->properties)->firstWhere('property', $name);
+
+    return $property;
 }
 
 it('maps datetime casts to string/date-time', function (): void {
@@ -63,12 +87,13 @@ it('includes $appends names in the property set', function (): void {
     expect($schema['properties'])->toHaveKey('reading_time');
 });
 
-it('types scalar @property fields and marks nullable ones', function (): void {
-    $schema = readModelSchema(Article::class);
+it('types scalar @property fields and expresses nullable ones via the OAS 3.1 idiom', function (): void {
+    $schema = buildModelSchema(Article::class);
 
-    expect($schema['properties']['title']['type'])->toBe('string')
-        ->and($schema['properties']['subtitle']['type'])->toBe('string')
-        ->and($schema['properties']['subtitle']['nullable'] ?? false)->toBeTrue();
+    // OAS 3.1 removed `nullable`; a nullable scalar widens its `type` to include 'null'. Asserted
+    // on the object because swagger-php's json_encode down-converts the union to `nullable: true`.
+    expect(modelProperty($schema, 'title')->type)->toBe('string')
+        ->and(modelProperty($schema, 'subtitle')->type)->toBe(['string', 'null']);
 });
 
 it('marks non-nullable @property fields required and omits nullable ones', function (): void {
@@ -126,4 +151,19 @@ it('emits a $ref for a @property-read model relation and registers the nested co
 
     expect($article['properties']['author']['$ref'])->toBe('#/components/schemas/Author')
         ->and($authorRegistered)->not->toBeNull();
+});
+
+it('wraps a nullable relation $ref in oneOf (OAS 3.1) rather than a dropped sibling nullable', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    // A bare $ref ignores sibling keywords in OAS 3.1, so nullability must be expressed as a
+    // oneOf of the ref and a null type — not `{$ref, nullable: true}`.
+    $editor = $schema['properties']['editor'];
+
+    expect($editor)->not->toHaveKey('$ref')
+        ->and($editor)->not->toHaveKey('nullable')
+        ->and($editor['oneOf'])->toBe([
+            ['$ref' => '#/components/schemas/Author'],
+            ['type' => 'null'],
+        ]);
 });

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -84,3 +84,16 @@ it('marks a cast-typed field required when its @property is non-nullable', funct
 
     expect($schema['required'] ?? [])->toContain('published_at');
 });
+
+it('maps an enum cast to an inline enum schema', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['properties']['status']['type'])->toBe('string')
+        ->and($schema['properties']['status']['enum'])->toBe(['draft', 'published']);
+});
+
+it('types an $appends accessor from its return type', function (): void {
+    $schema = readModelSchema(Article::class);
+
+    expect($schema['properties']['reading_time']['type'])->toBe('integer');
+});

--- a/tests/Unit/Support/Types/TypeNodeResolverTest.php
+++ b/tests/Unit/Support/Types/TypeNodeResolverTest.php
@@ -14,12 +14,24 @@ use RuntimeException;
 use stdClass;
 
 /**
+ * Same-namespace value class referenced bare (no `use` import) in a generic below, exercising the
+ * CollectionType-unwrap branch symfony/type-info takes for same-namespace identifiers.
+ */
+class SameNamespaceValue {}
+
+/**
  * Fixture supplies the namespace + `use` context the resolver reads.
  */
 class TypeNodeResolverFixture
 {
     /** @return Collection<int, stdClass> */
     public function generic(): Collection
+    {
+        return new Collection();
+    }
+
+    /** @return Collection<int, SameNamespaceValue> */
+    public function sameNamespaceGeneric(): Collection
     {
         return new Collection();
     }
@@ -62,6 +74,14 @@ it('resolves the value class of a generic to an FQCN', function (): void {
     $type = $parser->parse((string) $method->getDocComment())->returnType();
 
     expect($resolver->genericValueClass($type, $method))->toBe('stdClass');
+});
+
+it('resolves a same-namespace generic value class via the CollectionType branch', function (): void {
+    [$parser, $resolver] = makeResolverPair();
+    $method = new ReflectionMethod(TypeNodeResolverFixture::class, 'sameNamespaceGeneric');
+    $type = $parser->parse((string) $method->getDocComment())->returnType();
+
+    expect($resolver->genericValueClass($type, $method))->toBe(SameNamespaceValue::class);
 });
 
 it('resolves the value class of a nullable generic', function (): void {


### PR DESCRIPTION
## What & why

Closes #18 (epic #6 — Response-body schema fidelity, Tier-0).

Returning a model directly (`function show(): Flight`) is the most common Laravel response shape, yet the generator reads none of the model's metadata and emits an empty body. This builds a response schema from the model's own metadata — pure reflection, no method-body parsing — closing the highest-leverage response-fidelity gap in the OSS survey.

Spec & decisions: https://github.com/Radiergummi/laravel-openapi/issues/18#issuecomment-4613636060

## Scope (this PR)

- A plugin-agnostic **`EloquentModelToSchema` reader** in `src/Support/Extraction/` (beside `ValidationRulesToSchema`/`FakerExampleSynthesiser`) → model class to a reusable `#/components/schemas/{Model}` component.
- A Core **`EloquentModelResponseResolver`** (`PrimaryResponseResolver`) for **direct model** and **`Collection<Model>`** returns.

Smarts stay gated behind Core (disable Core → no model schemas); the reader is reusable Support infra so the ApiResources plugin can consume it later.

### Decisions (from brainstorming)

- **Tier-0 only.** `find()`/`findOrFail()` body-scan source descoped (Tier-1, needs #5) → **#97**.
- **Resource-wrapping** → ApiResources plugin follow-up reusing the reader → **#98**.
- **Property sources:** `$casts` (authoritative) → `@property`/`@property-read` (typed, IDE-helper-friendly) → `$appends` accessor return type → empty "unknown" fallback. Minus `$hidden`; `$visible` as allow-list. **No DB / no migration parsing** (keeps generation deterministic).
- **Relations** (`@property-read Author $author`) → `$ref` to the related model's component, recursed via `ComponentSchemaRegistry::buildOnce()` with the existing cycle guard.
- `required` only with positive non-nullability evidence; `#[ResponseField]` remains the escape hatch.

## File structure

| File | Action |
|---|---|
| `src/Support/Extraction/EloquentModelToSchema.php` | create — the reader (`build(class): string`) |
| `src/Support/Generator/JsonSchemaFromType.php` | modify — extract public `fromBackedEnumClass()` |
| `src/Support/Types/TypeNodeResolver.php` | modify — add public `resolveClassName()` |
| `src/Plugins/Core/Resolvers/EloquentModelResponseResolver.php` | create — the resolver |
| `src/Plugins/Core/CorePlugin.php` | modify — register after `PaginatorResponseResolver` |
| `tests/Fixtures/Models/{Article,Author}.php`, `tests/Fixtures/Enums/ArticleStatus.php` | create — fixtures |
| `tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php` | create — reader unit tests |
| `tests/Feature/Plugins/Core/EloquentModelResponseTest.php` | create — resolver feature tests |
| `examples/vanilla/Http/TypedFlightController.php` + routes + `openapi.yaml` | create/modify — e2e flavor |
| `CHANGELOG.md`, `docs/` | modify |

## Implementation plan (TDD, one commit per task)

1. **Reader: property set + cast→schema map** — union of cast keys/fillable/appends/`@property` names minus `$hidden`, `$visible` allow-list; scalar/datetime/decimal/array cast mapping.
2. **Reader: `@property` typing + nullability + `required`** — adds `TypeNodeResolver::resolveClassName()`; scalar `@property` types, `?T` → `nullable`, `required` = non-nullable annotated fields.
3. **Reader: enum casts + `$appends` accessors** — extracts reusable `JsonSchemaFromType::fromBackedEnumClass()`; appended attributes typed from accessor return types.
4. **Reader: relation `$ref`s** — `@property-read Model` → `$ref`, recursed & cycle-guarded.
5. **`EloquentModelResponseResolver`: single model** — reflection-detect a `Model` return, emit `200` `$ref`; register in `CorePlugin`.
6. **Resolver: `Collection<Model>`** — `@return Collection<Model>` generic → `array` of `$ref`.
7. **`#[ResponseField]` merge** — escape-hatch virtual fields win over inference.
8. **E2E vanilla flavor** — typed `Flight` controller + routes, regenerate snapshot (snapshot + OpenAPI 3.1 validate + lint-clean).
9. **Docs + CHANGELOG**.
10. **Gates + finalize** — `composer test`, `composer lint`, `vendor/bin/pint --test`; mark PR ready.

Granular task-by-task plan (with full code per step) is tracked locally per the superpowers workflow; deviations will be recorded as PR comments.

## Follow-ups spun out

- #97 — `find()`/`findOrFail()` model-class source (Tier-1, blocked on #5)
- #98 — ApiResources resource-wrapping reuses `EloquentModelToSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
