### PR TITLE
fix(survey): harden corpus.sh — stdin drain, --only clobber, run races, stale library links

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,6 +26,7 @@ parameters:
         - tests
     scanFiles:
         - tools/survey/metrics.php
+        - tools/survey/aggregate.php
         - .claude/skills/survey/bin/survey-assemble-spec
         - .claude/skills/survey/bin/survey-harvest-docs
     excludePaths:

--- a/tests/Unit/SurveyAggregateResultsTest.php
+++ b/tests/Unit/SurveyAggregateResultsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../tools/survey/aggregate.php';
+
+function surveyEntry(string $name, int $marker): array
+{
+    return ['name' => $name, 'metrics' => ['marker' => $marker]];
+}
+
+it('replaces every entry on a full run, in corpus order', function (): void {
+    $order = ['Alpha', 'Beta', 'Gamma'];
+    $existing = [surveyEntry('Alpha', 1), surveyEntry('Beta', 1), surveyEntry('Gamma', 1)];
+    $fresh = [surveyEntry('Gamma', 2), surveyEntry('Alpha', 2), surveyEntry('Beta', 2)];
+
+    $merged = surveyMergeResults($existing, $fresh, $order);
+
+    expect(array_column($merged, 'name'))->toBe(['Alpha', 'Beta', 'Gamma'])
+        ->and(array_map(static fn($e) => $e['metrics']['marker'], $merged))->toBe([2, 2, 2]);
+});
+
+it('replaces only the named app and preserves the rest on an --only backfill', function (): void {
+    // The #229 scenario: a 9/11 aggregate, backfilling one app must not drop the other eight.
+    $order = ['Alpha', 'Beta', 'Gamma'];
+    $existing = [surveyEntry('Alpha', 1), surveyEntry('Beta', 1)];
+    $fresh = [surveyEntry('Gamma', 9)]; // a single-app `--only Gamma` run
+
+    $merged = surveyMergeResults($existing, $fresh, $order);
+
+    expect($merged)->toHaveCount(3)
+        ->and(array_column($merged, 'name'))->toBe(['Alpha', 'Beta', 'Gamma'])
+        ->and($merged[0]['metrics']['marker'])->toBe(1)
+        ->and($merged[2]['metrics']['marker'])->toBe(9);
+});
+
+it('builds the aggregate from scratch when there is no existing results file', function (): void {
+    $merged = surveyMergeResults([], [surveyEntry('Beta', 5), surveyEntry('Alpha', 5)], ['Alpha', 'Beta']);
+
+    expect(array_column($merged, 'name'))->toBe(['Alpha', 'Beta']);
+});
+
+it('keeps an entry whose app is no longer pinned in the corpus, at the tail', function (): void {
+    $order = ['Alpha'];
+    $existing = [surveyEntry('Retired', 1)];
+    $fresh = [surveyEntry('Alpha', 1)];
+
+    $merged = surveyMergeResults($existing, $fresh, $order);
+
+    expect(array_column($merged, 'name'))->toBe(['Alpha', 'Retired']);
+});
+
+it('ignores malformed entries that carry no name', function (): void {
+    $merged = surveyMergeResults([['metrics' => []]], [surveyEntry('Alpha', 1)], ['Alpha']);
+
+    expect($merged)->toHaveCount(1)
+        ->and($merged[0]['name'])->toBe('Alpha');
+});

--- a/tools/survey/README.md
+++ b/tools/survey/README.md
@@ -75,7 +75,7 @@ code is never modified or committed — this is black-box.
 | `run.sh <name>` | Run `openapi:generate` + `openapi:lint` in the app; capture spec, logs, exit codes; print a scorecard line. A crash is captured as data, not aborted on. |
 | `compare.php <generated> <published>` | Path×method coverage of our spec vs an app's published one. Accepts JSON or YAML. Defaults `LIB` to this repo; override the `LIB` env var to point elsewhere. |
 | `completeness.php <generated> [--prefix=/api]` | Per-operation completeness scoreboard: request body (where the verb needs one) + substantive 2xx response, under an API prefix. The gate for the attribute-completion pass. |
