### PR TITLE
feat(#68): selectable operationId strategy + return-type nudge lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- `openapi.operation_id_strategy` config key selecting how each operation's `operationId` is derived: `'route-name'` (default — the existing behaviour: sanitised route name, or `{method}_{path}` for unnamed routes; byte-stable with prior output) or `'method-path'` (always `{method}_{path}`, ignoring route names — for client toolchains where route names aren't meaningful method names). Every strategy's output is sanitised to satisfy the `operation.id-invalid-chars` rule; unknown values fall back to `'route-name'`. (#43)
+- Lint rule `operation.return-type-missing` (level 3): nudges controller actions that have neither a usable return type (absent / `mixed` / `void`-like) nor a response-declaring attribute (`#[Response]` / `#[ResponseResource]`) — the most common reason a generated operation emits no response schema. Documentation-quality only; off at the default `--level 1`. (#44)
+
 - Response schemas are now derived from Eloquent model metadata when a controller returns a model
   (or a `Collection<Model>`) directly. The schema is built by reflection from `$casts`, the model's
   `@property`/`@property-read` docblock, typed `$appends` accessors, and `$hidden`/`$visible`;

--- a/config/openapi.php
+++ b/config/openapi.php
@@ -371,6 +371,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | operationId Strategy
+    |--------------------------------------------------------------------------
+    |
+    | Controls how each operation's `operationId` is derived. Whatever strategy
+    | is selected, the result is always sanitised to the codegen-safe identifier
+    | shape enforced by the `operation.id-invalid-chars` lint rule.
+    |
+    |   'route-name' (default) — use the route name (with a `.{method}` suffix
+    |       for multi-verb routes); unnamed routes fall back to `{method}_{path}`.
+    |   'method-path'          — always `{method}_{path}`, ignoring route names.
+    |       Useful when route names aren't stable or meaningful as method names
+    |       in a generated client.
+    |
+    | Unknown values fall back to 'route-name'.
+    |
+    */
+
+    'operation_id_strategy' => 'route-name',
+
+    /*
+    |--------------------------------------------------------------------------
     | Operation Overrides
     |--------------------------------------------------------------------------
     |

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,7 @@ this page is the at-a-glance summary.
 | `servers` | List of `OA\Server` entries. Default uses `APP_URL`. |
 | `tags` | Document-level tag descriptions keyed by tag name. |
 | `output_path` | Absolute path the `openapi:generate` command writes to and the spec route serves from. Defaults to `storage_path('openapi.yaml')`. |
+| `operation_id_strategy` | How each operation's `operationId` is derived: `'route-name'` (default — route name, or `{method}_{path}` for unnamed routes) or `'method-path'` (always `{method}_{path}`, ignoring route names). Output is always sanitised to satisfy `operation.id-invalid-chars`. Unknown values fall back to `'route-name'`. |
 | `exception_responses` | Maps exception FQCNs (or short names) to `['status', 'description']`. See [precedence](#exception-response-precedence) below. |
 | `middleware_responses` | 401/403/429 responses keyed by Laravel middleware alias (`auth`/`scope`/`throttle`) — only fills status codes no `@throws`-derived response already supplied. |
 | `security_schemes` | Custom OpenAPI security schemes. Merged with the auto-derived defaults (Passport's OAuth2 flows; a `sanctum` http/bearer scheme when any route uses `auth:sanctum`); config wins on key collision. See [Recipes → Declare custom security schemes](recipes.md#declare-custom-security-schemes). |

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -347,6 +347,7 @@ plugin-registered rules.
 | `meta.too-many-suppressions` | 3 | Symbol carries an excessive number of suppression directives. |
 | `meta.unknown-rule` | 3 | #[IgnoreLint] references a rule ID not in the registry. |
 | `operation.id-naming-inconsistent` | 3 | operationId doesn't follow the configured operation_id_case convention. |
+| `operation.return-type-missing` | 3 | Action has no typed return value or response attribute, so no response schema can be inferred. |
 | `operation.summary-equals-description` | 3 | Operation summary and description are identical (redundant). |
 | `overrides.unknown-field` | 3 | An `openapi.overrides` block sets a field outside the allowlist (operationId, summary, description, tags, deprecated, x-*). |
 | `overrides.unused` | 3 | An `openapi.overrides` key matches no route name and no route URI. |

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -84,6 +84,13 @@ parameters:
             identifier: argument.type
             paths:
                 - tests/Fixtures/Lint/
+        # The ReturnTypeNudgeController fixture intentionally omits return types — the missing
+        # return type is exactly what the `operation.return-type-missing` lint rule detects, so
+        # adding types would defeat the fixture.
+        -
+            identifier: missingType.return
+            paths:
+                - tests/Fixtures/Lint/ReturnTypeNudgeController.php
         # Attribute-misuse fixtures intentionally trip the bundled PHPStan rules so the linter
         # / generator tests have something to consume. The static rules report the misuse for
         # everyone else; here the misuse is the test input. Identifiers use camelCase because

--- a/src/Lint/Rules/ActionMissingReturnType.php
+++ b/src/Lint/Rules/ActionMissingReturnType.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Rules;
+
+use Override;
+use Radiergummi\OpenApi\Attributes\Response;
+use Radiergummi\OpenApi\Attributes\ResponseResource;
+use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\LintContext;
+use Radiergummi\OpenApi\Lint\Tree\OperationNode;
+use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use ReflectionNamedType;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * Reports controller actions that carry neither a usable return type nor a response-declaring
+ * attribute — the most common reason a generated operation ends up with no response schema.
+ *
+ * Response inference reads the action's return type; when that is absent, `mixed`, or `void`-like
+ * and no `#[Response]` / `#[ResponseResource]` is present, there is nothing to infer from and the
+ * operation silently emits a bare success response. This is a low-severity documentation nudge,
+ * not a hard error: stay silent the moment either signal exists.
+ */
+final class ActionMissingReturnType implements Rule, OperationRuleVisitor
+{
+    /**
+     * @return iterable<Finding>
+     */
+    #[Override]
+    public function checkOperation(OperationNode $operation, LintContext $context): iterable
+    {
+        if ($operation->webhook || $operation->descriptor === null) {
+            return;
+        }
+
+        $descriptor = $operation->descriptor;
+
+        if ($this->hasResponseAttribute($descriptor) || $this->hasUsableReturnType($descriptor)) {
+            return;
+        }
+
+        yield new Finding(
+            ruleId: $this->id(),
+            level: $this->level(),
+            message: sprintf(
+                '%s::%s() has no return type or response attribute, so no response schema can be inferred',
+                $descriptor->controller?->getShortName() ?? '(unknown)',
+                $descriptor->method?->getName() ?? '(unknown)',
+            ),
+            fixHint: 'Add a return type to the action, or annotate it with #[Response] / #[ResponseResource].',
+        );
+    }
+
+    private function hasResponseAttribute(ActionDescriptor $descriptor): bool
+    {
+        return $descriptor->attributeInstances(Response::class) !== []
+            || $descriptor->attributeInstances(ResponseResource::class) !== [];
+    }
+
+    /**
+     * A return type is "usable" when it is declared and not `mixed`, `void`, or `never` — anything
+     * the generator could in principle shape a response from. An absent type is not usable.
+     */
+    private function hasUsableReturnType(ActionDescriptor $descriptor): bool
+    {
+        $returnType = $descriptor->actionReflector?->getReturnType();
+
+        if ($returnType === null) {
+            return false;
+        }
+
+        if (!$returnType instanceof ReflectionNamedType) {
+            // Union/intersection types are still a declared shape.
+            return true;
+        }
+
+        return !in_array($returnType->getName(), ['mixed', 'void', 'never'], true);
+    }
+
+    #[Override]
+    public function id(): string
+    {
+        return 'operation.return-type-missing';
+    }
+
+    #[Override]
+    public function level(): int
+    {
+        return 3;
+    }
+
+    #[Override]
+    public function description(): string
+    {
+        return 'Action has no typed return value or response attribute, so no response schema can be inferred.';
+    }
+}

--- a/src/Support/Generator/BaselineRegistration.php
+++ b/src/Support/Generator/BaselineRegistration.php
@@ -7,6 +7,7 @@ namespace Radiergummi\OpenApi\Support\Generator;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseContributor;
 use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseResolver;
+use Radiergummi\OpenApi\Lint\Rules\ActionMissingReturnType;
 use Radiergummi\OpenApi\Lint\Rules\ComponentNameNamingInconsistent;
 use Radiergummi\OpenApi\Lint\Rules\ComponentOrphaned;
 use Radiergummi\OpenApi\Lint\Rules\DeprecatedAttribute;
@@ -230,6 +231,7 @@ final class BaselineRegistration
         SchemaExampleMissing::class,
         OperationDescriptionMissing::class,
         OperationSummaryEqualsDescription::class,
+        ActionMissingReturnType::class,
         EnumValuesUndocumented::class,
         WebhookDescriptionMissing::class,
         DeprecatedNoSunsetDate::class,

--- a/src/Support/Generator/Stages/PathsStage.php
+++ b/src/Support/Generator/Stages/PathsStage.php
@@ -28,6 +28,7 @@ use function array_filter;
 use function array_reverse;
 use function array_values;
 use function assert;
+use function config;
 use function count;
 use function explode;
 use function in_array;
@@ -192,21 +193,40 @@ final readonly class PathsStage implements SpecStage
     }
 
     /**
-     * Builds an operation ID for the given route.
+     * Builds an operation ID for the given route, dispatching on the configured
+     * `openapi.operation_id_strategy`:
      *
+     * - `route-name` (default) → {@see routeNameOperationId}: named route verbatim (sanitised),
+     *   unnamed routes fall back to `{method}_{path}`.
+     * - `method-path` → {@see methodPathOperationId}: always `{method}_{path}`, ignoring names.
+     *
+     * Unknown values fall back to the default. Every strategy's output satisfies the
+     * `operation.id-invalid-chars` pattern.
+     */
+    private function buildOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
+    {
+        if (config('openapi.operation_id_strategy') === 'method-path') {
+            return $this->methodPathOperationId($descriptor, $method);
+        }
+
+        return $this->routeNameOperationId($descriptor, $method);
+    }
+
+    /**
      * Priority:
      * 1. Named route → `{name}.{method}` for multi-method routes, plain `{name}` otherwise.
      * 2. Generated/unnamed (`generated::*` prefix or null) → `{method}_{sanitised_path}`.
      */
-    private function buildOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
+    private function routeNameOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
     {
         $name = $descriptor->route->getName();
-        $methods = array_filter(
-            $descriptor->route->methods(),
-            static fn(string $method): bool => HttpMethod::fromString($method) !== HttpMethod::Head,
-        );
 
         if ($name !== null && !Str::startsWith($name, 'generated::')) {
+            $methods = array_filter(
+                $descriptor->route->methods(),
+                static fn(string $method): bool => HttpMethod::fromString($method) !== HttpMethod::Head,
+            );
+
             $operationId = count($methods) > 1
                 ? $name . '.' . strtolower($method->value)
                 : $name;
@@ -214,6 +234,11 @@ final readonly class PathsStage implements SpecStage
             return $this->sanitiseOperationId($operationId);
         }
 
+        return $this->methodPathOperationId($descriptor, $method);
+    }
+
+    private function methodPathOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
+    {
         $sanitised = preg_replace('/[^a-zA-Z0-9]+/', '_', $descriptor->route->uri())
             ?? $descriptor->route->uri();
 

--- a/tests/Feature/OperationIdStrategyTest.php
+++ b/tests/Feature/OperationIdStrategyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+
+uses()->group('openapi');
+
+beforeEach(function (): void {
+    Route::get('/users', static fn(): array => [])->name('users.index');
+    Route::get('/health/check', static fn(): array => []); // unnamed
+});
+
+it('defaults to the route-name strategy (byte-stable)', function (): void {
+    $spec = generateSpec();
+
+    expect($spec['paths']['/users']['get']['operationId'])->toBe('users.index')
+        ->and($spec['paths']['/health/check']['get']['operationId'])->toBe('get_health_check');
+});
+
+it('honours the method-path strategy, ignoring route names', function (): void {
+    config()->set('openapi.operation_id_strategy', 'method-path');
+
+    $spec = generateSpec();
+
+    expect($spec['paths']['/users']['get']['operationId'])->toBe('get_users')
+        ->and($spec['paths']['/health/check']['get']['operationId'])->toBe('get_health_check');
+});
+
+it('falls back to the default strategy for an unknown value', function (): void {
+    config()->set('openapi.operation_id_strategy', 'nonsense');
+
+    $spec = generateSpec();
+
+    expect($spec['paths']['/users']['get']['operationId'])->toBe('users.index');
+});
+
+it('produces codegen-safe ids under every strategy', function (string $strategy): void {
+    config()->set('openapi.operation_id_strategy', $strategy);
+
+    $spec = generateSpec();
+
+    foreach ($spec['paths'] as $methods) {
+        foreach ($methods as $operation) {
+            expect($operation['operationId'])->toMatch('/^[A-Za-z][A-Za-z0-9._-]*$/');
+        }
+    }
+})->with(['route-name', 'method-path']);

--- a/tests/Fixtures/Lint/ReturnTypeNudgeController.php
+++ b/tests/Fixtures/Lint/ReturnTypeNudgeController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;
+
+use Radiergummi\OpenApi\Attributes\Response;
+use Radiergummi\OpenApi\Attributes\ResponseResource;
+use stdClass;
+
+class ReturnTypeNudgeController
+{
+    public function untyped(string $value) {}
+
+    public function mixedReturn(): mixed
+    {
+        return null;
+    }
+
+    public function voidReturn(): void {}
+
+    public function typedArray(): array
+    {
+        return [];
+    }
+
+    #[Response(status: 200, description: 'OK')]
+    public function withResponseAttribute() {}
+
+    #[ResponseResource(class: stdClass::class)]
+    public function withResponseResourceAttribute() {}
+}

--- a/tests/Unit/Lint/Rules/ActionMissingReturnTypeTest.php
+++ b/tests/Unit/Lint/Rules/ActionMissingReturnTypeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Rules\ActionMissingReturnType;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\ReturnTypeNudgeController;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
+use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
+
+uses()->group('openapi', 'lint');
+
+function returnTypeNudgeFindings(string $method): array
+{
+    $descriptor = ActionDescriptorFactory::forControllerMethod(ReturnTypeNudgeController::class, $method);
+    $operation = OperationNodeFactory::forDescriptor($descriptor);
+
+    return iterator_to_array(
+        new ActionMissingReturnType()->checkOperation($operation, OperationNodeFactory::emptyContext()),
+    );
+}
+
+it('reports its id and level', function (): void {
+    $rule = new ActionMissingReturnType();
+
+    expect($rule->id())->toBe('operation.return-type-missing')
+        ->and($rule->level())->toBe(3);
+});
+
+it('emits a finding when the action has no return type and no response attribute', function (): void {
+    $findings = returnTypeNudgeFindings('untyped');
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->ruleId)->toBe('operation.return-type-missing')
+        ->and($findings[0]->level)->toBe(3)
+        ->and($findings[0]->message)->toContain('ReturnTypeNudgeController')
+        ->and($findings[0]->message)->toContain('untyped')
+        ->and($findings[0]->fixHint)->not->toBeNull();
+});
+
+it('emits a finding for a mixed return type', function (): void {
+    expect(returnTypeNudgeFindings('mixedReturn'))->toHaveCount(1);
+});
+
+it('emits a finding for a void return type', function (): void {
+    expect(returnTypeNudgeFindings('voidReturn'))->toHaveCount(1);
+});
+
+it('emits no finding', function (string $method): void {
+    expect(returnTypeNudgeFindings($method))->toBe([]);
+})->with([
+    'typed return value' => ['typedArray'],
+    'untyped but carries #[Response]' => ['withResponseAttribute'],
+    'untyped but carries #[ResponseResource]' => ['withResponseResourceAttribute'],
+]);


### PR DESCRIPTION
## Plan

Closes #43, closes #44 (both sub-issues of epic #68). #42 already merged.

### Prior state (discovered while scoping)
- #42's named-route operationId sanitisation is **already on `main`** (`PathsStage::sanitiseOperationId`).
- #43's **collision lint rule is already implemented**: `Lint\Rules\OperationIdDuplicate` (`operation.id-duplicate`, level 0) is registered in `BaselineRegistration`, tested, and in the docs catalog. So only the **strategy-selection half of #43 remains**.

### #43 — selectable operationId strategy
- New flat config key `operation_id_strategy` in `config/openapi.php` (mirrors the flat `error_envelope` scalar; consistent with `operation_id_case`).
  - `'route-name'` (default) — current behaviour, byte-stable: sanitised route name (`.method` suffix for multi-method routes), unnamed routes fall back to `{method}_{uri}`.
  - `'method-path'` — always `{method}_{sanitised_uri}`, ignoring route names.
- `PathsStage::buildOperationId()` dispatches on the config value; existing branches become the two strategy implementations. Unknown values fall back to the default. Every strategy's output satisfies `operation.id-invalid-chars`.
- Feature test asserting ids per strategy via `generateSpec()`; docs (`docs/config.md`) + CHANGELOG.

### #44 — "action missing return type" nudge
- New `Lint\Rules\ActionMissingReturnType` (`operation.return-type-missing`, level 3 doc-quality, off at default `--level 1`).
- `OperationRule`; reads the `ActionDescriptor` off the operation node. Fires only when **both**: the action's return type is absent / `mixed` / `void`-like, **and** no `#[Response]` / `#[ResponseResource]` (action- or class-level). Otherwise silent.
- Registered in `BaselineRegistration`. Unit test + small controller fixtures under `tests/Fixtures/Lint/`; docs catalog row + CHANGELOG.

### Verify
`vendor/bin/pest tests/Unit/Lint/Rules tests/Feature`, `vendor/bin/pint --test`, `composer lint`.
