### PR TITLE
chore: gitignore transient .claude run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .cache/
 .claude/settings.local.json
 .claude/worktrees/
+.claude/workflows/
+.claude/scheduled_tasks.lock
 vendor/
 docs/superpowers/
 docs/internal/


### PR DESCRIPTION
Extends the existing selective `.claude/` ignores (`settings.local.json`, `worktrees/`) with two more machine-generated agent run artifacts:

- `.claude/workflows/` — whole directory, mirroring the existing `.claude/worktrees/` ignore
- `.claude/scheduled_tasks.lock` — transient lock file

### Why

`.claude/scheduled_tasks.lock` and `.claude/workflows/fullspec-analysis.js` leaked into the #133 branch (#137) via a `git add -A` because the directory wasn't ignored. They've since been removed from that branch's history; this prevents recurrence across all branches.

Kept the per-path style the repo already uses rather than blanket-ignoring `.claude/`, so deliberately-tracked `.claude/` content (e.g. shared skills) stays possible. Shout if you'd rather track some workflows — I can narrow `.claude/workflows/` to the specific lock/state files instead.