### PR TITLE
feat(#16): detect constructor $this->middleware() — crash-safe fallback for non-instantiable controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- **Constructor `$this->middleware(...)` now survives non-instantiable controllers** (#16). Laravel
+  itself resolves controller middleware when routes are gathered — the static
+  `HasMiddleware::middleware()` form without instantiation, the classic constructor form by
+  instantiating the controller through the container, both honouring `only` / `except`. The gap was
+  the controller the container *cannot* build at generation time (unbound constructor dependency, a
+  constructor that throws outside a real request): `Route::gatherMiddleware()` threw, crashed the
+  whole run, and poisoned the route's middleware cache so a retry silently returned `[]`. All
+  middleware reads now flow through one crash-safe seam (`RouteMiddlewareGatherer`): on an
+  instantiation failure it logs a notice and falls back to the route-declared middleware merged with
+  a bounded static scan of the constructor body (Tier-1, first 10 top-level statements, epic #5) —
+  literal `$this->middleware(...)` names with literal fluent `->only(...)` / `->except(...)` or
+  options-array scoping, matched against the route's action method, deduplicated against
+  route-declared names. Inherited (base-controller) constructors are read through their declaring
+  class. Security schemes, per-operation `security`, the implicit 401/403/429 responses, multi-spec
+  `match.middleware`, and `openapi:why` all see the same merged list; `#[Security]` /
+  `#[PublicEndpoint]` keep winning. Dynamic names, non-literal scoping, and conditionally applied
+  registrations are refused with a generation-log notice (documenting conditional auth as
+  unconditional would overstate the contract). See
+  [Auto-derivation → Controller middleware](docs/auto-derivation.md#controller-middleware).
 - **`spatie/laravel-query-builder` fluent chains now document themselves** (#15). The QueryBuilder
   plugin reads the literal `QueryBuilder::for(...)->allowedFilters([...])->allowedSorts([...])
   ->allowedIncludes([...])` chain straight from the controller method body (Tier-1 bounded scan of

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -14,8 +14,8 @@ source.
 | Query parameters | Request-accessor reads in the method body — `$request->query('sort')` / `input('q')` → `string`, `string('name')` / `integer('page')` / `boolean('active')` → their named type (bounded scan; see [Query parameters from the method body](#query-parameters-from-the-method-body)). On GET/HEAD routes, inline `validate()` keys become query parameters (name, schema, `required` from the rules) instead of a request body. With the QueryBuilder plugin enabled, a literal `QueryBuilder::for(...)` chain's `allowedFilters` / `allowedSorts` / `allowedIncludes` become `filter[…]` / `sort` / `include` parameters (see [Plugins → QueryBuilder](plugins.md#querybuilder)). `#[QueryParam]` attributes win for their name; other names compose. |
 | Request body | Spatie Data class on the action (or on a configured payload-indirection object); `FormRequest` is supported natively. Schema is built from PHP types and validation rules. Without a typed payload parameter, inline `validate()` calls and a controller-declared `$rules` property / `rules()` method are read from the method body (bounded scan; see [Request bodies → Inline validation in the controller](request-bodies.md#inline-validation-in-the-controller)). |
 | Response body | Spatie Data class or `DataCollection<…>` return type → component `$ref`. `JsonResource` subclass → component schema: fields are inferred from a single-`return [...]` `toArray()` literal (`$this->field` typed from the wrapped `@mixin`/`@extends` model, nested resources as `$ref`s, `when*` wrappers optional) composed with declared `#[ResourceField]` attributes, which win per field; a passthrough or dynamic `toArray()` falls back to the wrapped model's schema (see [Plugins → ApiResources](plugins.md#apiresources)). A **base** resource return type (`JsonResource`, bare `ResourceCollection`, `AnonymousResourceCollection`) resolves the concrete resource from the method's return expression — `X::collection(…)` / `X::make(…)` / `new X(…)`, `->toResource(…)`, or a `@return …Collection<X>` generic; a collection only claims the paginated envelope when its source visibly ends in a `paginate()`-family call, looking through paginator-preserving links like `withQueryString()` (bounded scan; see [Plugins → ApiResources → Resolving the resource from the return expression](plugins.md#resolving-the-resource-from-the-return-expression)). Eloquent `Model` subclass → component schema built from `$casts`, `@property`/`@property-read` annotations, typed `$appends` accessors, and `$hidden`/`$visible`. See [Eloquent model response schemas](#eloquent-model-response-schemas). Without a schema-bearing return type, a literal `response()->json([...])` in the method body is read instead (bounded scan; see [Inline JSON responses](#inline-json-responses)). |
-| Security | `auth:*` / `scope:*` / `scopes:*` (and Sanctum's `abilities:*` / `ability:*`) middleware → a per-operation `security` requirement against the derived scheme(s): Passport's OAuth2 flows, a `sanctum` http/bearer scheme when any route uses `auth:sanctum`, or `openapi.security_schemes`. Sanctum's all-of `abilities:a,b` lists both as scopes on one requirement; its any-of `ability:a,b` emits one OR-alternative requirement per ability. Map project-specific guard middleware to a declared scheme via `openapi.security_middleware_map`. When the route is authed but no scheme is derivable, `security` is omitted (not `[]`, which means *public*) and `operation.security-missing` flags it. |
-| Error responses | `@throws ExceptionClass` → status codes; `abort(403)` / `abort_if(…, 404, 'msg')` / `abort_unless(…, 403, 'msg')` in the method body → that status, with a literal message as the response description (bounded scan of the first 10 statements; class-constant statuses such as `abort(Response::HTTP_FORBIDDEN, …)` resolve too, a genuinely non-literal status is skipped with a generation-log note); a route-model-bound parameter (`show(Post $post)`) → 404; a `FormRequest` parameter → 422; `auth`/`scope`/`can`/`throttle` middleware → 401 / 403 / 403 / 429. An explicit `#[Response]` for the same status always wins. |
+| Security | `auth:*` / `scope:*` / `scopes:*` (and Sanctum's `abilities:*` / `ability:*`) middleware — route-declared or controller-applied, including constructor `$this->middleware(...)` and the static `HasMiddleware` form (see [Controller middleware](#controller-middleware)) — → a per-operation `security` requirement against the derived scheme(s): Passport's OAuth2 flows, a `sanctum` http/bearer scheme when any route uses `auth:sanctum`, or `openapi.security_schemes`. Sanctum's all-of `abilities:a,b` lists both as scopes on one requirement; its any-of `ability:a,b` emits one OR-alternative requirement per ability. Map project-specific guard middleware to a declared scheme via `openapi.security_middleware_map`. When the route is authed but no scheme is derivable, `security` is omitted (not `[]`, which means *public*) and `operation.security-missing` flags it. |
+| Error responses | `@throws ExceptionClass` → status codes; `abort(403)` / `abort_if(…, 404, 'msg')` / `abort_unless(…, 403, 'msg')` in the method body → that status, with a literal message as the response description (bounded scan of the first 10 statements; class-constant statuses such as `abort(Response::HTTP_FORBIDDEN, …)` resolve too, a genuinely non-literal status is skipped with a generation-log note); a route-model-bound parameter (`show(Post $post)`) → 404; a `FormRequest` parameter → 422; `auth`/`scope`/`can`/`throttle` middleware (route-declared or controller-applied, see [Controller middleware](#controller-middleware)) → 401 / 403 / 403 / 429. An explicit `#[Response]` for the same status always wins. |
 | Validation constraints | `Data::rules()` and Spatie validation attributes → `maxLength`, `minLength`, `pattern`, `enum`, `format`, `minimum`/`maximum`, `minItems`/`maxItems`. |
 
 Use an authoring attribute when convention can't produce what you need. See
@@ -391,6 +391,58 @@ Boundaries, by design (no dataflow analysis):
   accessor read of the same name — they know `required` and the constraints.
 - An explicit `#[QueryParam]` wins **entirely** for its name (no merging);
   parameters from different sources with different names compose.
+
+## Controller middleware
+
+Everywhere the generator reads a route's middleware — security requirements,
+the implicit 401/403/429 responses, multi-spec `match.middleware`, and
+`openapi:why` — it sees **controller-applied middleware too**, not just what
+the route declares. Both controller idioms count:
+
+```php
+// Laravel 11+ static form — resolved without instantiating the controller.
+class ReportController implements HasMiddleware
+{
+    public static function middleware(): array
+    {
+        return [new Middleware('auth:sanctum', only: ['index'])];
+    }
+}
+
+// Classic constructor form, common in long-lived apps.
+class ExportController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+        $this->middleware('verified')->only(['index']);
+        $this->middleware('throttle:exports', ['except' => ['index']]);
+    }
+}
+```
+
+For instantiable controllers Laravel resolves both forms itself, `only` /
+`except` included. The interesting case is a controller the container *cannot*
+build at generation time — an unbound constructor dependency, a constructor
+that throws outside a real request. Previously that crashed the run; now the
+generator logs a notice and falls back to a **bounded static scan** of the
+constructor (the first 10 top-level statements): literal
+`$this->middleware(...)` names with literal `->only(...)` / `->except(...)` or
+options-array scoping are merged into the route's middleware list,
+deduplicated, and matched against the action method. Inherited constructors
+work — the scan reads the declaring (base) class.
+
+Boundaries, by design (no dataflow analysis):
+
+- Only literal strings (and class constants) are read. A dynamic name
+  (`$this->middleware($this->guard())`) or non-literal scoping is skipped with
+  a generation-log note.
+- A registration inside an `if` is **not** documented — conditional middleware
+  presented as unconditional would overstate the contract. The generation log
+  notes it; annotate the affected actions with `#[Security]` to document the
+  requirement explicitly.
+- `#[Security]` and `#[PublicEndpoint]` always win over middleware-derived
+  security, exactly as for route-declared middleware.
 
 ## Resource action conventions
 

--- a/src/Console/WhyCommand.php
+++ b/src/Console/WhyCommand.php
@@ -10,6 +10,7 @@ use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\Inclusion\InclusionDecision;
 use Radiergummi\OpenApi\Support\Inclusion\InclusionEvaluator;
 use Radiergummi\OpenApi\Support\Routing\RouteIntrospector;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
 use ReflectionException;
 use UnexpectedValueException;
@@ -130,7 +131,7 @@ class WhyCommand extends Command
         $middleware = array_values(
             array_map(
                 static fn(mixed $entry): string => (string) $entry,
-                $descriptor->route->gatherMiddleware(),
+                app(RouteMiddlewareGatherer::class)->middlewareFor($descriptor->route),
             ),
         );
 

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -45,6 +45,7 @@ use Radiergummi\OpenApi\Support\Generator\Stages\ErrorResponseInferenceStage;
 use Radiergummi\OpenApi\Support\Inclusion\InclusionEvaluator;
 use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
 use Radiergummi\OpenApi\Support\Routing\ReturnTypeExtractor;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Radiergummi\OpenApi\Support\Routing\UriParameterResolver;
 use Radiergummi\OpenApi\Support\Spec\SpecDefinition;
 use Radiergummi\OpenApi\Support\Spec\SpecMatcher;
@@ -216,6 +217,7 @@ class OpenApiServiceProvider extends ServiceProvider
                     matcher: $app->make(SpecMatcher::class),
                     specResolver: $app->make(SpecResolver::class),
                     visibility: $app->make(VisibilityResolver::class),
+                    middlewareGatherer: $app->make(RouteMiddlewareGatherer::class),
                 );
             },
         );

--- a/src/Plugins/Core/ErrorContributors/MiddlewareErrorContributor.php
+++ b/src/Plugins/Core/ErrorContributors/MiddlewareErrorContributor.php
@@ -11,6 +11,7 @@ use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseContributor;
 use Radiergummi\OpenApi\Errors\ErrorDescriptor;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\Extraction\DetectsAuthMiddleware;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Throwable;
 
 use function array_any;
@@ -34,6 +35,7 @@ final readonly class MiddlewareErrorContributor implements ErrorResponseContribu
      * @param array<string, array{status: int, description: string, exception?: class-string<Throwable>}> $middlewareMap
      */
     public function __construct(
+        private RouteMiddlewareGatherer $middlewareGatherer,
         #[Config('openapi.middleware_responses', default: [])]
         private array $middlewareMap = [],
     ) {}
@@ -45,11 +47,11 @@ final readonly class MiddlewareErrorContributor implements ErrorResponseContribu
     public function contribute(ActionDescriptor $descriptor): array
     {
         $descriptors = [];
-        // gatherMiddleware() may include closure middleware; the string-typed
+        // The gathered list may include closure middleware; the string-typed
         // detectors below only understand named middleware, so drop the rest.
         $middleware = array_values(
             array_filter(
-                $descriptor->route->gatherMiddleware(),
+                $this->middlewareGatherer->middlewareFor($descriptor->route),
                 is_string(...),
             ),
         );

--- a/src/Support/Extraction/SecurityExtractor.php
+++ b/src/Support/Extraction/SecurityExtractor.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Laravel\Passport\Passport;
 use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 
 use function array_any;
 use function array_filter;
@@ -96,7 +97,10 @@ final class SecurityExtractor
     /** @var ?list<string> */
     private ?array $defaultSchemeNames = null;
 
-    public function __construct(private readonly Router $router) {}
+    public function __construct(
+        private readonly Router $router,
+        private readonly RouteMiddlewareGatherer $middlewareGatherer,
+    ) {}
 
     /**
      * @return list<OA\SecurityScheme>
@@ -319,13 +323,18 @@ final class SecurityExtractor
     }
 
     /**
-     * Gathers a route's middleware and expands any group names to their members.
+     * Gathers a route's middleware — via the crash-safe {@see RouteMiddlewareGatherer}, so
+     * constructor-applied middleware of non-instantiable controllers participates — and expands
+     * any group names to their members.
      *
      * @return list<string>
      */
     private function expandedMiddlewareFor(Route $route): array
     {
-        return $this->expandGroups(array_values($route->gatherMiddleware()), $this->middlewareGroups());
+        return $this->expandGroups(
+            array_values($this->middlewareGatherer->middlewareFor($route)),
+            $this->middlewareGroups(),
+        );
     }
 
     /**

--- a/src/Support/Inclusion/InclusionEvaluator.php
+++ b/src/Support/Inclusion/InclusionEvaluator.php
@@ -9,9 +9,9 @@ use Radiergummi\OpenApi\Attributes\Hide;
 use Radiergummi\OpenApi\Contracts\Routing\RouteFilter;
 use Radiergummi\OpenApi\Events\SkipReason;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Radiergummi\OpenApi\Support\Spec\SpecDefinition;
 use Radiergummi\OpenApi\Support\Spec\SpecMatcher;
-use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Radiergummi\OpenApi\Support\Spec\SpecResolver;
 use Radiergummi\OpenApi\Support\Visibility\VisibilityResolver;
 

--- a/src/Support/Inclusion/InclusionEvaluator.php
+++ b/src/Support/Inclusion/InclusionEvaluator.php
@@ -11,6 +11,7 @@ use Radiergummi\OpenApi\Events\SkipReason;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\Spec\SpecDefinition;
 use Radiergummi\OpenApi\Support\Spec\SpecMatcher;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Radiergummi\OpenApi\Support\Spec\SpecResolver;
 use Radiergummi\OpenApi\Support\Visibility\VisibilityResolver;
 
@@ -47,6 +48,7 @@ final readonly class InclusionEvaluator
         private SpecMatcher $matcher,
         private SpecResolver $specResolver,
         private VisibilityResolver $visibility,
+        private RouteMiddlewareGatherer $middlewareGatherer,
     ) {}
 
     /**
@@ -132,7 +134,7 @@ final readonly class InclusionEvaluator
                     middleware: array_values(
                         array_map(
                             static fn(mixed $entry): string => (string) $entry,
-                            $descriptor->route->gatherMiddleware(),
+                            $this->middlewareGatherer->middlewareFor($descriptor->route),
                         ),
                     ),
                     controller: $descriptor->controller?->getName(),

--- a/src/Support/Routing/ConstructorMiddlewareScan.php
+++ b/src/Support/Routing/ConstructorMiddlewareScan.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Routing;
+
+use function array_unique;
+use function array_values;
+use function in_array;
+
+/**
+ * Result of one {@see ConstructorMiddlewareScanner} pass over a controller's constructor.
+ *
+ * Each entry is one matched `$this->middleware(...)` registration: the literal middleware names
+ * plus the `only` / `except` action scoping it carries (null = unscoped). The two booleans carry
+ * degrade evidence for the caller's generation-log notice: a registration was found but refused
+ * (non-literal name or scope, unknown chain link), or found only inside a conditional context.
+ *
+ * @internal
+ */
+final readonly class ConstructorMiddlewareScan
+{
+    /**
+     * @param list<array{names: list<string>, only: null|list<string>, except: null|list<string>}> $entries
+     */
+    public function __construct(
+        public array $entries = [],
+        public bool $unreadableCallDetected = false,
+        public bool $conditionalCallDetected = false,
+    ) {}
+
+    /**
+     * The middleware names that apply to the given action method, after `only` / `except`
+     * scoping — the same semantics as Laravel's `ControllerDispatcher::methodExcludedByOptions()`.
+     *
+     * @return list<string>
+     */
+    public function middlewareForAction(string $actionMethod): array
+    {
+        $names = [];
+
+        foreach ($this->entries as $entry) {
+            if ($entry['only'] !== null && !in_array($actionMethod, $entry['only'], true)) {
+                continue;
+            }
+
+            if ($entry['except'] !== null && in_array($actionMethod, $entry['except'], true)) {
+                continue;
+            }
+
+            foreach ($entry['names'] as $name) {
+                $names[] = $name;
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+}

--- a/src/Support/Routing/ConstructorMiddlewareScanner.php
+++ b/src/Support/Routing/ConstructorMiddlewareScanner.php
@@ -19,7 +19,6 @@ use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
 use ReflectionClass;
 
 use function array_slice;
-use function array_values;
 use function count;
 use function end;
 use function is_array;
@@ -277,7 +276,7 @@ final class ConstructorMiddlewareScanner
     }
 
     /**
-     * @param list<Node\Arg> $arguments
+     * @param array<Node\Arg> $arguments
      */
     private function hasSpreadArgument(array $arguments): bool
     {
@@ -326,6 +325,6 @@ final class ConstructorMiddlewareScanner
             $strings[] = $entry;
         }
 
-        return array_values($strings);
+        return $strings;
     }
 }

--- a/src/Support/Routing/ConstructorMiddlewareScanner.php
+++ b/src/Support/Routing/ConstructorMiddlewareScanner.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Routing;
+
+use Illuminate\Container\Attributes\Scoped;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Expression;
+use Radiergummi\OpenApi\Support\MethodBody\AstLiteralEvaluator;
+use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
+use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
+use ReflectionClass;
+
+use function array_slice;
+use function array_values;
+use function count;
+use function end;
+use function is_array;
+use function is_string;
+use function spl_object_id;
+
+/**
+ * Tier-1 whitelist matcher for imperative `$this->middleware(...)` registrations in a controller
+ * constructor (epic #5, issue #16).
+ *
+ * Scans the first {@see self::STATEMENT_LIMIT} top-level statements of `__construct` for
+ * statement-level `$this->middleware(<literal>)` chains and reads the literal middleware names
+ * together with their action scoping — the fluent `->only(...)` / `->except(...)` links and the
+ * equivalent `['only' => ..., 'except' => ...]` options-array argument. Literals resolve via
+ * {@see AstLiteralEvaluator}, so class-constant strings work.
+ *
+ * This is the *static fallback* for Laravel's own runtime resolution: `Route::gatherMiddleware()`
+ * already reads constructor middleware by instantiating the controller, so the scan only runs when
+ * instantiation fails in the generation context (see {@see RouteMiddlewareGatherer}). Receiver
+ * discipline is strict — only calls on the literal `$this` match. Inherited constructors work
+ * naturally: `ReflectionClass::getConstructor()` reflects the declaring class, so the scanner
+ * reads the base controller's file.
+ *
+ * Only straight-line registrations participate ({@see ConditionalContextPolicy}): a
+ * `$this->middleware()` inside an `if` documents conditional auth as unconditional, which
+ * overstates the contract — it is refused and reported as conditional evidence instead.
+ * Non-literal names or scoping, unknown chain links, and spread arguments are refused likewise
+ * and reported as unreadable; the caller degrades with a generation-log note.
+ *
+ * @internal
+ */
+#[Scoped]
+final class ConstructorMiddlewareScanner
+{
+    public const int STATEMENT_LIMIT = 10;
+
+    /**
+     * Memoised scans per controller class: one parse per generation run, however many routes
+     * point at the controller.
+     *
+     * @var array<class-string, ConstructorMiddlewareScan>
+     */
+    private array $cache = [];
+
+    private readonly StatementNodeFinder $statementNodeFinder;
+
+    public function __construct(private readonly MethodBodyScanner $scanner)
+    {
+        $this->statementNodeFinder = new StatementNodeFinder();
+    }
+
+    /**
+     * @param ReflectionClass<object> $controller
+     */
+    public function scan(ReflectionClass $controller): ConstructorMiddlewareScan
+    {
+        return $this->cache[$controller->getName()] ??= $this->scanConstructor($controller);
+    }
+
+    /**
+     * @param ReflectionClass<object> $controller
+     */
+    private function scanConstructor(ReflectionClass $controller): ConstructorMiddlewareScan
+    {
+        $constructor = $controller->getConstructor();
+
+        if ($constructor === null) {
+            return new ConstructorMiddlewareScan();
+        }
+
+        $statements = $this->scanner->firstStatements($constructor, self::STATEMENT_LIMIT);
+
+        if ($statements === []) {
+            return new ConstructorMiddlewareScan();
+        }
+
+        $entries = [];
+        $unreadableCallDetected = false;
+
+        /** @var array<int, true> $consumedCalls spl_object_id set of matched middleware call nodes */
+        $consumedCalls = [];
+
+        foreach ($statements as $statement) {
+            $registration = $this->registrationChain($statement);
+
+            if ($registration === null) {
+                continue;
+            }
+
+            [$middlewareCall, $chainLinks] = $registration;
+            $consumedCalls[spl_object_id($middlewareCall)] = true;
+
+            $entry = $this->entryFrom($middlewareCall, $chainLinks);
+
+            if ($entry === null) {
+                $unreadableCallDetected = true;
+
+                continue;
+            }
+
+            $entries[] = $entry;
+        }
+
+        // Detection is broader than matching: a middleware call reachable on the straight-line
+        // path but not consumed above (nested in an argument, an unmatched chain shape) is
+        // unreadable; one reachable only under the inclusive policy is conditionally applied.
+        $straightLineCalls = $this->statementNodeFinder->findAll(
+            $statements,
+            ConditionalContextPolicy::SkipConditionalContexts,
+            $this->isMiddlewareRegistration(...),
+        );
+
+        foreach ($straightLineCalls as $call) {
+            if (!isset($consumedCalls[spl_object_id($call)])) {
+                $unreadableCallDetected = true;
+            }
+        }
+
+        $allCalls = $this->statementNodeFinder->findAll(
+            $statements,
+            ConditionalContextPolicy::IncludeConditionalContexts,
+            $this->isMiddlewareRegistration(...),
+        );
+
+        return new ConstructorMiddlewareScan(
+            entries: $entries,
+            unreadableCallDetected: $unreadableCallDetected,
+            conditionalCallDetected: count($allCalls) > count($straightLineCalls),
+        );
+    }
+
+    /**
+     * Unwraps a top-level statement into a method-call chain rooted at `$this->middleware(...)`:
+     * the canonical registration idiom, as a bare statement or an assignment's right-hand side.
+     * Returns the root call plus the chain links above it (`->only()` / `->except()` / …), or
+     * null when the statement is no such chain.
+     *
+     * @return null|array{MethodCall, list<MethodCall>}
+     */
+    private function registrationChain(Node $statement): ?array
+    {
+        if (!$statement instanceof Expression) {
+            return null;
+        }
+
+        $expression = $statement->expr;
+
+        if ($expression instanceof Assign) {
+            $expression = $expression->expr;
+        }
+
+        if (!$expression instanceof MethodCall) {
+            return null;
+        }
+
+        // Outermost call first; the innermost link is the chain root.
+        $links = [];
+        $current = $expression;
+
+        while ($current instanceof MethodCall) {
+            $links[] = $current;
+            $current = $current->var;
+        }
+
+        $root = end($links);
+
+        if (!$this->isMiddlewareRegistration($root)) {
+            return null;
+        }
+
+        return [$root, array_slice($links, 0, -1)];
+    }
+
+    private function isMiddlewareRegistration(Node $node): bool
+    {
+        return $node instanceof MethodCall
+            && $node->var instanceof Variable
+            && $node->var->name === 'this'
+            && $node->name instanceof Identifier
+            && $node->name->toLowerString() === 'middleware'
+            && !$node->isFirstClassCallable();
+    }
+
+    /**
+     * Reads one registration into an entry, or null when any part is not statically readable:
+     * the middleware names (literal string or array of strings), the optional options-array
+     * argument, and the fluent `only` / `except` chain links.
+     *
+     * @param list<MethodCall> $chainLinks
+     *
+     * @return null|array{names: list<string>, only: null|list<string>, except: null|list<string>}
+     */
+    private function entryFrom(MethodCall $middlewareCall, array $chainLinks): ?array
+    {
+        $arguments = $middlewareCall->getArgs();
+
+        if (count($arguments) < 1 || count($arguments) > 2 || $this->hasSpreadArgument($arguments)) {
+            return null;
+        }
+
+        $names = $this->stringList($this->literal($arguments[0]->value));
+
+        if ($names === null) {
+            return null;
+        }
+
+        $only = null;
+        $except = null;
+
+        if (isset($arguments[1])) {
+            $options = $this->literal($arguments[1]->value);
+
+            if (!is_array($options)) {
+                return null;
+            }
+
+            if (isset($options['only']) && ($only = $this->stringList($options['only'])) === null) {
+                return null;
+            }
+
+            if (isset($options['except']) && ($except = $this->stringList($options['except'])) === null) {
+                return null;
+            }
+        }
+
+        foreach ($chainLinks as $link) {
+            if (!$link->name instanceof Identifier || $link->isFirstClassCallable()) {
+                return null;
+            }
+
+            $linkArguments = $link->getArgs();
+
+            if (count($linkArguments) !== 1 || $this->hasSpreadArgument($linkArguments)) {
+                return null;
+            }
+
+            $methods = $this->stringList($this->literal($linkArguments[0]->value));
+
+            if ($methods === null) {
+                return null;
+            }
+
+            match ($link->name->toLowerString()) {
+                'only' => $only = $methods,
+                'except' => $except = $methods,
+                default => $methods = null,
+            };
+
+            if ($methods === null) {
+                return null;
+            }
+        }
+
+        return ['names' => $names, 'only' => $only, 'except' => $except];
+    }
+
+    /**
+     * @param list<Node\Arg> $arguments
+     */
+    private function hasSpreadArgument(array $arguments): bool
+    {
+        foreach ($arguments as $argument) {
+            if ($argument->unpack) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function literal(Node\Expr $expression): mixed
+    {
+        try {
+            return AstLiteralEvaluator::evaluate($expression);
+        } catch (NonLiteralValueException) {
+            return null;
+        }
+    }
+
+    /**
+     * Normalises a literal value to a list of strings: a string becomes a one-element list
+     * (Laravel `Arr::wrap()`s scoping arguments the same way); an array qualifies when every
+     * value is a string. Anything else — including null from a failed literal read — refuses.
+     *
+     * @return null|list<string>
+     */
+    private function stringList(mixed $value): ?array
+    {
+        if (is_string($value)) {
+            return [$value];
+        }
+
+        if (!is_array($value)) {
+            return null;
+        }
+
+        $strings = [];
+
+        foreach ($value as $entry) {
+            if (!is_string($entry)) {
+                return null;
+            }
+
+            $strings[] = $entry;
+        }
+
+        return array_values($strings);
+    }
+}

--- a/src/Support/Routing/RouteMiddlewareGatherer.php
+++ b/src/Support/Routing/RouteMiddlewareGatherer.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Routing;
+
+use Illuminate\Container\Attributes\Scoped;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use Throwable;
+
+use function array_merge;
+use function array_values;
+use function class_exists;
+use function is_string;
+use function spl_object_id;
+use function sprintf;
+
+/**
+ * The single seam through which the generator reads a route's middleware list.
+ *
+ * The happy path is Laravel's own `Route::gatherMiddleware()`, which already resolves controller
+ * middleware: the static `HasMiddleware::middleware()` form without instantiation, and classic
+ * constructor `$this->middleware(...)` registrations by instantiating the controller through the
+ * container. Both honour `only` / `except` scoping — for instantiable controllers nothing more is
+ * needed.
+ *
+ * The instantiation path is the failure mode this class exists for: a controller whose
+ * constructor cannot run in the generation context (unbound dependency, runtime side effects)
+ * makes `gatherMiddleware()` throw, which previously crashed the whole run — and poisons the
+ * route's internal middleware cache, so a retry silently returns `[]`. On a throw, this gatherer
+ * logs a notice and falls back to the route-declared middleware merged with a bounded static scan
+ * of the constructor body ({@see ConstructorMiddlewareScanner}), deduplicated, so security
+ * schemes, implicit 401/403 responses, spec matching, and `openapi:why` all keep seeing one
+ * uniform list. Results are cached per route, immune to the poisoned-cache footgun.
+ *
+ * @internal
+ */
+#[Scoped]
+final class RouteMiddlewareGatherer
+{
+    /**
+     * Gathered middleware keyed by route object id. Route objects live in the router for the
+     * whole generation run, so ids are stable.
+     *
+     * @var array<int, array<int, mixed>>
+     */
+    private array $middlewareByRoute = [];
+
+    /**
+     * Controller classes for which degrade notices have been emitted, so a controller with many
+     * routes logs once.
+     *
+     * @var array<class-string, true>
+     */
+    private array $notedControllers = [];
+
+    public function __construct(
+        private readonly ConstructorMiddlewareScanner $scanner,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Same shape as `Route::gatherMiddleware()`: middleware names plus any closure middleware
+     * the route carries — callers already filter for strings.
+     *
+     * @return array<int, mixed>
+     */
+    public function middlewareFor(Route $route): array
+    {
+        $key = spl_object_id($route);
+
+        if (isset($this->middlewareByRoute[$key])) {
+            return $this->middlewareByRoute[$key];
+        }
+
+        try {
+            return $this->middlewareByRoute[$key] = array_values($route->gatherMiddleware());
+        } catch (Throwable $exception) {
+            return $this->middlewareByRoute[$key] = $this->staticallyGatheredFallback($route, $exception);
+        }
+    }
+
+    /**
+     * Route-declared middleware plus the literal constructor registrations that apply to the
+     * route's action method, deduplicated. Runs only when the runtime gather threw — the Tier-0
+     * miss that licenses a body scan.
+     *
+     * @return array<int, mixed>
+     */
+    private function staticallyGatheredFallback(Route $route, Throwable $exception): array
+    {
+        /** @var array<int, mixed> $declared */
+        $declared = array_values((array) $route->middleware());
+        $controllerClass = $route->getControllerClass();
+
+        if (!is_string($controllerClass) || !class_exists($controllerClass)) {
+            return $declared;
+        }
+
+        $scan = $this->scanner->scan(new ReflectionClass($controllerClass));
+        $this->noteDegradation($controllerClass, $exception, $scan);
+
+        $actionMethod = $route->getActionMethod();
+
+        // Invokable controllers report the class name as the action method.
+        if ($actionMethod === $controllerClass) {
+            $actionMethod = '__invoke';
+        }
+
+        /** @var array<int, mixed> $merged */
+        $merged = Router::uniqueMiddleware(
+            array_merge($declared, $scan->middlewareForAction($actionMethod)),
+        );
+
+        return $merged;
+    }
+
+    /**
+     * @param class-string $controllerClass
+     */
+    private function noteDegradation(
+        string $controllerClass,
+        Throwable $exception,
+        ConstructorMiddlewareScan $scan,
+    ): void {
+        if (isset($this->notedControllers[$controllerClass])) {
+            return;
+        }
+
+        $this->notedControllers[$controllerClass] = true;
+
+        $this->logger->notice(sprintf(
+            'Controller %s could not be instantiated while gathering route middleware (%s); '
+            . 'falling back to route-declared middleware plus a static scan of the constructor.',
+            $controllerClass,
+            $exception->getMessage(),
+        ));
+
+        if ($scan->unreadableCallDetected) {
+            $this->logger->notice(sprintf(
+                'A $this->middleware() registration in %s::__construct() has no statically '
+                . 'readable name or scope; it is not documented. Annotate the affected actions '
+                . 'with #[Security] or #[PublicEndpoint] to document them.',
+                $controllerClass,
+            ));
+        }
+
+        if ($scan->conditionalCallDetected) {
+            $this->logger->notice(sprintf(
+                'A $this->middleware() registration in %s::__construct() is conditionally '
+                . 'applied; it is not documented, since documenting conditional middleware as '
+                . 'unconditional would overstate the contract. Annotate the affected actions '
+                . 'with #[Security] to document them.',
+                $controllerClass,
+            ));
+        }
+    }
+}

--- a/tests/Feature/ConstructorMiddlewareTest.php
+++ b/tests/Feature/ConstructorMiddlewareTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareChildController;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareFixtureController;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\StaticMiddlewareFixtureController;
+
+use function array_any;
+use function str_contains;
+
+uses()->group('openapi');
+
+// region Constructor middleware of a non-instantiable controller
+
+it('derives security and the implicit 401 from constructor middleware when instantiation fails', function (): void {
+    Route::get('/oa-fixture/reports', [ConstructorMiddlewareFixtureController::class, 'index']);
+
+    $spec = generateSpec();
+    $operation = $spec['paths']['/oa-fixture/reports']['get'];
+
+    // Passport is active in the Testbench environment, so the derived default-scheme set
+    // includes the oauth2 pair besides sanctum; the sanctum requirement is what this feature adds.
+    expect($operation['security'])->toContain(['sanctum' => []])
+        ->and($operation['responses'])->toHaveKey('401')
+        ->and($spec['components']['securitySchemes']['sanctum']['type'])->toBe('http');
+});
+
+it('scopes only() and except() registrations to the matching operations', function (): void {
+    Route::get('/oa-fixture/reports', [ConstructorMiddlewareFixtureController::class, 'index']);
+    Route::post('/oa-fixture/reports', [ConstructorMiddlewareFixtureController::class, 'store']);
+
+    $spec = generateSpec();
+    $index = $spec['paths']['/oa-fixture/reports']['get'];
+    $store = $spec['paths']['/oa-fixture/reports']['post'];
+
+    // `throttle:exports` is except('index'): the 429 only appears on store.
+    expect($index['responses'])->not->toHaveKey('429')
+        ->and($store['responses'])->toHaveKey('429');
+});
+
+it('keeps generation alive and notices the degradation instead of crashing', function (): void {
+    Route::get('/oa-fixture/reports', [ConstructorMiddlewareFixtureController::class, 'index']);
+
+    $logger = recordingLogger();
+    app()->instance(LoggerInterface::class, $logger);
+
+    generateSpec();
+
+    $messages = array_map(static fn(array $record): string => $record['message'], $logger->records);
+
+    expect(array_any($messages, static fn(string $m): bool => str_contains($m, 'could not be instantiated')))
+        ->toBeTrue()
+        ->and(array_any($messages, static fn(string $m): bool => str_contains($m, 'no statically readable name or scope')))
+        ->toBeTrue()
+        ->and(array_any($messages, static fn(string $m): bool => str_contains($m, 'conditionally applied')))
+        ->toBeTrue();
+});
+
+it('lets #[PublicEndpoint] win over constructor-derived security', function (): void {
+    Route::get('/oa-fixture/reports/health', [ConstructorMiddlewareFixtureController::class, 'health']);
+
+    $spec = generateSpec();
+    $operation = $spec['paths']['/oa-fixture/reports/health']['get'];
+
+    // The attribute wins for `security` — same precedence as for route-declared middleware.
+    // (The implicit 401 still follows the middleware list, also matching route-declared behaviour.)
+    expect($operation['security'] ?? [])->toBe([]);
+});
+
+// endregion
+
+// region Inherited base-controller constructor
+
+it('reads middleware applied by a parent constructor', function (): void {
+    Route::get('/oa-fixture/inherited', [ConstructorMiddlewareChildController::class, 'index']);
+
+    $spec = generateSpec();
+    $operation = $spec['paths']['/oa-fixture/inherited']['get'];
+
+    // `auth:api` resolves to the Passport default pair in the Testbench environment.
+    expect($operation['security'])->toBe([['oauth2' => []], ['oauth2ClientCredentials' => []]])
+        ->and($operation['responses'])->toHaveKey('401');
+});
+
+// endregion
+
+// region HasMiddleware static form (pinned: resolved natively by the framework)
+
+it('documents HasMiddleware static middleware without any constructor scan', function (): void {
+    Route::get('/oa-fixture/static', [StaticMiddlewareFixtureController::class, 'index']);
+    Route::get('/oa-fixture/static/{id}', [StaticMiddlewareFixtureController::class, 'show']);
+
+    $spec = generateSpec();
+    $index = $spec['paths']['/oa-fixture/static']['get'];
+    $show = $spec['paths']['/oa-fixture/static/{id}']['get'];
+
+    expect($index['security'])->toContain(['sanctum' => []])
+        ->and($index['responses'])->toHaveKey('401')
+        ->and($show['security'] ?? [])->toBe([])
+        ->and($show['responses'])->not->toHaveKey('401');
+});
+
+// endregion

--- a/tests/Fixtures/ConstructorMiddleware/ConstructorMiddlewareBaseController.php
+++ b/tests/Fixtures/ConstructorMiddleware/ConstructorMiddlewareBaseController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware;
+
+use Illuminate\Routing\Controller;
+
+/**
+ * BookStack-style base controller: the constructor applying middleware lives on the parent,
+ * concrete controllers inherit it. `ReflectionClass::getConstructor()` on a child reflects this
+ * declaring class, so the scanner reads this file.
+ */
+abstract class ConstructorMiddlewareBaseController extends Controller
+{
+    public function __construct(public readonly UnresolvableSigningKey $signingKey)
+    {
+        $this->middleware('auth:api');
+    }
+}

--- a/tests/Fixtures/ConstructorMiddleware/ConstructorMiddlewareChildController.php
+++ b/tests/Fixtures/ConstructorMiddleware/ConstructorMiddlewareChildController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware;
+
+use Illuminate\Http\JsonResponse;
+
+/**
+ * No own constructor — the middleware comes from {@see ConstructorMiddlewareBaseController}.
+ */
+class ConstructorMiddlewareChildController extends ConstructorMiddlewareBaseController
+{
+    public function index(): JsonResponse
+    {
+        return new JsonResponse([]);
+    }
+}

--- a/tests/Fixtures/ConstructorMiddleware/ConstructorMiddlewareFixtureController.php
+++ b/tests/Fixtures/ConstructorMiddleware/ConstructorMiddlewareFixtureController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Radiergummi\OpenApi\Attributes\PublicEndpoint;
+
+use function config;
+
+/**
+ * Classic constructor-middleware controller that the container cannot instantiate (see
+ * {@see UnresolvableSigningKey}), exercising every whitelisted registration shape plus the
+ * degrade cases.
+ */
+class ConstructorMiddlewareFixtureController extends Controller
+{
+    public function __construct(public readonly UnresolvableSigningKey $signingKey)
+    {
+        // Unscoped registration: applies to every action.
+        $this->middleware('auth:sanctum');
+
+        // Fluent only() with an array literal.
+        $this->middleware('verified')->only(['index']);
+
+        // Fluent except() with a bare string (Arr::wrap semantics).
+        $this->middleware('throttle:exports')->except('index');
+
+        // Options-array scoping, array form of the middleware argument.
+        $this->middleware(['signed.params'], ['only' => ['store']]);
+
+        // Non-literal middleware name: refused, reported as unreadable.
+        $this->middleware($this->dynamicMiddlewareName());
+
+        // Conditionally applied: refused, reported as conditional.
+        if (config('app.debug') === true) {
+            $this->middleware('debugbar');
+        }
+
+        // Receiver discipline: not our registration, invisible to the scan.
+        $aliased = $this;
+        $aliased->middleware('aliased-receiver');
+    }
+
+    public function index(): JsonResponse
+    {
+        return new JsonResponse([]);
+    }
+
+    public function store(): JsonResponse
+    {
+        return new JsonResponse([], 201);
+    }
+
+    #[PublicEndpoint]
+    public function health(): JsonResponse
+    {
+        return new JsonResponse(['status' => 'ok']);
+    }
+
+    private function dynamicMiddlewareName(): string
+    {
+        return 'computed';
+    }
+}

--- a/tests/Fixtures/ConstructorMiddleware/StaticMiddlewareFixtureController.php
+++ b/tests/Fixtures/ConstructorMiddleware/StaticMiddlewareFixtureController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+
+/**
+ * The modern Laravel 11+ idiom: static `HasMiddleware::middleware()`. Resolved natively by
+ * `Route::gatherMiddleware()` without instantiation — pinned by a feature test, no scanner
+ * involvement.
+ */
+class StaticMiddlewareFixtureController implements HasMiddleware
+{
+    public static function middleware(): array
+    {
+        return [new Middleware('auth:sanctum', only: ['index'])];
+    }
+
+    public function index(): JsonResponse
+    {
+        return new JsonResponse([]);
+    }
+
+    public function show(string $id): JsonResponse
+    {
+        return new JsonResponse(['id' => $id]);
+    }
+}

--- a/tests/Fixtures/ConstructorMiddleware/UnresolvableSigningKey.php
+++ b/tests/Fixtures/ConstructorMiddleware/UnresolvableSigningKey.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware;
+
+/**
+ * Deliberately unbound constructor dependency: any controller requiring it cannot be
+ * instantiated by the container, so `Route::gatherMiddleware()` throws — the scenario the
+ * static constructor-middleware scan exists for.
+ */
+interface UnresolvableSigningKey {}

--- a/tests/Unit/Core/Inference/MiddlewareErrorContributorTest.php
+++ b/tests/Unit/Core/Inference/MiddlewareErrorContributorTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Route;
 use Radiergummi\OpenApi\Plugins\Core\ErrorContributors\MiddlewareErrorContributor;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
 
 uses()->group('openapi');
@@ -14,7 +15,7 @@ uses()->group('openapi');
 // region Empty middleware
 
 it('returns an empty list when there is no middleware', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'auth'     => ['status' => 401, 'description' => 'Unauthenticated', 'exception' => AuthenticationException::class],
         'scope'    => ['status' => 403, 'description' => 'Insufficient scope'],
         'throttle' => ['status' => 429, 'description' => 'Too many requests', 'exception' => ThrottleRequestsException::class],
@@ -30,7 +31,7 @@ it('returns an empty list when there is no middleware', function (): void {
 // region auth middleware
 
 it('returns a 401 descriptor when auth middleware is present and auth is configured', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'auth' => ['status' => 401, 'description' => 'Unauthenticated', 'exception' => AuthenticationException::class],
     ]);
 
@@ -47,7 +48,7 @@ it('returns a 401 descriptor when auth middleware is present and auth is configu
 // region scope middleware
 
 it('returns a 403 descriptor when scope middleware is present and scope is configured', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'scope' => ['status' => 403, 'description' => 'Insufficient scope'],
     ]);
 
@@ -64,7 +65,7 @@ it('returns a 403 descriptor when scope middleware is present and scope is confi
 // region can middleware
 
 it('returns a 403 descriptor when can middleware is present and can is configured', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'can' => ['status' => 403, 'description' => 'Forbidden'],
     ]);
 
@@ -80,7 +81,7 @@ it('returns a 403 descriptor when can middleware is present and can is configure
 // region throttle middleware
 
 it('returns a 429 descriptor when throttle middleware is present and throttle is configured', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'throttle' => ['status' => 429, 'description' => 'Too many requests', 'exception' => ThrottleRequestsException::class],
     ]);
 
@@ -97,7 +98,7 @@ it('returns a 429 descriptor when throttle middleware is present and throttle is
 // region all three middleware
 
 it('returns three descriptors in auth/scope/throttle order when all three middleware are present', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'auth'     => ['status' => 401, 'description' => 'Unauthenticated', 'exception' => AuthenticationException::class],
         'scope'    => ['status' => 403, 'description' => 'Insufficient scope'],
         'throttle' => ['status' => 429, 'description' => 'Too many requests', 'exception' => ThrottleRequestsException::class],
@@ -116,7 +117,7 @@ it('returns three descriptors in auth/scope/throttle order when all three middle
 // region middleware present but kind absent from config
 
 it('emits no descriptor for a middleware kind absent from the config map', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'auth' => ['status' => 401, 'description' => 'Unauthenticated'],
         // 'throttle' intentionally absent
     ]);
@@ -132,7 +133,7 @@ it('emits no descriptor for a middleware kind absent from the config map', funct
 // region closure middleware
 
 it('ignores closure middleware without crashing', function (): void {
-    $contributor = new MiddlewareErrorContributor(middlewareMap: [
+    $contributor = new MiddlewareErrorContributor(middlewareGatherer: app(RouteMiddlewareGatherer::class), middlewareMap: [
         'auth' => ['status' => 401, 'description' => 'Unauthenticated', 'exception' => AuthenticationException::class],
     ]);
 

--- a/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
@@ -23,6 +23,7 @@ function specConfigOrphanedEvaluator(): InclusionEvaluator
         matcher: new SpecMatcher(),
         specResolver: new SpecResolver(),
         visibility: new VisibilityResolver(VisibilityMode::Public),
+        middlewareGatherer: app(\Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer::class),
     );
 }
 

--- a/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
@@ -23,7 +23,7 @@ function specConfigOrphanedEvaluator(): InclusionEvaluator
         matcher: new SpecMatcher(),
         specResolver: new SpecResolver(),
         visibility: new VisibilityResolver(VisibilityMode::Public),
-        middlewareGatherer: app(\Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer::class),
+        middlewareGatherer: app(Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer::class),
     );
 }
 

--- a/tests/Unit/Support/Extraction/SecurityExtractorTest.php
+++ b/tests/Unit/Support/Extraction/SecurityExtractorTest.php
@@ -464,5 +464,5 @@ it('does not double-derive when route and constructor declare the same middlewar
     $extractor = securityExtractor(app('router'));
     $requirement = $extractor->forRoute($route) ?? [];
 
-    expect(array_values(array_keys($requirement, ['sanctum' => []], true)))->toHaveCount(1);
+    expect(array_keys($requirement, ['sanctum' => []], true))->toHaveCount(1);
 });

--- a/tests/Unit/Support/Extraction/SecurityExtractorTest.php
+++ b/tests/Unit/Support/Extraction/SecurityExtractorTest.php
@@ -441,3 +441,28 @@ it('does not crash on a route carrying closure middleware', function (): void {
             ['oauth2ClientCredentials' => []],
         ]);
 });
+
+it('merges constructor middleware into the requirement when the controller cannot be instantiated', function (): void {
+    $route = Illuminate\Support\Facades\Route::get(
+        '/constructor-mw',
+        [Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareFixtureController::class, 'index'],
+    );
+
+    $extractor = securityExtractor(app('router'));
+
+    // The constructor applies `auth:sanctum`; instantiation throws on the unbound dependency,
+    // so the requirement can only come from the static constructor scan.
+    expect($extractor->forRoute($route))->toContain(['sanctum' => []]);
+});
+
+it('does not double-derive when route and constructor declare the same middleware', function (): void {
+    $route = Illuminate\Support\Facades\Route::get(
+        '/constructor-mw',
+        [Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareFixtureController::class, 'index'],
+    )->middleware('auth:sanctum');
+
+    $extractor = securityExtractor(app('router'));
+    $requirement = $extractor->forRoute($route) ?? [];
+
+    expect(array_values(array_keys($requirement, ['sanctum' => []], true)))->toHaveCount(1);
+});

--- a/tests/Unit/Support/Extraction/SecurityExtractorTest.php
+++ b/tests/Unit/Support/Extraction/SecurityExtractorTest.php
@@ -6,8 +6,17 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\Router;
 use Radiergummi\OpenApi\Support\Extraction\SecurityExtractor;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
 
 uses()->group('openapi');
+
+function securityExtractor(Router $router): SecurityExtractor
+{
+    return new SecurityExtractor(
+        router: $router,
+        middlewareGatherer: app(RouteMiddlewareGatherer::class),
+    );
+}
 
 // Covers the public `openapi.security_schemes` and `openapi.security_default_scheme`
 // config surfaces. Per-route middleware extraction is exercised end-to-end by
@@ -22,7 +31,7 @@ it('emits config-declared security schemes from openapi.security_schemes', funct
         ],
     ]);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
     $names     = array_map(static fn($s) => $s->securityScheme, $extractor->buildSchemes());
 
     expect($names)->toContain('bearer');
@@ -33,7 +42,7 @@ it('merges config-declared schemes with Passport-derived ones', function (): voi
         'bearer' => ['type' => 'http', 'scheme' => 'bearer'],
     ]);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
     $names     = array_map(static fn($s) => $s->securityScheme, $extractor->buildSchemes());
 
     expect($names)
@@ -47,7 +56,7 @@ it('lets a config entry override a Passport-derived scheme on key collision', fu
         'oauth2' => ['type' => 'apiKey', 'name' => 'X-API-Key', 'in' => 'header'],
     ]);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     $byName = [];
 
@@ -61,7 +70,7 @@ it('lets a config entry override a Passport-derived scheme on key collision', fu
 it('auto-derives a sanctum bearer scheme when an auth:sanctum route exists', function (): void {
     app('router')->get('/protected', static fn() => null)->middleware('auth:sanctum');
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     $byName = [];
 
@@ -77,7 +86,7 @@ it('auto-derives a sanctum bearer scheme when an auth:sanctum route exists', fun
 it('does not register a sanctum scheme when no route uses auth:sanctum', function (): void {
     // Token-based detection guards against over-registration: Passport is the only
     // auto-derived source here, and no route carries auth:sanctum.
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     $names = array_map(static fn($s) => $s->securityScheme, $extractor->buildSchemes());
 
@@ -101,13 +110,13 @@ it('emits a sanctum per-operation requirement for an auth:sanctum route when Pas
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['sanctum' => []]]);
 });
 
 it('targets the explicit scheme name when requirementForScopes is called with $scheme', function (): void {
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     expect($extractor->requirementForScopes(['read'], scheme: 'bearer'))
         ->toBe([['bearer' => ['read']]]);
@@ -119,7 +128,7 @@ it('uses openapi.security_default_scheme (string) as the default when set', func
     ]);
     config()->set('openapi.security_default_scheme', 'bearer');
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     expect($extractor->requirementForScopes(['read']))
         ->toBe([['bearer' => ['read']]]);
@@ -132,7 +141,7 @@ it('uses openapi.security_default_scheme (list) to emit multiple OR-alternatives
     ]);
     config()->set('openapi.security_default_scheme', ['bearer', 'apiKey']);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     expect($extractor->requirementForScopes(['read']))
         ->toBe([
@@ -156,7 +165,7 @@ it('falls back to the first config-declared scheme when default is unset and Pas
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn(new RouteCollection())->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->requirementForScopes(['read']))
         ->toBe([['bearer' => ['read']]]);
@@ -165,7 +174,7 @@ it('falls back to the first config-declared scheme when default is unset and Pas
 it('preserves the Passport oauth2 pair as the default when default is unset and Passport is installed', function (): void {
     config()->set('openapi.security_default_scheme', null);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     expect($extractor->requirementForScopes(['read']))
         ->toBe([
@@ -190,7 +199,7 @@ it('omits security for an auth route when no scheme is derivable, instead of an 
     $route                        = new Route(['GET'], '/protected', ['uses' => static fn() => null]);
     $route->action['middleware']  = ['auth:web'];
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBeNull();
 });
@@ -198,7 +207,7 @@ it('omits security for an auth route when no scheme is derivable, instead of an 
 it('emits an explicit empty (public) requirement for a route with no auth or scope middleware', function (): void {
     $route = new Route(['GET'], '/open', ['uses' => static fn() => null]);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     expect($extractor->forRoute($route))->toBe([]);
 });
@@ -220,7 +229,7 @@ it('lists abilities:read,write as scopes on the security requirement', function 
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['sanctum' => ['read', 'write']]]);
 });
@@ -240,7 +249,7 @@ it('lists ability:admin as a scope on the security requirement', function (): vo
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['sanctum' => ['admin']]]);
 });
@@ -262,7 +271,7 @@ it('maps ability: (any-of) to OR-alternative requirements, one per ability', fun
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([
         ['sanctum' => ['read']],
@@ -286,7 +295,7 @@ it('carries the all-of abilities onto each any-of alternative when both are pres
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([
         ['sanctum' => ['base', 'x']],
@@ -309,7 +318,7 @@ it('deduplicates repeated abilities like the Passport scope path', function (): 
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['sanctum' => ['read', 'write']]]);
 });
@@ -331,7 +340,7 @@ it('emits the mapped scheme for a route carrying a configured custom guard middl
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn(new RouteCollection())->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['partner' => []]]);
 });
@@ -341,7 +350,7 @@ it('leaves a route with no mapped middleware as a public requirement', function 
 
     $route = new Route(['GET'], '/open', ['uses' => static fn() => null]);
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     expect($extractor->forRoute($route))->toBe([]);
 });
@@ -367,7 +376,7 @@ it('lets a mapped scheme take precedence over the auto-derived default, carrying
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['partner' => ['read']]]);
 });
@@ -388,7 +397,7 @@ it('emits a single requirement for a mapped scheme whose name matches the auto-d
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['sanctum' => []]]);
 });
@@ -408,7 +417,7 @@ it('does not leak an empty-string scope from an argument-less ability token', fu
     $router->allows('getMiddlewareGroups')->andReturn([])->byDefault();
     $router->allows('getRoutes')->andReturn($collection)->byDefault();
 
-    $extractor = new SecurityExtractor(router: $router);
+    $extractor = securityExtractor($router);
 
     expect($extractor->forRoute($route))->toBe([['sanctum' => []]]);
 });
@@ -420,7 +429,7 @@ it('does not crash on a route carrying closure middleware', function (): void {
     $route = new Route(['GET'], '/closure-mw', ['uses' => static fn() => null]);
     $route->action['middleware'] = [static fn($request, $next) => $next($request), 'auth:api'];
 
-    $extractor = new SecurityExtractor(router: app('router'));
+    $extractor = securityExtractor(app('router'));
 
     // The closure middleware must be skipped; the string middleware still drives
     // the requirement. Previously this threw a TypeError on the closure key.

--- a/tests/Unit/Support/Inclusion/InclusionEvaluatorTest.php
+++ b/tests/Unit/Support/Inclusion/InclusionEvaluatorTest.php
@@ -101,6 +101,7 @@ function makeEvaluator(array $globalFilters = []): InclusionEvaluator
         matcher: new SpecMatcher(),
         specResolver: new SpecResolver(),
         visibility: new VisibilityResolver(VisibilityMode::Public),
+        middlewareGatherer: app(\Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer::class),
     );
 }
 

--- a/tests/Unit/Support/Routing/ConstructorMiddlewareScannerTest.php
+++ b/tests/Unit/Support/Routing/ConstructorMiddlewareScannerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Support\Routing\ConstructorMiddlewareScanner;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareChildController;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareFixtureController;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\StaticMiddlewareFixtureController;
+
+uses()->group('openapi');
+
+function scanConstructorMiddleware(string $controller): Radiergummi\OpenApi\Support\Routing\ConstructorMiddlewareScan
+{
+    return new ConstructorMiddlewareScanner(new MethodBodyScanner())
+        ->scan(new ReflectionClass($controller));
+}
+
+// region Whitelist matching
+
+it('reads an unscoped literal registration for every action', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    expect($scan->middlewareForAction('index'))->toContain('auth:sanctum')
+        ->and($scan->middlewareForAction('store'))->toContain('auth:sanctum')
+        ->and($scan->middlewareForAction('health'))->toContain('auth:sanctum');
+});
+
+it('honours fluent only() scoping with an array literal', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    expect($scan->middlewareForAction('index'))->toContain('verified')
+        ->and($scan->middlewareForAction('store'))->not->toContain('verified');
+});
+
+it('honours fluent except() scoping with a bare string argument', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    expect($scan->middlewareForAction('index'))->not->toContain('throttle:exports')
+        ->and($scan->middlewareForAction('store'))->toContain('throttle:exports');
+});
+
+it('reads the options-array scoping form and the array middleware argument', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    expect($scan->middlewareForAction('store'))->toContain('signed.params')
+        ->and($scan->middlewareForAction('index'))->not->toContain('signed.params');
+});
+
+// endregion
+
+// region Degradation
+
+it('refuses a non-literal middleware name and reports it as unreadable', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    $allNames = [
+        ...$scan->middlewareForAction('index'),
+        ...$scan->middlewareForAction('store'),
+        ...$scan->middlewareForAction('health'),
+    ];
+
+    expect($allNames)->not->toContain('computed')
+        ->and($scan->unreadableCallDetected)->toBeTrue();
+});
+
+it('refuses a conditionally applied registration and reports it as conditional', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    expect($scan->middlewareForAction('index'))->not->toContain('debugbar')
+        ->and($scan->conditionalCallDetected)->toBeTrue();
+});
+
+it('ignores middleware() calls on a receiver other than the literal $this', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareFixtureController::class);
+
+    expect($scan->middlewareForAction('index'))->not->toContain('aliased-receiver');
+});
+
+// endregion
+
+// region Inheritance and absence
+
+it('scans an inherited base-controller constructor through the declaring class', function (): void {
+    $scan = scanConstructorMiddleware(ConstructorMiddlewareChildController::class);
+
+    expect($scan->middlewareForAction('index'))->toBe(['auth:api'])
+        ->and($scan->unreadableCallDetected)->toBeFalse()
+        ->and($scan->conditionalCallDetected)->toBeFalse();
+});
+
+it('returns an empty scan for a controller without a constructor', function (): void {
+    $scan = scanConstructorMiddleware(StaticMiddlewareFixtureController::class);
+
+    expect($scan->entries)->toBe([])
+        ->and($scan->middlewareForAction('index'))->toBe([])
+        ->and($scan->unreadableCallDetected)->toBeFalse()
+        ->and($scan->conditionalCallDetected)->toBeFalse();
+});
+
+// endregion

--- a/tests/Unit/Support/Routing/RouteMiddlewareGathererTest.php
+++ b/tests/Unit/Support/Routing/RouteMiddlewareGathererTest.php
@@ -46,7 +46,7 @@ it('deduplicates a name declared both on the route and in the constructor', func
 
     $middleware = middlewareGatherer()->middlewareFor($route);
 
-    expect(array_values(array_keys($middleware, 'auth:sanctum', true)))->toHaveCount(1);
+    expect(array_keys($middleware, 'auth:sanctum', true))->toHaveCount(1);
 });
 
 it('caches the fallback per route instead of re-reading the poisoned runtime cache', function (): void {

--- a/tests/Unit/Support/Routing/RouteMiddlewareGathererTest.php
+++ b/tests/Unit/Support/Routing/RouteMiddlewareGathererTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Support\Routing\ConstructorMiddlewareScanner;
+use Radiergummi\OpenApi\Support\Routing\RouteMiddlewareGatherer;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareChildController;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\ConstructorMiddlewareFixtureController;
+use Radiergummi\OpenApi\Tests\Fixtures\ConstructorMiddleware\StaticMiddlewareFixtureController;
+
+uses()->group('openapi');
+
+function middlewareGatherer(?Psr\Log\AbstractLogger $logger = null): RouteMiddlewareGatherer
+{
+    return new RouteMiddlewareGatherer(
+        scanner: new ConstructorMiddlewareScanner(new MethodBodyScanner()),
+        logger: $logger ?? recordingLogger(),
+    );
+}
+
+it('passes the runtime gather through untouched for an instantiable controller', function (): void {
+    $route = RouteFacade::get('/static-middleware', [StaticMiddlewareFixtureController::class, 'index']);
+    $logger = recordingLogger();
+
+    expect(middlewareGatherer($logger)->middlewareFor($route))->toBe(['auth:sanctum'])
+        ->and($logger->records)->toBe([]);
+});
+
+it('falls back to route-declared middleware plus the constructor scan when instantiation throws', function (): void {
+    $route = RouteFacade::get('/constructor-middleware', [ConstructorMiddlewareFixtureController::class, 'index'])
+        ->middleware('api');
+
+    $middleware = middlewareGatherer()->middlewareFor($route);
+
+    expect($middleware)->toContain('api')
+        ->and($middleware)->toContain('auth:sanctum')
+        ->and($middleware)->toContain('verified')
+        ->and($middleware)->not->toContain('throttle:exports');
+});
+
+it('deduplicates a name declared both on the route and in the constructor', function (): void {
+    $route = RouteFacade::get('/constructor-middleware', [ConstructorMiddlewareFixtureController::class, 'index'])
+        ->middleware('auth:sanctum');
+
+    $middleware = middlewareGatherer()->middlewareFor($route);
+
+    expect(array_values(array_keys($middleware, 'auth:sanctum', true)))->toHaveCount(1);
+});
+
+it('caches the fallback per route instead of re-reading the poisoned runtime cache', function (): void {
+    $route = RouteFacade::get('/constructor-middleware', [ConstructorMiddlewareFixtureController::class, 'index']);
+    $gatherer = middlewareGatherer();
+
+    $first = $gatherer->middlewareFor($route);
+
+    // After the throw, the route's own gatherMiddleware() silently returns [] — the
+    // gatherer must keep returning the merged fallback.
+    expect($route->gatherMiddleware())->toBe([])
+        ->and($gatherer->middlewareFor($route))->toBe($first)
+        ->and($first)->toContain('auth:sanctum');
+});
+
+it('reads an inherited base-controller constructor through the declaring class', function (): void {
+    $route = RouteFacade::get('/child-middleware', [ConstructorMiddlewareChildController::class, 'index']);
+
+    expect(middlewareGatherer()->middlewareFor($route))->toBe(['auth:api']);
+});
+
+it('notices the degradation once per controller, including unreadable and conditional registrations', function (): void {
+    $indexRoute = RouteFacade::get('/constructor-middleware', [ConstructorMiddlewareFixtureController::class, 'index']);
+    $storeRoute = RouteFacade::post('/constructor-middleware', [ConstructorMiddlewareFixtureController::class, 'store']);
+
+    $logger = recordingLogger();
+    $gatherer = middlewareGatherer($logger);
+    $gatherer->middlewareFor($indexRoute);
+    $gatherer->middlewareFor($storeRoute);
+
+    $messages = array_column($logger->records, 'message');
+
+    expect($messages)->toHaveCount(3)
+        ->and($messages[0])->toContain('could not be instantiated')
+        ->and($messages[1])->toContain('no statically readable name or scope')
+        ->and($messages[2])->toContain('conditionally applied');
+});


### PR DESCRIPTION
## Summary

Detect auth (and other) middleware that a controller applies imperatively in its `__construct` — `$this->middleware('auth:sanctum')->only([...])` — so constructor-middleware controllers feed security-scheme derivation and the implicit 401/403 inference on equal footing with route-declared middleware. Closes #16.

**Stack:** #219 ← #225 ← #230 ← #235 ← #241 ← #247 ← #248 ← #251 ← #253 ← #256 ← this (base: `feat/15-querybuilder-chain-detection`).

## Reality check (changes the plan vs. the issue text)

Probed against the Laravel 12 vendor code and Testbench before designing:

- `Route::gatherMiddleware()` **already** resolves classic constructor middleware — `controllerMiddleware()` instantiates the controller through the container and reads its recorded middleware, honouring `only`/`except`. For instantiable controllers there is **no gap today**.
- The `HasMiddleware` static `middleware()` form (Laravel 11+) is also resolved natively (`staticallyProvidedControllerMiddleware()`, no instantiation, `only:`/`except:` honoured).
- The **actual gap**: when the controller cannot be instantiated in the generation context (unbound constructor dependency, throwing side effects — the BookStack-style constructor), `gatherMiddleware()` throws `BindingResolutionException` and **crashes the whole generation run**. Worse, `gatherMiddleware()` poisons its `computedMiddleware` cache on the way down: a second call silently returns `[]`.

So the static constructor scan is the **fallback** for exactly that case; the native runtime path stays primary (a Tier-0 hit — per the `MethodBodyScanner` contract the body scan only runs on a Tier-0 miss).

## Plan

1. **`Support\Routing\ConstructorMiddlewareScanner`** (`@internal`, scoped) — Tier-1 whitelist over the first 10 top-level statements of `__construct`:
   - `$this->middleware(<literal string | array-of-strings>)`, fluent `->only(<literal>)` / `->except(<literal>)`, and the equivalent `['only' => …]` / `['except' => …]` options-array argument.
   - Literals via `AstLiteralEvaluator` (class constants work); scoping matched against the route's action method.
   - `SkipConditionalContexts`: a conditionally-applied `$this->middleware()` is **not** documented (documenting conditional auth as always-required overstates the contract) — it degrades to a generation-log NOTICE, like any non-literal name/scope.
   - Inheritance: `ReflectionClass::getConstructor()` lands on the declaring class, so a base-controller constructor applying middleware is scanned through its own file. Pinned with a parent-constructor fixture.
2. **`Support\Routing\RouteMiddlewareGatherer`** (`@internal`, scoped) — the single middleware-assembly seam: try `$route->gatherMiddleware()`; on `Throwable`, NOTICE + fall back to route-declared middleware merged (deduped) with the constructor scan. Caches per route, immune to the poisoned-cache footgun.
3. **Consumers** — all four current `gatherMiddleware()` readers switch to the gatherer, so the merged list is uniform everywhere: `SecurityExtractor` (security schemes + scopes), `MiddlewareErrorContributor` (implicit 401/403/429), `InclusionEvaluator` (spec `match.middleware`), `WhyCommand` (display). No consumer logic changes. `#[Security]` / `#[PublicEndpoint]` precedence is untouched (checked in `OperationBuilder::resolveSecurity()` before the extractor runs) and pinned by a feature test.
4. **HasMiddleware decision:** in scope as a *pinning test + docs* only — the framework already resolves it without instantiation; no new code needed. If the static `middleware()` itself throws, the gatherer's fallback catches that too.

### Layering

The scanner emulates Laravel's own `ControllerDispatcher::getMiddleware()` contract — framework semantics, not an app convention — and its primary consumer (`SecurityExtractor`) is plugin-agnostic `Support\` infrastructure that must not depend on `Plugins\Core`. So both new classes live in `Support\Routing`, next to `RouteIntrospector`, following the `Support\MethodBody\SingleReturnArrayLiteralFinder` precedent (scan machinery in Support, plugin-specific whitelists with their plugin consumers). A registry seam (`Contracts\Registry` middleware contributor) would be speculative DI for a single implementation.

## Tests

- Unit: scanner whitelist + scoping matrix (string/array forms, fluent + options-array scoping, non-literal name, non-literal scope, conditional context, parent constructor, no constructor, receiver discipline, unknown chain link).
- Unit: gatherer happy-path passthrough, throwing-constructor fallback + dedup, cache stability.
- `SecurityExtractorTest`: constructor middleware drives the requirement; dedup against route-declared.
- Feature end-to-end: non-instantiable constructor-middleware controller → sanctum security + 401 on in-scope operations only; `only`/`except`; degrade NOTICE; `#[PublicEndpoint]` wins; `HasMiddleware` pinning.

## Docs

Security docs page (constructor middleware + HasMiddleware + degrade conditions), auto-derivation row, CHANGELOG.
