### PR TITLE
refactor(lint): extract methods from LintRunner & SpecTreeBuilder

### DIFF
--- a/src/Lint/LintRunner.php
+++ b/src/Lint/LintRunner.php
@@ -163,27 +163,7 @@ final readonly class LintRunner
     ): LintResult {
         // region Descriptor collection + path/diff filtering
 
-        $descriptors = [];
-
-        // The introspector yields every Laravel route; vendor routes (Telescope, Nova, Passport,
-        // Ignition) and any user-configured filter rejects are discarded here so the pre-build
-        // rules and tree walk only see routes that could plausibly belong to a spec. Per-spec
-        // InclusionEvaluator::decide() still runs inside the generator and re-filters per
-        // (route × spec), so this is the single-pass equivalent.
-        foreach ($this->introspector->discover() as $descriptor) {
-            if (!$this->evaluator->passesGlobalFilters($descriptor)) {
-                continue;
-            }
-
-            $descriptors[] = $descriptor;
-        }
-
-        $descriptors = $this->routeFilter->filter(
-            descriptors: $descriptors,
-            uriGlob: $options->uriGlob,
-            files: $options->files,
-            diff: $options->diff,
-        );
+        $descriptors = $this->collectDescriptors($options);
 
         // When --path or --diff narrows the route set, build the allowed-URI set up front so
         // post-processing can drop findings emitted by generation stages (e.g. RequestBodyExtractor,
@@ -313,26 +293,10 @@ final readonly class LintRunner
                 inference: $inference,
             );
 
