### PR TITLE
fix(#222): race-harden parallel fixture-copy in TestCase::setUp

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,18 +63,32 @@ abstract class TestCase extends Orchestra
 
         $destination = base_path('tests/Fixtures/OpenApi/example_payloads');
 
-        if (
-            !is_dir($destination)
-            && !mkdir($destination, 0o777, true)
-            && !is_dir($destination)
-        ) {
-            throw new RuntimeException("Failed to create fixture destination: {$destination}");
+        // Under Pest's parallel runner many workers race this same path. Suppress the mkdir error
+        // (a worker that loses the race gets false even though the directory now exists), clear the
+        // per-process stat cache the recursive mkdir can leave stale, then re-check authoritatively.
+        if (!is_dir($destination)) {
+            @mkdir($destination, 0o777, true);
+            clearstatcache(true, $destination);
+
+            if (!is_dir($destination)) {
+                throw new RuntimeException("Failed to create fixture destination: {$destination}");
+            }
         }
 
         foreach ((array) glob($source . '/*') as $file) {
             $target = $destination . '/' . basename((string) $file);
 
-            if (!copy((string) $file, $target)) {
+            // Idempotent + atomic: skip a fixture already mirrored, and copy via a process-unique
+            // temp + rename so a concurrent worker never reads a half-written file.
+            if (is_file($target)) {
+                continue;
+            }
+
+            $temp = $target . '.' . getmypid() . '.tmp';
+
+            if (!copy((string) $file, $temp) || !rename($temp, $target)) {
+                @unlink($temp);
+
                 throw new RuntimeException("Failed to copy fixture {$file} -> {$target}");
             }
         }


### PR DESCRIPTION
Closes #222.

## Problem
Rare flake in `composer test` (Pest `--parallel`, 12 workers) on a cold cache: a worker threw `RuntimeException: Failed to create fixture destination` from `tests/TestCase.php::setUp()`. Pre-existing (the file is untouched by recent feature PRs). Two unsynchronized filesystem ops on a shared path race across workers:

1. The `!is_dir / mkdir / !is_dir` guard can throw spuriously — a worker losing the recursive `mkdir` race gets `false` even though the directory now exists, and PHP's per-process stat cache can return the stale pre-`mkdir` result, defeating the re-check.
2. The `copy()` loop truncate-rewrites each fixture every `setUp()`, so a worker can read a half-written file mid-copy.

## Fix
- **mkdir guard:** `@mkdir(...)` (tolerate a lost race) → `clearstatcache(true, $destination)` → authoritative `is_dir()` re-check before throwing.
- **copy loop:** skip a fixture already mirrored (`is_file`), else copy to a process-unique `*.tmp` and `rename()` into place — atomic on the same filesystem, so a concurrent reader never sees a partial file.

Preserves the existing "re-mirror if missing" semantics; just makes each step idempotent and race-safe.

## Verification
A 12-worker filesystem race has no deterministic unit reproduction, so a unit test would be theater. Verified instead by exercising the exact failure scenario — wipe the Testbench-skeleton fixture dir + `.cache/pest`, run the full parallel suite cold — **three times, all green** (1995 passed each). Pint clean, PHPStan (level 8) clean.

Test infrastructure only — nothing ships to package consumers, so no `CHANGELOG` entry (consistent with PR #242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)