### PR TITLE
test: cover null-coverage path in CoberturaFormatter (#280)

### DIFF
--- a/tests/Unit/Lint/Formatters/CoberturaFormatterTest.php
+++ b/tests/Unit/Lint/Formatters/CoberturaFormatterTest.php
@@ -103,3 +103,16 @@ it('emits a valid empty coverage document when there is nothing to attribute', f
         ->and((int) $xml['lines-valid'])->toBe(0)
         ->and($xml->xpath('//class'))->toBe([]);
 });
+
+it('emits a valid empty coverage document when coverage is null', function (): void {
+    $output = new BufferedOutput();
+    $result = new LintResult(findings: [], level: 1, exitCode: 0, coverage: null);
+
+    new CoberturaFormatter()->render($result, $output);
+
+    $xml = new SimpleXMLElement($output->fetch());
+
+    expect($xml->getName())->toBe('coverage')
+        ->and((int) $xml['lines-valid'])->toBe(0)
+        ->and($xml->xpath('//class'))->toBe([]);
+});


### PR DESCRIPTION
## Summary
Investigating #280 (claimed: `CoberturaFormatter`/`LcovFormatter` fatal-error on null coverage via the `--fix` path).

**This is a verified non-bug.** The issue's premise — "PHP 8 throws `Error: Attempt to read property … on null` before `??` is evaluated" — is incorrect. PHP's null-coalescing operator uses `isset()` semantics over the *entire* access chain, so both:
- `$coverage->generatorVersion ?? 'unknown'` (CoberturaFormatter:65), and
- `foreach ($coverage->perOperation ?? [] as …)` (CoberturaFormatter:100, LcovFormatter:64)

short-circuit safely when `$coverage` itself is `null`. Those are the **only** dereferences of `$coverage` in either formatter, so both already render a well-formed empty document/tracefile on null coverage — no crash.

`LcovFormatterTest` already had a `handles null coverage gracefully` case; `CoberturaFormatterTest` did not. This PR adds the matching Cobertura regression test to lock the behaviour in. No production code changes, no CHANGELOG entry (no behaviour change).

## Verification
- `vendor/bin/pest tests/Unit/Lint/Formatters/CoberturaFormatterTest.php` → 6 passed
- Full suite green, Pint clean, PHPStan clean (per implementer run: 2443 passed)

## Recommendation
Close #280 as **not-a-bug** once this regression test lands.

Refs #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)