-            foreach ($operations as $operation) {
-                // Scope the coverage denominator the same way findings are scoped: when a route
-                // filter is active, an out-of-scope operation must not count. walkSpec already
-                // restricts $document->paths when $descriptors is non-empty, but an empty match
-                // (e.g. a glob that hits nothing) leaves every operation in $api->operations, so
-                // gate the URI explicitly here.
-                if ($allowedRouteUris !== null && !isset($allowedRouteUris[ltrim($operation->pathUri, '/')])) {
-                    continue;
-                }
-
-                $key = CoverageCalculator::operationKey(
-                    $spec->name,
-                    $operation->method,
-                    $operation->pathUri,
-                );
-
-                if ($key !== null) {
-                    $operationTags[$key] = $operation->tags;
-                }
-            }
+            $operationTags = [
+                ...$operationTags,
+                ...$this->collectOperationTags($operations, $allowedRouteUris, $spec->name),
+            ];
 
             foreach ($specLocal->all() as $finding) {
                 $emit->emit($finding->withSpec($spec->name));
@@ -343,7 +307,131 @@ final readonly class LintRunner
 
         // region Post-processing: overrides, --only/--skip, suppressions, level filter
 
-        $findings = $this->registry->applyOverrides($inner->all());
+        $findings = $this->filterFindings(
+            $inner->all(),
+            $options,
+            $level,
+            $only,
+            $skip,
+            $suppressionsAll,
+            $allowedRouteUris,
+            $allowedSchemaClasses,
+            $allComponentClasses,
+        );
+
+        // endregion
+
+        $coverage = new CoverageCalculator()->calculate(
+            $operationTags,
+            $findings,
+            $level,
+            $this->generatorVersion(),
+        );
+
+        return new LintResult(
+            $findings,
+            $level,
+            $this->resolveExitCode($findings, $coverage, $options),
+            $coverage,
+        );
+    }
+
+    /**
+     * Discover every Laravel route, drop global-filter rejects (vendor routes like Telescope, Nova,
+     * Passport, Ignition and any user-configured filter), then apply the --path/--files/--diff
+     * narrowing. Per-spec {@see InclusionEvaluator::decide()} still re-filters per (route × spec)
+     * inside the generator, so this is the single-pass equivalent.
+     *
+     * @return list<ActionDescriptor>
+     *
+     * @throws LogicException
+     * @throws ProcessRuntimeException
+     * @throws ProcessSignaledException
+     * @throws ProcessStartFailedException
+     * @throws ProcessTimedOutException
+     * @throws ReflectionException
+     * @throws UnexpectedValueException
+     */
+    private function collectDescriptors(LintOptions $options): array
+    {
+        $descriptors = [];
+
+        foreach ($this->introspector->discover() as $descriptor) {
+            if (!$this->evaluator->passesGlobalFilters($descriptor)) {
+                continue;
+            }
+
+            $descriptors[] = $descriptor;
+        }
+
+        return $this->routeFilter->filter(
+            descriptors: $descriptors,
+            uriGlob: $options->uriGlob,
+            files: $options->files,
+            diff: $options->diff,
+        );
+    }
+
+    /**
+     * Map in-scope operations to their tag lists for the coverage denominator. When a route filter
+     * is active, an out-of-scope operation must not count: {@see walkSpec()} already restricts
+     * $document->paths when descriptors match, but an empty match (e.g. a glob that hits nothing)
+     * leaves every operation in place, so the URI is gated explicitly here.
+     *
+     * @param list<OperationNode>      $operations
+     * @param null|array<string, true> $allowedRouteUris
+     *
+     * @return array<string, list<string>>
+     */
+    private function collectOperationTags(array $operations, ?array $allowedRouteUris, string $specName): array
+    {
+        $operationTags = [];
+
+        foreach ($operations as $operation) {
+            if ($allowedRouteUris !== null && !isset($allowedRouteUris[ltrim($operation->pathUri, '/')])) {
+                continue;
+            }
+
+            $key = CoverageCalculator::operationKey(
+                $specName,
+                $operation->method,
+                $operation->pathUri,
+            );
+
+            if ($key !== null) {
+                $operationTags[$key] = $operation->tags;
+            }
+        }
+
+        return $operationTags;
+    }
+
+    /**
+     * Apply the post-walk finding pipeline: severity overrides, route/schema scope filtering (when
+     * --path/--diff is active), --only/--skip, suppressions, and the level cutoff.
+     *
+     * @param list<Finding>              $rawFindings
+     * @param list<string>               $only
+     * @param list<string>               $skip
+     * @param list<SuppressionDirective> $suppressionsAll
+     * @param null|array<string, true>   $allowedRouteUris
+     * @param array<string, true>        $allowedSchemaClasses
+     * @param array<string, true>        $allComponentClasses
+     *
+     * @return list<Finding>
+     */
+    private function filterFindings(
+        array $rawFindings,
+        LintOptions $options,
+        int $level,
+        array $only,
+        array $skip,
+        array $suppressionsAll,
+        ?array $allowedRouteUris,
+        array $allowedSchemaClasses,
+        array $allComponentClasses,
+    ): array {
+        $findings = $this->registry->applyOverrides($rawFindings);
 
         if ($allowedRouteUris !== null) {
             $findings = array_filter(
@@ -391,27 +479,11 @@ final readonly class LintRunner
             $findings = $this->applySuppressions(array_values($findings), $suppressionsAll);
         }
 
-        $findings = array_values(
+        return array_values(
             array_filter(
                 $findings,
                 static fn(Finding $finding): bool => $finding->level <= $level,
             ),
-        );
-
-        // endregion
-
-        $coverage = new CoverageCalculator()->calculate(
-            $operationTags,
-            $findings,
-            $level,
-            $this->generatorVersion(),
-        );
-
-        return new LintResult(
-            $findings,
-            $level,
-            $this->resolveExitCode($findings, $coverage, $options),
-            $coverage,
         );
     }
 

--- a/src/Lint/Tree/NodeFactory.php
+++ b/src/Lint/Tree/NodeFactory.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Tree;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+use function is_array;
+use function is_string;
+use function Radiergummi\OpenApi\is_defined;
+use function Radiergummi\OpenApi\is_undefined;
+
+/**
+ * Stateless converters from swagger-php annotation objects to leaf domain-tree nodes. Split out of
+ * {@see SpecTreeBuilder} so the builder keeps only the stateful, component-index-aware traversal;
+ * these conversions depend on nothing but their argument. Companion to the equally stateless
+ * {@see SchemaAccessor}.
+ */
+final class NodeFactory
+{
+    public static function exampleNode(OA\Examples $example): ExampleNode
+    {
+        return new ExampleNode(
+            name: is_defined($example->example)
+                ? $example->example
+                : null,
+            value: is_defined($example->value)
+                ? $example->value
+                : null,
+            summary: SchemaAccessor::undefinedToNull($example->summary),
+            description: SchemaAccessor::undefinedToNull($example->description),
+            raw: $example,
+        );
+    }
+
+    /**
+     * Build example nodes from a parameter's `examples` map.
+     *
+     * @return list<ExampleNode>
+     */
+    public static function examplesFromParameter(OA\Parameter $parameter): array
+    {
+        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
+        return self::examplesFromList($parameter->examples ?? Generator::UNDEFINED);
+    }
+
+    /**
+     * Build example nodes from a schema's `examples` map.
+     *
+     * @return list<ExampleNode>
+     */
+    public static function examplesFromSchema(OA\Schema $schema): array
+    {
+        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
+        return self::examplesFromList($schema->examples ?? Generator::UNDEFINED);
+    }
+
+    public static function header(OA\Header $header): HeaderNode
+    {
+        // Latent: a `$ref`'d header would carry no inline description and false-fire
+        // `header.description-missing`, mirroring the response-ref bug fixed in SpecTreeBuilder. The
+        // generator never emits `components.headers`/`$ref` headers today (headers are always
+        // inlined on responses), so no dereference is wired in. Add one here if that changes.
+        return new HeaderNode(
+            name: is_defined($header->header)
+                ? $header->header
+                : '(unknown)',
+            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
+            schema: SchemaAccessor::extractSchemaType($header->schema ?? null),
+            description: SchemaAccessor::undefinedToNull($header->description),
+            required: is_defined($header->required)
+            && $header->required === true,
+            raw: $header,
+        );
+    }
+
+    public static function link(OA\Link $link): LinkNode
+    {
+        $parameters = [];
+        $oaParams = $link->parameters;
+
+        if (is_array($oaParams) && is_defined($oaParams)) {
+            foreach ($oaParams as $key => $value) {
+                if (is_string($key) && is_string($value)) {
+                    $parameters[$key] = $value;
+                }
+            }
+        }
+
+        return new LinkNode(
+            name: is_defined($link->link)
+                ? $link->link
+                : '(unnamed)',
+            operationId: SchemaAccessor::undefinedToNull($link->operationId),
+            operationRef: SchemaAccessor::undefinedToNull($link->operationRef),
+            parameters: $parameters,
+            description: SchemaAccessor::undefinedToNull($link->description),
+            raw: $link,
+        );
+    }
+
+    /**
+     * @return list<ExampleNode>
+     */
+    private static function examplesFromList(mixed $examples): array
+    {
+        if (!is_array($examples) || is_undefined($examples)) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($examples as $example) {
+            if (is_undefined($example)) {
+                continue;
+            }
+
+            if ($example instanceof OA\Examples) {
+                $result[] = self::exampleNode($example);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Lint/Tree/SpecTreeBuilder.php
+++ b/src/Lint/Tree/SpecTreeBuilder.php
@@ -337,7 +337,7 @@ final class SpecTreeBuilder
             // `parameter.description-missing`, like the response-ref bug fixed in this class. The
             // generator never emits `components.parameters`/`$ref` parameters today (parameters are
             // always inlined), so no dereference is wired in. Add one here if that changes.
-            $examples = $this->buildExamplesFromParameter($param);
+            $examples = NodeFactory::examplesFromParameter($param);
             $node = new ParameterNode(
                 name: is_defined($param->name)
                     ? $param->name
@@ -361,50 +361,6 @@ final class SpecTreeBuilder
         }
 
         return $result;
-    }
-
-    /**
-     * Build examples from a parameter's `examples` array.
-     *
-     * @return list<ExampleNode>
-     */
-    private function buildExamplesFromParameter(OA\Parameter $param): array
-    {
-        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
-        $examples = $param->examples ?? Generator::UNDEFINED;
-
-        if (!is_array($examples) || is_undefined($examples)) {
-            return [];
-        }
-
-        $result = [];
-
-        foreach ($examples as $example) {
-            if (is_undefined($example)) {
-                continue;
-            }
-
-            if ($example instanceof OA\Examples) {
-                $result[] = $this->buildExampleNode($example);
-            }
-        }
-
-        return $result;
-    }
-
-    private function buildExampleNode(OA\Examples $example): ExampleNode
-    {
-        return new ExampleNode(
-            name: is_defined($example->example)
-                ? $example->example
-                : null,
-            value: is_defined($example->value)
-                ? $example->value
-                : null,
-            summary: SchemaAccessor::undefinedToNull($example->summary),
-            description: SchemaAccessor::undefinedToNull($example->description),
-            raw: $example,
-        );
     }
 
     /**
@@ -435,7 +391,7 @@ final class SpecTreeBuilder
                 continue;
             }
 
-            $examples = $this->buildExamplesFromParameter($param);
+            $examples = NodeFactory::examplesFromParameter($param);
             // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
             $schema = $param->schema ?? null;
             $node = new QueryParameterNode(
@@ -518,7 +474,7 @@ final class SpecTreeBuilder
                             continue;
                         }
 
-                        $examples[] = $this->buildExampleNode($mediaTypeExample);
+                        $examples[] = NodeFactory::exampleNode($mediaTypeExample);
                     }
                 }
             }
@@ -584,7 +540,7 @@ final class SpecTreeBuilder
 
         foreach ($properties as $name => $property) {
             $children = $this->buildFields($property);
-            $examples = $this->buildExamplesFromSchema($property);
+            $examples = NodeFactory::examplesFromSchema($property);
 
             $field = new FieldNode(
                 name: $name,
@@ -714,35 +670,6 @@ final class SpecTreeBuilder
     }
 
     /**
-     * Build examples from a schema's examples.
-     *
-     * @return list<ExampleNode>
-     */
-    private function buildExamplesFromSchema(OA\Schema $schema): array
-    {
-        // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
-        $examples = $schema->examples ?? Generator::UNDEFINED;
-
-        if (!is_array($examples) || is_undefined($examples)) {
-            return [];
-        }
-
-        $result = [];
-
-        foreach ($examples as $example) {
-            if (is_undefined($example)) {
-                continue;
-            }
-
-            if ($example instanceof OA\Examples) {
-                $result[] = $this->buildExampleNode($example);
-            }
-        }
-
-        return $result;
-    }
-
-    /**
      * @return list<ResponseNode>
      *
      * @throws LogicException
@@ -821,7 +748,7 @@ final class SpecTreeBuilder
                                 continue;
                             }
 
-                            $examples[] = $this->buildExampleNode($mediaTypeExample);
+                            $examples[] = NodeFactory::exampleNode($mediaTypeExample);
                         }
                     }
                 }
@@ -836,7 +763,7 @@ final class SpecTreeBuilder
                         continue;
                     }
 
-                    $headers[] = $this->buildHeader($header);
+                    $headers[] = NodeFactory::header($header);
                 }
             }
 
@@ -849,7 +776,7 @@ final class SpecTreeBuilder
                         continue;
                     }
 
-                    $links[] = $this->buildLink($link);
+                    $links[] = NodeFactory::link($link);
                 }
             }
 
@@ -908,50 +835,6 @@ final class SpecTreeBuilder
         }
 
         return SchemaAccessor::undefinedToNull($target->description);
-    }
-
-    private function buildHeader(OA\Header $header): HeaderNode
-    {
-        // Latent: a `$ref`'d header would carry no inline description and false-fire
-        // `header.description-missing`, mirroring the response-ref bug fixed in this class. The
-        // generator never emits `components.headers`/`$ref` headers today (headers are always
-        // inlined on responses), so no dereference is wired in. Add one here if that changes.
-        return new HeaderNode(
-            name: is_defined($header->header)
-                ? $header->header
-                : '(unknown)',
-            // @phpstan-ignore nullCoalesce.property (swagger-php may leave property unset at runtime)
-            schema: SchemaAccessor::extractSchemaType($header->schema ?? null),
-            description: SchemaAccessor::undefinedToNull($header->description),
-            required: is_defined($header->required)
-            && $header->required === true,
-            raw: $header,
-        );
-    }
-
-    private function buildLink(OA\Link $link): LinkNode
-    {
-        $parameters = [];
-        $oaParams = $link->parameters;
-
-        if (is_array($oaParams) && is_defined($oaParams)) {
-            foreach ($oaParams as $key => $value) {
-                if (is_string($key) && is_string($value)) {
-                    $parameters[$key] = $value;
-                }
-            }
-        }
-
-        return new LinkNode(
-            name: is_defined($link->link)
-                ? $link->link
-                : '(unnamed)',
-            operationId: SchemaAccessor::undefinedToNull($link->operationId),
-            operationRef: SchemaAccessor::undefinedToNull($link->operationRef),
-            parameters: $parameters,
-            description: SchemaAccessor::undefinedToNull($link->description),
-            raw: $link,
-        );
     }
 
     /**

--- a/tests/Unit/Lint/Tree/NodeFactoryTest.php
+++ b/tests/Unit/Lint/Tree/NodeFactoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use Radiergummi\OpenApi\Lint\Tree\NodeFactory;
+
+uses()->group('openapi', 'lint');
+
+describe('exampleNode', function (): void {
+    it('maps every defined field onto the node', function (): void {
+        $raw = new OA\Examples([
+            'example' => 'first',
+            'value' => ['id' => 1],
+            'summary' => 'A summary',
+            'description' => 'A description',
+        ]);
+
+        $node = NodeFactory::exampleNode($raw);
+
+        expect($node->name)->toBe('first')
+            ->and($node->value)->toBe(['id' => 1])
+            ->and($node->summary)->toBe('A summary')
+            ->and($node->description)->toBe('A description')
+            ->and($node->raw)->toBe($raw);
+    });
+
+    it('nulls out undefined fields rather than leaking the UNDEFINED sentinel', function (): void {
+        $node = NodeFactory::exampleNode(new OA\Examples([]));
+
+        expect($node->name)->toBeNull()
+            ->and($node->value)->toBeNull()
+            ->and($node->summary)->toBeNull()
+            ->and($node->description)->toBeNull();
+    });
+});
+
+describe('examplesFromParameter / examplesFromSchema', function (): void {
+    it('returns an empty list when no examples are defined', function (): void {
+        expect(NodeFactory::examplesFromParameter(new OA\Parameter(['name' => 'q', 'in' => 'query'])))->toBe([])
+            ->and(NodeFactory::examplesFromSchema(new OA\Schema(['type' => 'string'])))->toBe([]);
+    });
+
+    it('builds one ExampleNode per OA\\Examples entry on a parameter', function (): void {
+        $parameter = new OA\Parameter([
+            'name' => 'q',
+            'in' => 'query',
+            'examples' => [
+                'one' => new OA\Examples(['example' => 'one', 'value' => 1]),
+                'two' => new OA\Examples(['example' => 'two', 'value' => 2]),
+            ],
+        ]);
+
+        $nodes = NodeFactory::examplesFromParameter($parameter);
+
+        expect($nodes)->toHaveCount(2)
+            ->and($nodes[0]->name)->toBe('one')
+            ->and($nodes[1]->name)->toBe('two');
+    });
+
+    it('skips undefined and non-OA\\Examples entries', function (): void {
+        $schema = new OA\Schema([
+            'type' => 'string',
+            'examples' => [
+                'valid' => new OA\Examples(['example' => 'valid', 'value' => 'x']),
+                'sentinel' => Generator::UNDEFINED,
+                'bogus' => 'not-an-example-object',
+            ],
+        ]);
+
+        $nodes = NodeFactory::examplesFromSchema($schema);
+
+        expect($nodes)->toHaveCount(1)
+            ->and($nodes[0]->name)->toBe('valid');
+    });
+});
+
+describe('header', function (): void {
+    it('maps a fully-populated header', function (): void {
+        $raw = new OA\Header([
+            'header' => 'X-Rate-Limit',
+            'schema' => new OA\Schema(['type' => 'integer']),
+            'description' => 'Requests left',
+            'required' => true,
+        ]);
+
+        $node = NodeFactory::header($raw);
+
+        expect($node->name)->toBe('X-Rate-Limit')
+            ->and($node->schema)->toBe('integer')
+            ->and($node->description)->toBe('Requests left')
+            ->and($node->required)->toBeTrue()
+            ->and($node->raw)->toBe($raw);
+    });
+
+    it('falls back to "(unknown)" and safe defaults when fields are undefined', function (): void {
+        $node = NodeFactory::header(new OA\Header([]));
+
+        expect($node->name)->toBe('(unknown)')
+            ->and($node->schema)->toBeNull()
+            ->and($node->description)->toBeNull()
+            ->and($node->required)->toBeFalse();
+    });
+
+    it('treats a non-true required value as not required', function (): void {
+        $node = NodeFactory::header(new OA\Header(['header' => 'X-Thing', 'required' => false]));
+
+        expect($node->required)->toBeFalse();
+    });
+});
+
+describe('link', function (): void {
+    it('maps a fully-populated link, keeping only string parameter mappings', function (): void {
+        $raw = new OA\Link([
+            'link' => 'GetUserById',
+            'operationId' => 'getUser',
+            'operationRef' => '#/paths/~1users~1{id}/get',
+            'description' => 'Follow to the user',
+            'parameters' => [
+                'id' => '$response.body#/id',
+                'bogus' => 42,
+            ],
+        ]);
+
+        $node = NodeFactory::link($raw);
+
+        expect($node->name)->toBe('GetUserById')
+            ->and($node->operationId)->toBe('getUser')
+            ->and($node->operationRef)->toBe('#/paths/~1users~1{id}/get')
+            ->and($node->description)->toBe('Follow to the user')
+            ->and($node->parameters)->toBe(['id' => '$response.body#/id'])
+            ->and($node->raw)->toBe($raw);
+    });
+
+    it('falls back to "(unnamed)" and empty parameters when fields are undefined', function (): void {
+        $node = NodeFactory::link(new OA\Link([]));
+
+        expect($node->name)->toBe('(unnamed)')
+            ->and($node->operationId)->toBeNull()
+            ->and($node->operationRef)->toBeNull()
+            ->and($node->description)->toBeNull()
+            ->and($node->parameters)->toBe([]);
+    });
+});


### PR DESCRIPTION
## What

Two abstraction-free extractions that shrink the two largest classes in the lint subsystem without adding indirection layers. Pure relocation/decomposition — **no behaviour change**.

### 1. `LintRunner::runWithCollector` → named private methods
The ~257-line method is decomposed into three single-output private helpers, leaving the orchestrator as its region skeleton (~145 lines):
- `collectDescriptors()` — route discovery + global-filter + path/diff narrowing
- `collectOperationTags()` — per-spec coverage-tag mapping
- `filterFindings()` — the post-walk pipeline (overrides, scope filter, only/skip, suppressions, level cutoff)

No new class, no new type. The per-spec loop's cross-iteration accumulation (scope-class sets, suppressions) stays **inline** rather than threaded through a collaborator, to avoid by-ref/DTO coupling.

### 2. SpecTreeBuilder leaf converters → `NodeFactory`
The pure `OA`-annotation → leaf-node converters (`exampleNode`, `header`, `link`, and the parameter/schema example collectors) move into a new stateless `NodeFactory`, mirroring the existing `SchemaAccessor` helper in the same namespace. SpecTreeBuilder keeps only the stateful, component-index-aware traversal; the moved methods depend on nothing but their argument. The two near-identical example collectors now share a private `examplesFromList` helper.

**SpecTreeBuilder: 1166 → 1049 lines** (−117).

## What was deliberately *not* done
- **No `ComponentIndex` read-model.** SpecTreeBuilder is constructed fresh per spec, so its mutable index properties are not a corruption risk — there's no bug to fix. Extracting them as a non-instance read-model would force threading the index through ~8 methods of the recursive call graph, which is exactly the coupling this PR avoids.
- **No base classes / phase objects / strategy registries.** The recursive traversal spine and the per-spec orchestration loop are single cohesive algorithms; splitting them across collaborators would fragment them and add state-threading for no real gain.

## Verification
- `composer test` — 1931 passed (4827 assertions)
- `composer lint` (PHPStan level 8) — no errors
- `vendor/bin/pint --test` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)