### PR TITLE
docs: recipe for reshaping operationIds via transformOperation()

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ New to the package? Read [Getting started](getting-started.md), then
 | [Auto-derivation](auto-derivation.md) | Which part of the spec comes from which part of your code. |
 | [Request bodies](request-bodies.md) | `FormRequest` vs Spatie Data; validation-rule → schema mapping. |
 | [Attributes](attributes.md) | Escape-hatch catalog. |
-| [Recipes](recipes.md) | Short snippets for streaming, multipart, polymorphism, links, and security schemes. |
+| [Recipes](recipes.md) | Short snippets for streaming, multipart, polymorphism, links, operationIds, and security schemes. |
 | [Plugins](plugins.md) | Bundled plugins: SpatieData, ApiResources, QueryBuilder, Fractal. |
 | [Linting](linting.md) | `openapi:lint`, severity levels, rule catalog, `#[IgnoreLint]`. |
 | [Multi-spec](multi-spec.md) | Multiple OpenAPI documents from one app. |

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -349,6 +349,37 @@ Drop the scoping check to apply the extension to every operation. For
 document-level or schema-level extensions, use `transformDocument()` and
 `transformSchema()`. See [Extensions](extensions.md).
 
+## Reshape the operationId
+
+operationIds default to the route name (`api.v1.projects.index`); the
+`operation_id_strategy` config key switches between `route-name` and
+`method-path`. To reshape them beyond those two presets — e.g. strip a
+versioned `api.v{N}.` route-name prefix so a generated client reads
+`projects.index` rather than `api.v1.projects.index` — register an operation
+transformer at boot. `OperationContext` exposes the route, so any
+route-derived rule works:
+
+```php
+// AppServiceProvider::boot()
+use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Extensions\OpenApiExtensions;
+use Radiergummi\OpenApi\Extensions\OperationContext;
+
+OpenApiExtensions::transformOperation(
+    static function (OA\Operation $operation, OperationContext $context): void {
+        $routeName = $context->descriptor->route->getName();
+
+        if ($routeName !== null && preg_match('/^api\.v\d+\./', $routeName)) {
+            $operation->operationId = preg_replace('/^api\.v\d+\./', '', $routeName);
+        }
+    },
+);
+```
+
+Keep the result within the codegen-safe identifier shape — the
+`operation.id-invalid-chars` lint rule flags violations, and
+`lint.style.operation_id_case` enforces the casing convention.
+
 ## Suppress a lint finding
 
 ```php


### PR DESCRIPTION
## What

Adds a **Recipes** entry — *Reshape the operationId* — documenting how to customize the generated `operationId` (e.g. strip a versioned `api.v{N}.` route-name prefix → `projects.index`) via the existing `OpenApiExtensions::transformOperation()` hook. `OperationContext` exposes the route (`$context->descriptor->route`), so any route-derived rule works. Also adds "operationIds" to the Recipes row in the docs index.

## Why

The two built-in `operation_id_strategy` presets (`route-name` / `method-path`) don't cover prefix-stripping, but the per-operation transformer hook already does — it just wasn't documented as the answer. Surfaced during the **AdvisingApp full-spec dogfood**: AdvisingApp ships a Scramble `OperationIdGeneratorExtension` that strips the `api.v{N}.` prefix, and we confirmed `transformOperation()` is the direct equivalent (operationIds collapse to match, lint stays clean). No new config knob needed — documentation closes the gap.

## Notes

- Docs-only; no behaviour change, so no `CHANGELOG.md` entry.
- Verified the referenced `operation.id-invalid-chars` lint rule and `lint.style.operation_id_case` config key both exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)