### PR TITLE
refactor: extract SpecRouteConfig helper for spec route-URI resolution (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,15 @@ All notable changes to this project are documented here.
 
 ### Changed
 
+- Extracted the spec route-URI convention into a single `Support\Spec\SpecRouteConfig` helper
+  (`@internal`), removing the duplicated `route_uri` / `playground_uri` resolution that previously
+  lived inline in both `SpecRegistry::buildSpec()` and the service provider's route mounting. The
+  two copies are now one source of truth, so the served route path and the generated spec path can
+  no longer drift. Extracting the two copies surfaced a latent divergence on a `null` URI override:
+  `SpecRegistry` already treated `null` (like `false`) as opting the spec out of HTTP serving, but
+  the service provider's `?? default` fall-through still mounted the route. Both now opt out on
+  `null`, matching the documented config convention (`false`/`null` = do not mount). The `false`
+  case and all string overrides are unchanged. (#48)
 - PHP 8.4 modernization pass across `src/`. Every method that implements an interface or overrides
   a parent now carries `#[Override]` (118 added, bringing the codebase to full coverage); `foreach`
   search/existence/universal loops over plain arrays were replaced with `array_find` / `array_any`

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -52,6 +52,7 @@ use Radiergummi\OpenApi\Support\Spec\SpecDefinition;
 use Radiergummi\OpenApi\Support\Spec\SpecMatcher;
 use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
 use Radiergummi\OpenApi\Support\Spec\SpecResolver;
+use Radiergummi\OpenApi\Support\Spec\SpecRouteConfig;
 use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
 use Radiergummi\OpenApi\Support\Visibility\VisibilityResolver;
 use RuntimeException;
@@ -114,8 +115,9 @@ class OpenApiServiceProvider extends ServiceProvider
      * Reads route URIs directly from config rather than resolving {@see SpecRegistry}. The registry
      * would force eager materialisation of `info`/`servers`/`tags` at boot, which is too early —
      * later-booting providers (e.g. example flavors) are still entitled to override those keys
-     * before generation runs. Only the URI fields are needed here, and URI resolution is replicated
-     * inline to keep `default`'s name correct even when an explicit `'specs.default'` entry exists.
+     * before generation runs. Only the URI fields are needed here, resolved via the shared
+     * {@see SpecRouteConfig} so `default`'s name stays correct even when an explicit `'specs.default'`
+     * entry exists.
      *
      * Route names follow the convention:
      *   - default spec: `openapi.spec` / `openapi.playground`
@@ -134,28 +136,20 @@ class OpenApiServiceProvider extends ServiceProvider
         /** @var array<string, array<string, mixed>> $specs */
         $specs = is_array(config('openapi.specs')) ? config('openapi.specs') : [];
 
-        $rootRouteUri = is_string($config['spec']['uri'] ?? null)
-            ? $config['spec']['uri']
-            : 'openapi.yaml';
-        $rootPlaygroundUri = is_string($config['playground']['uri'] ?? null)
-            ? $config['playground']['uri']
-            : 'docs';
+        $routeConfig = new SpecRouteConfig(
+            rootRouteUri: is_string($config['spec']['uri'] ?? null) ? $config['spec']['uri'] : 'openapi.yaml',
+            rootPlaygroundUri: is_string($config['playground']['uri'] ?? null) ? $config['playground']['uri'] : 'docs',
+        );
 
         /** @var array<string, array{route_uri: false|string, playground_uri: false|string}> $entries */
         $entries = [];
 
         foreach (['default' => [], ...$specs] as $name => $overrides) {
             $name = (string) $name;
-            $isDefault = $name === 'default';
-
-            $rawRoute = $overrides['route_uri']
-                ?? ($isDefault ? $rootRouteUri : sprintf('openapi-%s.yaml', $name));
-            $rawPlayground = $overrides['playground_uri']
-                ?? ($isDefault ? $rootPlaygroundUri : sprintf('docs/%s', $name));
 
             $entries[$name] = [
-                'route_uri' => $rawRoute === false ? false : (string) $rawRoute,
-                'playground_uri' => $rawPlayground === false ? false : (string) $rawPlayground,
+                'route_uri' => $routeConfig->routeUri($name, $overrides),
+                'playground_uri' => $routeConfig->playgroundUri($name, $overrides),
             ];
         }
 

--- a/src/Support/Spec/SpecRegistry.php
+++ b/src/Support/Spec/SpecRegistry.php
@@ -142,20 +142,11 @@ final class SpecRegistry
         $match = is_array($overrides['match'] ?? null) ? $overrides['match'] : [];
 
         $outputPath = $this->resolveOutputPath($name, $overrides);
-        $routeUri = $this->resolveOptional(
-            $overrides,
-            'route_uri',
-            $name === 'default'
-                ? $this->rootRouteUri
-                : sprintf('openapi-%s.yaml', $name),
-        );
-        $playgroundUri = $this->resolveOptional(
-            $overrides,
-            'playground_uri',
-            $name === 'default'
-                ? $this->rootPlaygroundUri
-                : sprintf('docs/%s', $name),
-        );
+        $routes = new SpecRouteConfig($this->rootRouteUri, $this->rootPlaygroundUri);
+
+        // `SpecDefinition` opts out of HTTP serving with `null`; the helper signals it with `false`.
+        $routeUri = $routes->routeUri($name, $overrides);
+        $playgroundUri = $routes->playgroundUri($name, $overrides);
 
         return new SpecDefinition(
             name: $name,
@@ -164,8 +155,8 @@ final class SpecRegistry
             tags: $tags,
             match: $match,
             outputPath: $outputPath,
-            routeUri: $routeUri,
-            playgroundUri: $playgroundUri,
+            routeUri: $routeUri === false ? null : $routeUri,
+            playgroundUri: $playgroundUri === false ? null : $playgroundUri,
         );
     }
 
@@ -181,24 +172,6 @@ final class SpecRegistry
         return $name === 'default'
             ? $this->rootOutputPath
             : rtrim($this->storagePath, '/') . sprintf('/openapi-%s.yaml', $name);
-    }
-
-    /**
-     * @param array<string, mixed> $overrides
-     */
-    private function resolveOptional(array $overrides, string $key, string $default): ?string
-    {
-        if (!array_key_exists($key, $overrides)) {
-            return $default;
-        }
-
-        $value = $overrides[$key];
-
-        if ($value === false || $value === null) {
-            return null;
-        }
-
-        return (string) $value;
     }
 
     /**

--- a/src/Support/Spec/SpecRouteConfig.php
+++ b/src/Support/Spec/SpecRouteConfig.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Spec;
+
+use function array_key_exists;
+use function sprintf;
+
+/**
+ * Resolves a single spec's served `route_uri` / `playground_uri` from the root `openapi.routes`
+ * defaults plus that spec's per-spec overrides.
+ *
+ * The convention is shared by two call sites — {@see SpecRegistry::buildSpec()} (which feeds the
+ * resolved URIs into {@see SpecDefinition}) and the service provider's route mounting — so it lives
+ * here as the single source of truth. The rules:
+ *
+ *   - No override key present: the default applies. For the `default` spec that is the root
+ *     `routes.spec.uri` / `routes.playground.uri`; for a named spec it is `openapi-{name}.yaml` /
+ *     `docs/{name}`.
+ *   - An explicit `false` or `null` override opts the spec out of HTTP serving (returns `false`).
+ *   - Any other override value is cast to a string and used verbatim.
+ *
+ * @internal
+ */
+final readonly class SpecRouteConfig
+{
+    public function __construct(
+        private string $rootRouteUri = 'openapi.yaml',
+        private string $rootPlaygroundUri = 'docs',
+    ) {}
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    public function routeUri(string $specName, array $overrides): false|string
+    {
+        return $this->resolve(
+            $overrides,
+            'route_uri',
+            $specName === 'default'
+                ? $this->rootRouteUri
+                : sprintf('openapi-%s.yaml', $specName),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    public function playgroundUri(string $specName, array $overrides): false|string
+    {
+        return $this->resolve(
+            $overrides,
+            'playground_uri',
+            $specName === 'default'
+                ? $this->rootPlaygroundUri
+                : sprintf('docs/%s', $specName),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function resolve(array $overrides, string $key, string $default): false|string
+    {
+        if (!array_key_exists($key, $overrides)) {
+            return $default;
+        }
+
+        $value = $overrides[$key];
+
+        if ($value === false || $value === null) {
+            return false;
+        }
+
+        return (string) $value;
+    }
+}

--- a/tests/Unit/Support/Spec/SpecRouteConfigTest.php
+++ b/tests/Unit/Support/Spec/SpecRouteConfigTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Support\Spec;
+
+use Radiergummi\OpenApi\Support\Spec\SpecRouteConfig;
+
+function makeRouteConfig(): SpecRouteConfig
+{
+    return new SpecRouteConfig(
+        rootRouteUri: 'openapi.yaml',
+        rootPlaygroundUri: 'docs',
+    );
+}
+
+it('applies the root default when the default spec has no override', function (): void {
+    $config = makeRouteConfig();
+
+    expect($config->routeUri('default', []))
+        ->toBe('openapi.yaml')
+        ->and($config->playgroundUri('default', []))->toBe('docs');
+});
+
+it('applies the per-name default when a named spec has no override', function (): void {
+    $config = makeRouteConfig();
+
+    expect($config->routeUri('v1', []))
+        ->toBe('openapi-v1.yaml')
+        ->and($config->playgroundUri('v1', []))->toBe('docs/v1');
+});
+
+it('lets a per-spec override win over the default', function (): void {
+    $config = makeRouteConfig();
+    $overrides = [
+        'route_uri' => 'custom.yaml',
+        'playground_uri' => 'reference/v1',
+    ];
+
+    expect($config->routeUri('v1', $overrides))
+        ->toBe('custom.yaml')
+        ->and($config->playgroundUri('v1', $overrides))->toBe('reference/v1');
+});
+
+it('propagates a `false` override as opt-out for both URIs', function (): void {
+    $config = makeRouteConfig();
+    $overrides = [
+        'route_uri' => false,
+        'playground_uri' => false,
+    ];
+
+    expect($config->routeUri('v1', $overrides))
+        ->toBeFalse()
+        ->and($config->playgroundUri('v1', $overrides))->toBeFalse();
+});
+
+it('treats a `null` override as opt-out for both URIs', function (): void {
+    $config = makeRouteConfig();
+    $overrides = [
+        'route_uri' => null,
+        'playground_uri' => null,
+    ];
+
+    expect($config->routeUri('v1', $overrides))
+        ->toBeFalse()
+        ->and($config->playgroundUri('v1', $overrides))->toBeFalse();
+});


### PR DESCRIPTION
Closes #48.

## Problem

`SpecRegistry::buildSpec()` and `OpenApiServiceProvider::registerRoutes()` each resolved a spec's `route_uri` / `playground_uri` independently (root default → per-spec override → literal `false` disables). Two copies of the same convention → a future change has to be made twice, or the served route path and the generated spec path silently diverge.

## Fix

New `@internal Support\Spec\SpecRouteConfig` helper owns the resolution:
```php
public function routeUri(string $specName, array $overrides): false|string
public function playgroundUri(string $specName, array $overrides): false|string
```
Both call sites delegate to it; no duplicated normalisation remains. `SpecRegistry` maps the helper's `false` → `null` for `SpecDefinition` (which uses `null` = opt out); the provider's `enabled` guards and `default`-spec docblock note are preserved.

## Behaviour change surfaced (and reconciled)

The extraction exposed a **latent divergence**: on a `null` URI override, `SpecRegistry` already opted the spec out of HTTP serving, but the provider's `?? default` fall-through still **mounted** the route. Both now opt out on `null`, matching the documented config convention (`config/openapi.php`: `false`/`null` = do not mount). The `false` case and all string overrides are unchanged; no test pinned the provider's old `null`→mount behaviour. Called out in the CHANGELOG.

## Tests

New `tests/Unit/Support/Spec/SpecRouteConfigTest.php`: root-default, named-spec defaults, override-wins, `false`-propagates, and the `null`-opt-out reconciliation — for both URIs.

## Gates

`composer test` 2447 passed (+5 new, no existing test removed/weakened) · `vendor/bin/pint --test` passed · `composer lint` no errors.

Reviewed by a code-review subagent (the null-override reconciliation independently verified against `main`; PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)