-| `bootstrap/_lib.sh` | Shared bootstrap helpers sourced by every per-app script: `survey_link_library` (composer path repo + require), `survey_scaffold_env` (`.env`, sqlite, `key:generate`), `survey_publish_config` (publishes the package config), `survey_blocked` (records `blocked-compat` as data without aborting). |
+| `bootstrap/_lib.sh` | Shared bootstrap helpers sourced by every per-app script: `survey_link_library` (composer path repo + require, then asserts the vendor link actually resolves to `$LIB`), `survey_scaffold_env` (`.env`, sqlite, `key:generate`), `survey_publish_config` (publishes the package config), `survey_blocked` (records `blocked-compat` as data without aborting). |
 | `bootstrap/<name>.sh` | Per-app clean-clone → runnable. Sources `_lib.sh`, calls the shared scaffold functions, then applies any app-specific deltas (database driver, queue config, extra composer packages, etc.). |
 | `runbook-template.md` | Stamped per app by `setup.sh`. |
 
@@ -90,13 +90,22 @@ tools/survey/corpus.sh --only BookStack
 ```
 
 `corpus.sh` reads `corpus.json`, clones each app at its pinned SHA (via
-`setup.sh`), runs the per-app bootstrap, runs `run.sh`, and calls `metrics.php`.
-After iterating, it writes two files to `$WS`:
+`setup.sh`), resets any stale composer state the previous run left behind (so the
+library always relinks to the current `$LIB`), runs the per-app bootstrap, runs
+`run.sh`, and calls `metrics.php`. After iterating, it writes two files to `$WS`:
 
-- **`results.json`** — array of `{name, metrics}` objects, one per app.
-- **`manifest.json`** — provenance record: per-app pinned SHA + actual
-  on-disk HEAD SHA, library commit, and run timestamp. The manifest covers the
-  full corpus regardless of `--only`.
+- **`results.json`** — array of `{name, metrics}` objects, one per app. A full
+  run rewrites every entry; `--only <name>` **merges** — it replaces just that
+  app's entry and preserves the rest, so it is a safe backfill.
+- **`manifest.json`** — provenance record: per-app pinned SHA + actual on-disk
+  HEAD SHA + the library commit actually installed into that app's vendor, the
+  library commit under test, and a run timestamp. The manifest covers the full
+  corpus regardless of `--only`.
+
+A run holds an exclusive lock on `$WS` (`$WS/.survey.lock`): a second `corpus.sh`
+against the same workspace fails fast rather than racing on the shared aggregate
+and flipping each app's vendor link mid-generation. A stale lock left by a killed
+run is reclaimed automatically.
 
 CI exposure is a manually-dispatched `survey` workflow
 (`.github/workflows/survey.yml`), milestone-gated. It is never triggered per-PR.

--- a/tools/survey/aggregate.php
+++ b/tools/survey/aggregate.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Survey results aggregator — merges a run's per-app metric entries into the existing
+ * results.json by app name, in corpus order.
+ *
+ * surveyMergeResults() is the pure contract: (existing, fresh, orderNames) -> merged.
+ * A full corpus run replaces every entry; `corpus.sh --only <app>` replaces just that
+ * app and preserves the rest, instead of clobbering the file with a single-app array (#229).
+ *
+ * Run as a CLI it reads the corpus pin registry, the existing results.json (if any), and a
+ * file of the current run's entries, then prints the merged array as validated JSON. A
+ * pre-existing results.json that does not parse (e.g. truncated/garbled by an aborted or
+ * concurrent run, #231) is discarded with a warning and rebuilt from this run.
+ *
+ * Usage: php aggregate.php <corpus.json> <results.json> <fresh-entries.json>
+ */
+
+/**
+ * Merge the current run's entries into the existing aggregate, keyed by app name (fresh wins),
+ * emitted in corpus order. Entries whose app is no longer in the corpus keep a stable tail slot.
+ *
+ * @param list<array<string, mixed>> $existing   entries already in results.json
+ * @param list<array<string, mixed>> $fresh      entries produced by the current run
+ * @param list<string>               $orderNames corpus app names, in canonical order
+ *
+ * @return list<array<string, mixed>>
+ */
+function surveyMergeResults(array $existing, array $fresh, array $orderNames): array
+{
+    $byName = [];
+
+    foreach ($existing as $entry) {
+        if (isset($entry['name'])) {
+            $byName[$entry['name']] = $entry;
+        }
+    }
+
+    foreach ($fresh as $entry) {
+        if (isset($entry['name'])) {
+            $byName[$entry['name']] = $entry;
+        }
+    }
+
+    $merged = [];
+
+    foreach ($orderNames as $name) {
+        if (isset($byName[$name])) {
+            $merged[] = $byName[$name];
+            unset($byName[$name]);
+        }
+    }
+
+    // Any entry whose app is no longer pinned in the corpus is kept rather than dropped.
+    foreach ($byName as $entry) {
+        $merged[] = $entry;
+    }
+
+    return $merged;
+}
+
+if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__FILE__)) {
+    $corpusPath = $argv[1] ?? null;
+    $resultsPath = $argv[2] ?? null;
+    $freshPath = $argv[3] ?? null;
+
+    if ($corpusPath === null || $resultsPath === null || $freshPath === null) {
+        fwrite(STDERR, "usage: aggregate.php <corpus.json> <results.json> <fresh-entries.json>\n");
+        exit(2);
+    }
+
+    $corpus = json_decode((string) @file_get_contents($corpusPath), true);
+
+    if (!is_array($corpus['apps'] ?? null)) {
+        fwrite(STDERR, "aggregate.php: cannot read corpus apps from {$corpusPath}\n");
+        exit(1);
+    }
+
+    $orderNames = array_map(static fn(array $app): string => (string) $app['name'], $corpus['apps']);
+
+    $existing = [];
+
+    if (is_file($resultsPath)) {
+        $decoded = json_decode((string) file_get_contents($resultsPath), true);
+
+        if (is_array($decoded)) {
+            $existing = $decoded;
+        } else {
+            fwrite(STDERR, "aggregate.php: existing {$resultsPath} did not parse — discarding it and rebuilding from this run\n");
+        }
+    }
+
+    $fresh = json_decode((string) @file_get_contents($freshPath), true);
+
+    if (!is_array($fresh)) {
+        fwrite(STDERR, "aggregate.php: fresh entries at {$freshPath} did not parse as JSON\n");
+        exit(1);
+    }
+
+    echo json_encode(
+        surveyMergeResults($existing, $fresh, $orderNames),
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+    ) . "\n";
+}

--- a/tools/survey/aggregate.php
+++ b/tools/survey/aggregate.php
@@ -32,13 +32,8 @@ function surveyMergeResults(array $existing, array $fresh, array $orderNames): a
 {
     $byName = [];
 
-    foreach ($existing as $entry) {
-        if (isset($entry['name'])) {
-            $byName[$entry['name']] = $entry;
-        }
-    }
-
-    foreach ($fresh as $entry) {
+    // Existing first, then fresh — last write wins, so a fresh entry replaces its prior one.
+    foreach (array_merge($existing, $fresh) as $entry) {
         if (isset($entry['name'])) {
             $byName[$entry['name']] = $entry;
         }

--- a/tools/survey/bootstrap/_lib.sh
+++ b/tools/survey/bootstrap/_lib.sh
@@ -11,9 +11,33 @@ LIB="${LIB:?set LIB to the laravel-openapi checkout under test}"
 # Extra args ($@) are forwarded to `composer require` — pass per-app flags
 # (--ignore-platform-req=…, --no-scripts) or extra packages here so the path-repo
 # registration always happens (forgetting it is a silent "library not found" trap).
+#
+# corpus.sh resets the app's composer state (composer.json/lock, vendor/radiergummi,
+# compiled caches) from git BEFORE the bootstrap runs, so this require always re-resolves
+# against $LIB rather than no-op'ing on a lock that still pins a previous run's library sha.
+# The post-link assertion is the safety net: a stale or missing link is recorded as
+# blocked-compat instead of silently measuring the wrong library commit (#233).
 survey_link_library() {
   composer config repositories.laravel-openapi path "$LIB" >/dev/null
   composer require "radiergummi/laravel-openapi:@dev" "$@" --no-interaction
+
+  survey_assert_library_linked
+}
+
+# Assert the freshly required package actually resolves to $LIB. Composer can report
+# "nothing to modify" and leave the vendor symlink pointing at a stale worktree; resolving
+# both sides to their real path catches that (and a missing link). On mismatch, record the
+# app as blocked-compat and fail the function so the caller's `|| survey_blocked` also fires.
+survey_assert_library_linked() {
+  local link="vendor/radiergummi/laravel-openapi"
+  local resolved lib_real
+  resolved="$(cd "$link" 2>/dev/null && pwd -P)" || resolved=""
+  lib_real="$(cd "$LIB" 2>/dev/null && pwd -P)" || lib_real=""
+
+  if [[ -z "$resolved" || "$resolved" != "$lib_real" ]]; then
+    survey_blocked "library link stale: ${link} resolves to '${resolved:-missing}', expected '${lib_real}'"
+    return 1
+  fi
 }
 
 # Prepare a minimal runnable env: .env, app key, sqlite. App-specific configs are

--- a/tools/survey/corpus.sh
+++ b/tools/survey/corpus.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # corpus.sh [--only <name>] — run the pinned corpus and aggregate metrics.
 #
-# For each app in corpus.json: clone (setup.sh) -> bootstrap -> run.sh -> metrics.php.
-# Aggregates per-app metrics into $WS/results.json and emits $WS/manifest.json.
+# For each app in corpus.json: clone (setup.sh) -> reset stale composer state -> bootstrap
+# -> run.sh -> metrics.php. Merges per-app metrics into $WS/results.json (by app name, so
+# --only backfills a single app without clobbering the rest) and emits $WS/manifest.json.
+#
+# Holds an exclusive lock on $WS for the duration: a second run against the same workspace
+# fails fast rather than corrupting the shared aggregate.
 #
 # Requires WS (workspace) and LIB (library checkout). Use a PHP 8.4 binary.
 set -uo pipefail
@@ -15,12 +19,42 @@ only=""
 [[ "${1:-}" == "--only" ]] && only="${2:-}"
 
 corpus="$HARNESS/corpus.json"
-names=$(php -r '$c=json_decode(file_get_contents($argv[1]),true); foreach($c["apps"] as $a){echo $a["name"],"\n";}' "$corpus")
 
-results="["
+# --- Run lock (#231) ---------------------------------------------------------------------
+# Two corpus runs sharing one $WS race on results.json/manifest.json and flip each app's
+# vendor link mid-generation. mkdir is atomic, so it doubles as the lock; a stale lock whose
+# owner has died is reclaimed, a live one aborts the run.
+mkdir -p "$WS"
+lockdir="$WS/.survey.lock"
+if ! mkdir "$lockdir" 2>/dev/null; then
+  holder="$(cat "$lockdir/pid" 2>/dev/null || true)"
+  if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+    echo "error: another corpus run (pid $holder) holds $lockdir — aborting to avoid corrupting \$WS" >&2
+    exit 1
+  fi
+  echo "warn: reclaiming stale lock (owner pid ${holder:-unknown} is gone)" >&2
+  rm -rf "$lockdir"
+  mkdir "$lockdir" || { echo "error: cannot acquire $lockdir" >&2; exit 1; }
+fi
+echo "$$" > "$lockdir/pid"
+fresh_entries="$WS/.run-entries.json"
+trap 'rm -rf "$lockdir"; rm -f "$fresh_entries" "$WS/results.json.tmp"' EXIT
+# -----------------------------------------------------------------------------------------
+
+# Read names into an array and iterate with `for`: a `while … <<< "$names"` loop leaks the
+# corpus list onto the loop body's stdin, where a bootstrap subprocess (artisan upgrades,
+# etc.) can drain it and silently end the loop early (#221). The array is immune. (Filled with
+# a `while read` rather than `mapfile`, which the macOS system bash 3.2 lacks.)
+names=()
+while IFS= read -r line; do
+  names+=("$line")
+done < <(php -r '$c=json_decode(file_get_contents($argv[1]),true); foreach($c["apps"] as $a){echo $a["name"],"\n";}' "$corpus")
+
+run_entries="["
 first=true
+ran=0
 
-while IFS= read -r name; do
+for name in ${names[@]+"${names[@]}"}; do
   [[ -z "$name" ]] && continue
   [[ -n "$only" && "$name" != "$only" ]] && continue
 
@@ -44,13 +78,25 @@ while IFS= read -r name; do
   # Pin exactly (setup.sh shallow-clones a branch; enforce the SHA when present).
   git -C "$repodir" rev-parse HEAD | grep -q "^$sha" || echo "  warn: HEAD != pinned SHA ($sha)"
 
+  # Reset composer state a previous run may have left dirty (#233): a lock still pinning an
+  # old library sha (which makes the relink a silent no-op), a corrupted composer.json, or
+  # stale compiled caches referencing the package. This runs BEFORE the bootstrap makes its
+  # own per-app composer.json edits (platform.php, constraint bumps), so those are preserved.
+  if [[ -d "$repodir/.git" ]]; then
+    git -C "$repodir" checkout -- composer.json composer.lock 2>/dev/null || true
+    rm -rf "$repodir/vendor/radiergummi" \
+           "$repodir/bootstrap/cache/packages.php" \
+           "$repodir/bootstrap/cache/services.php"
+  fi
+
   echo "booted" > "$appdir/boot_outcome"
   # A non-zero bootstrap exit that never reached survey_blocked still means the app
   # didn't come up — record it as blocked-compat so the outcome isn't left "booted".
-  ( cd "$repodir" && WS="$WS" LIB="$LIB" BOOT_OUTCOME_FILE="$appdir/boot_outcome" bash "$HARNESS/$boot" ) \
+  # stdin is fed from /dev/null so a bootstrap subprocess can't consume the caller's stdin.
+  ( cd "$repodir" && WS="$WS" LIB="$LIB" BOOT_OUTCOME_FILE="$appdir/boot_outcome" bash "$HARNESS/$boot" ) < /dev/null \
     || { echo "  bootstrap exited non-zero — recording blocked-compat"; echo "blocked-compat" > "$appdir/boot_outcome"; }
 
-  WS="$WS" "$HARNESS/run.sh" "$name" || true
+  WS="$WS" "$HARNESS/run.sh" "$name" < /dev/null || true
 
   pubArgs=()
   [[ "$published" != "-" ]] && pubArgs=("--published=$repodir/$published")
@@ -62,26 +108,53 @@ while IFS= read -r name; do
   ' "$name" "$metrics")
 
   if [[ -n "$entry" ]]; then
-    $first || results+=","
-    results+="$entry"
+    $first || run_entries+=","
+    run_entries+="$entry"
     first=false
+    ran=$((ran + 1))
   fi
-done <<< "$names"
+done
+run_entries+="]"
 
-results+="]"
-echo "$results" | php -r 'echo json_encode(json_decode((string)stream_get_contents(STDIN),true), JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);' > "$WS/results.json"
+# Merge this run's entries into the existing aggregate by app name (#229) and validate the
+# result parses before it replaces the live file (#231). aggregate.php always emits valid
+# JSON; the read-back guards against a truncated write (disk full, killed mid-write).
+printf '%s' "$run_entries" > "$fresh_entries"
+php "$HARNESS/aggregate.php" "$corpus" "$WS/results.json" "$fresh_entries" > "$WS/results.json.tmp"
+if ! php -r 'exit(is_array(json_decode((string)file_get_contents($argv[1]),true)) ? 0 : 1);' "$WS/results.json.tmp" 2>/dev/null; then
+  echo "error: merged results.json failed to parse — leaving the previous results.json intact" >&2
+  exit 1
+fi
+mv "$WS/results.json.tmp" "$WS/results.json"
 
-# Manifest covers the FULL corpus pin registry (not just --only): records each app's
-# pinned SHA + its actual on-disk SHA (null if not cloned) + the library commit.
+# Coverage guard (#221): on a full run, warn loudly if fewer apps were measured than the
+# corpus pins — the symptom of a silently dropped app.
+if [[ -z "$only" ]]; then
+  corpus_count=$(php -r 'echo count(json_decode(file_get_contents($argv[1]),true)["apps"]);' "$corpus")
+  if [[ "$ran" -ne "$corpus_count" ]]; then
+    echo "warn: measured $ran of $corpus_count corpus apps this run — some were skipped or dropped" >&2
+  fi
+fi
+
+# Manifest covers the FULL corpus pin registry (not just --only): records each app's pinned
+# SHA, its actual on-disk SHA (null if not cloned), and the library commit actually installed
+# into each app's vendor (read from the symlink target's git HEAD), so every results file is
+# self-verifying against the intended libraryCommit (#233).
 php -r '
   $c=json_decode(file_get_contents($argv[1]),true);
   $ws=$argv[2]; $lib=$argv[3];
+  $libCommit=trim(shell_exec("git -C ".escapeshellarg($lib)." rev-parse HEAD")?:"");
   $apps=[];
   foreach($c["apps"] as $a){
-    $head=@trim(shell_exec("git -C ".escapeshellarg($ws."/apps/".$a["name"]."/repo")." rev-parse HEAD 2>/dev/null")?:"");
-    $apps[]=["name"=>$a["name"],"pinnedSha"=>$a["sha"],"actualSha"=>$head?:null,"php"=>$a["php"]];
+    $repo=$ws."/apps/".$a["name"]."/repo";
+    $head=@trim(shell_exec("git -C ".escapeshellarg($repo)." rev-parse HEAD 2>/dev/null")?:"");
+    $vendorLib=$repo."/vendor/radiergummi/laravel-openapi";
+    $installed=@trim(shell_exec("git -C ".escapeshellarg($vendorLib)." rev-parse HEAD 2>/dev/null")?:"") ?: null;
+    if($installed!==null && $installed!==$libCommit){
+      fwrite(STDERR, "warn: ".$a["name"]." has library ".$installed." installed, expected ".$libCommit." (stale link?)\n");
+    }
+    $apps[]=["name"=>$a["name"],"pinnedSha"=>$a["sha"],"actualSha"=>$head?:null,"installedLibrarySha"=>$installed,"php"=>$a["php"]];
   }
-  $libCommit=trim(shell_exec("git -C ".escapeshellarg($lib)." rev-parse HEAD")?:"");
   echo json_encode(["generatedAt"=>date("c"),"libraryCommit"=>$libCommit,"apps"=>$apps], JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
 ' "$corpus" "$WS" "$LIB" > "$WS/manifest.json"
 


### PR DESCRIPTION
Closes #221. Closes #229. Closes #231. Closes #233.

Four interacting bugs in the survey harness (`tools/survey/`), all surfaced during recent dogfood runs, fixed on one branch since they overlap in `corpus.sh`.

## #221 — loop drops apps after a bootstrap consumes stdin
`while … <<< "$names"` leaked the corpus list onto the loop body's stdin; a bootstrap subprocess (Pelican's `artisan p:upgrade`) drained the rest and the loop ended early with no warning (9/11 apps, silently).
**Fix:** read names into an array and iterate with `for` (portable `while read` fill — the macOS system bash is 3.2, no `mapfile`); feed the bootstrap and `run.sh` `< /dev/null`. Plus a coverage guard that warns when a full run measures fewer apps than the corpus pins.

## #229 — `--only` clobbers results.json
`--only <app>` overwrote the aggregate with a single-app array, destroying the backfill it was meant to perform.
**Fix:** aggregation moved into a testable `aggregate.php` (`surveyMergeResults`): merge by app name in corpus order, so `--only` replaces just that app and preserves the rest. A full run still rewrites everything.

## #231 — no run lock; concurrent runs corrupt $WS
Two runs on one `$WS` produced trailing-garbage `results.json` and flipped vendor links mid-generation — invisible (both exit 0).
**Fix:** exclusive `mkdir "$WS/.survey.lock"` with stale-owner reclamation (PID + `kill -0`), released on exit. The merged aggregate is validated (write tmp → parse-check → `mv`) before replacing the live file.

## #233 — bootstrap trusts stale composer state
A lock still pinning an old library sha made `composer require @dev` a silent no-op, so the vendor symlink kept pointing at a previous run's worktree — apps were measured against the wrong library (zero-movement delta tables). Plus corrupted `composer.json` and stale compiled caches from aborted runs.
**Fix:** before each bootstrap (and before its own per-app `composer.json` edits like `platform.php`), reset `composer.json`/`composer.lock` + remove `vendor/radiergummi` and `bootstrap/cache/{packages,services}.php` from git. `survey_link_library` now asserts the vendor link resolves to `$LIB` (else records `blocked-compat` — silence here is what made this invisible). The manifest records each app's **installed** library sha for self-verification against `libraryCommit`.

## Tests / verification
- `SurveyAggregateResultsTest` covers the merge contract (full-run replace, `--only` backfill, scratch build, retired-app tail, malformed entries). `aggregate.php` added to phpstan `scanFiles`.
- The corpus itself can't run in CI without the external workspace, so the shell-level fixes were verified by: `shellcheck` (clean), `bash -n` under **bash 3.2** (the macOS survey host), and throwaway repros confirming the stdin-drain regression, the lock acquire/stale-reclaim, and the merge (incl. discarding a corrupt existing `results.json`).
- Full suite green (1999 passed), Pint clean, PHPStan clean.

Internal dev tooling — no `CHANGELOG` entry (nothing ships to package consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)