### PR TITLE
feat: read ->noContent() and literal ->setStatusCode() in the response body scan (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here.
 
 ### Added
 
+- The inline `response()->json()` scan now reads `->noContent()` (→ 204, no body) and a literal `->setStatusCode(...)` (class constants included) on the `json()` chain; an explicit literal status beats the resource-action convention, reusing the #240 precedence signal. (#236)
 - **New `query-builder.filter-duplicate` lint rule** (level 3, QueryBuilder plugin). Two or more `#[AllowedFilter]` attributes sharing the same wire name on a single action are silently deduplicated by `OperationBuilder` (last wins, earlier instances are dropped). The new rule flags each duplicated name with one finding, naming the duplicate wire name and the instance count. Mirrors the sibling `query-builder.filter-type-missing` rule's structure. A complementary edit-time PHPStan rule (`openapi.allowedFilter.duplicate`) catches the same collision in the IDE before a spec is generated, resolving the filter name from both the positional and named `name:` forms. See [Linting](docs/linting.md). (Closes #292)
 - **New `resource.response-empty` lint rule** (#255). A response typed to the base
   `Illuminate\Http\Resources\Json\JsonResource` (or an abstract subclass) the generator can't

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -286,8 +286,12 @@ A status you wrote in the call wins over the resource-action
 With no status argument the response documents as `200` and the convention
 still applies, so a conventional `store` with no explicit status is promoted to
 `201`. A literal `204` documents as `204 No Content` without a body schema — the
-runtime strips the body. When several calls match, a **returned** `json()` beats one only
-assigned to a variable; among returned calls, the first wins.
+runtime strips the body — as does a bare `response()->noContent()`. A chained
+`->setStatusCode(<literal>)` — `response()->json([...])->setStatusCode(201)`,
+class constants such as `Response::HTTP_CREATED` included — overrides the status
+and likewise wins over the convention. When several calls match, a **returned**
+`json()` beats one only assigned to a variable; among returned calls, the first
+wins.
 
 Boundaries, by design (no dataflow analysis):
 
@@ -309,11 +313,11 @@ Boundaries, by design (no dataflow analysis):
   conditional success — degrades with a log note instead of evicting the
   operation's success response. (Routing such literals into the error-response
   machinery, like `abort()` calls, is a tracked follow-up.)
-- A chained call that can **change the response's status or body** —
-  `->setStatusCode(201)`, `->setData(...)` — degrades the call rather than
-  documenting the body under the wrong status; header and cookie chains
-  (`->header(...)`, `->withHeaders(...)`, `->cookie(...)`) are harmless and
-  stay matched.
+- A chained **literal** `->setStatusCode(...)` is read as a status override (see
+  above); a non-literal `->setStatusCode(...)` or a body-mutating
+  `->setData(...)` degrades the call rather than documenting the body under the
+  wrong status. Header and cookie chains (`->header(...)`, `->withHeaders(...)`,
+  `->cookie(...)`) are harmless and stay matched.
 - A `response()->json()` call that only runs **conditionally** — inside an `if`
   branch, a ternary or `match` arm, a short-circuit operand, or a closure
   body — is not treated as the canonical success response, nor is one past the

--- a/src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php
+++ b/src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php
@@ -64,9 +64,11 @@ use function strtolower;
  * degrades the whole call — the body must not be documented under a guessed status. Only a 2xx
  * status may claim the primary response: a straight-line non-2xx literal (the guarded-success +
  * terminal-error-fallback idiom) degrades with a note rather than evicting the operation's
- * success response. A 204 documents without content — the runtime strips the body. A chained
- * call that can change the response's status or body (`->setStatusCode(...)`, `->setData(...)`)
- * degrades the call until those chains are read (#236); header/cookie chains stay matched.
+ * success response. A 204 documents without content — the runtime strips the body. A
+ * `response()->noContent()` is matched directly as a 204 with no body. A chained
+ * `->setStatusCode(<literal|class-constant>)` overrides the status (and beats the resource-action
+ * convention); a non-literal `->setStatusCode()` or a body-mutating `->setData()` degrades the
+ * call. Header/cookie chains stay matched.
  *
  * Degradation contract: a matched call that cannot be read statically is skipped with a
  * generation-log note (`#[Response]` is the escape hatch); a method without any matching call is
@@ -94,9 +96,9 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
 
     /**
      * Chained methods (lowercased) that cannot change the response's status or body — header and
-     * cookie decoration only. Any other chained call (`setStatusCode`, `setData`, `setNotModified`,
-     * …) may invalidate what the matched call promised, so it degrades the scan until #236 reads
-     * those chains.
+     * cookie decoration only. A `->setStatusCode(<literal>)` link is read as a status override; any
+     * other chained call (`setData`, `setNotModified`, …) may invalidate what the matched call
+     * promised, so it degrades the scan.
      */
     private const array RESPONSE_PRESERVING_CHAIN_METHODS = ['header', 'withheaders', 'cookie', 'withcookie'];
 
@@ -131,6 +133,15 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             return null;
         }
 
+        $noContentCall = $this->findNoContentCall($statements);
+
+        if ($noContentCall instanceof MethodCall) {
+            return $this->markStatusExplicit(
+                new OA\Response(['response' => '204', 'description' => 'No Content']),
+                true,
+            );
+        }
+
         $call = $this->findJsonCall($statements);
 
         if (!$call instanceof MethodCall) {
@@ -147,11 +158,15 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             return null;
         }
 
-        if (!$this->chainPreservesResponse($statements, $call, $method)) {
+        // The chain walk degrades the call (false), reads a literal `->setStatusCode()` as a status
+        // override (int), or leaves the json() status untouched (null).
+        $chainStatus = $this->statusFromChain($statements, $call, $method);
+
+        if ($chainStatus === false) {
             return null;
         }
 
-        return $this->responseFromCall($call, $method);
+        return $this->responseFromCall($call, $method, $chainStatus);
     }
 
     /**
@@ -217,10 +232,50 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
      */
     private function isJsonHelperCall(Node $node): bool
     {
+        return $this->isFactoryMethodCall($node, 'json');
+    }
+
+    /**
+     * The matched `response()->noContent()` call, preferring a *returned* call over one only
+     * assigned to a variable, mirroring {@see self::findJsonCall}. `noContent()` always documents
+     * a 204 with no body, so its (defaulted) status argument is not read.
+     *
+     * @param list<Stmt> $statements
+     */
+    private function findNoContentCall(array $statements): ?MethodCall
+    {
+        $returnStatements = array_values(
+            array_filter(
+                $statements,
+                static fn(Stmt $statement): bool => $statement instanceof Return_,
+            ),
+        );
+
+        foreach ([$returnStatements, $statements] as $candidates) {
+            $call = $this->statementNodeFinder->findFirst(
+                $candidates,
+                ConditionalContextPolicy::SkipConditionalContexts,
+                fn(Node $node): bool => $this->isFactoryMethodCall($node, 'nocontent'),
+            );
+
+            if ($call instanceof MethodCall) {
+                return $call;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the node is a `->{$method}(...)` call (method name lowercased) on a zero-argument
+     * `response()` helper call.
+     */
+    private function isFactoryMethodCall(Node $node, string $method): bool
+    {
         return $node instanceof MethodCall
             && !$node->isFirstClassCallable()
             && $node->name instanceof Identifier
-            && $node->name->toLowerString() === 'json'
+            && $node->name->toLowerString() === $method
             && $this->isResponseHelperCall($node->var);
     }
 
@@ -270,25 +325,40 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
     // region Response construction
 
     /**
-     * Whether every method call chained onto the matched `json()` leaves the response's status
-     * and body untouched. Walks the chain outwards (`json(...)->header(...)->setStatusCode(...)`)
-     * and degrades with a note on the first non-whitelisted link.
+     * Walks the chain outwards from the matched `json()` (`json(...)->header(...)->setStatusCode(...)`)
+     * to determine the response status. Header/cookie links leave the json() status untouched; a
+     * `->setStatusCode(<literal|class-constant>)` overrides it (returned as an int); any other link
+     * — including a non-literal `->setStatusCode()` or a body-mutating `->setData()` — degrades the
+     * call with a note (returned as false). A chain with no status override returns null.
      *
      * @param list<Stmt> $statements
      */
-    private function chainPreservesResponse(array $statements, MethodCall $call, ReflectionMethod $method): bool
+    private function statusFromChain(array $statements, MethodCall $call, ReflectionMethod $method): int|false|null
     {
         $current = $call;
+        $statusOverride = null;
 
         while (($parent = $this->chainParentOf($statements, $current)) !== null) {
-            $name = $parent->name instanceof Identifier ? $parent->name->toString() : null;
+            $name = $parent->name instanceof Identifier ? strtolower($parent->name->toString()) : null;
 
-            if ($name === null || !in_array(strtolower($name), self::RESPONSE_PRESERVING_CHAIN_METHODS, true)) {
+            if ($name === 'setstatuscode') {
+                $statusOverride = $this->statusFromSetStatusCode($parent, $method);
+
+                if ($statusOverride === false) {
+                    return false;
+                }
+
+                $current = $parent;
+
+                continue;
+            }
+
+            if ($name === null || !in_array($name, self::RESPONSE_PRESERVING_CHAIN_METHODS, true)) {
                 $this->note(
                     $method,
                     sprintf(
                         'is chained into ->%s(), which may change the response status or body',
-                        $name ?? '{dynamic}',
+                        $parent->name instanceof Identifier ? $parent->name->toString() : '{dynamic}',
                     ),
                 );
 
@@ -298,7 +368,39 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             $current = $parent;
         }
 
-        return true;
+        return $statusOverride;
+    }
+
+    /**
+     * The literal status argument of a chained `->setStatusCode(<literal|class-constant>)`, or
+     * false (degrade with a note) when the argument is absent or not statically readable —
+     * documenting the body under a guessed status would be wrong, the same contract the `json()`
+     * status argument follows.
+     */
+    private function statusFromSetStatusCode(MethodCall $call, ReflectionMethod $method): int|false
+    {
+        $arguments = $call->getArgs();
+        $statusArgument = $arguments[0] ?? null;
+
+        if ($statusArgument !== null && !$statusArgument->unpack) {
+            try {
+                $status = AstLiteralEvaluator::evaluate($statusArgument->value);
+            } catch (NonLiteralValueException) {
+                $status = null;
+            }
+
+            if (is_int($status)) {
+                return $status;
+            }
+        }
+
+        $this->note(
+            $method,
+            'is chained into ->setStatusCode() with no statically readable status code, '
+            . 'so the body must not be documented under a guessed status',
+        );
+
+        return false;
     }
 
     /**
@@ -318,7 +420,7 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
         return $parent instanceof MethodCall ? $parent : null;
     }
 
-    private function responseFromCall(MethodCall $call, ReflectionMethod $method): ?OA\Response
+    private function responseFromCall(MethodCall $call, ReflectionMethod $method, int|false|null $chainStatus): ?OA\Response
     {
         $arguments = $call->getArgs();
 
@@ -338,16 +440,22 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             return null;
         }
 
-        $status = $this->resolveStatus($arguments, $method);
+        // A chained `->setStatusCode(<literal>)` is the response's final status — it overrides the
+        // json() status argument. Both pass the same 2xx guard.
+        if ($chainStatus !== null && $chainStatus !== false) {
+            $status = $this->ensureSuccessStatus($chainStatus, $method);
+            $statusIsExplicit = true;
+        } else {
+            $status = $this->resolveStatus($arguments, $method);
+            // A status the author wrote in the call is ground truth, not a default; the resource
+            // convention must defer to it rather than relabel the body (#240). An absent status
+            // argument is the helper's own 200 default, which the convention may still override.
+            $statusIsExplicit = $this->argument($arguments, 'status', self::STATUS_ARGUMENT_POSITION) !== null;
+        }
 
         if ($status === null) {
             return null;
         }
-
-        // A status the author wrote in the call is ground truth, not a default; the resource
-        // convention must defer to it rather than relabel the body (#240). An absent status
-        // argument is the helper's own 200 default, which the convention may still override.
-        $statusIsExplicit = $this->argument($arguments, 'status', self::STATUS_ARGUMENT_POSITION) !== null;
 
         // A 204 must not carry a body — the runtime strips it (`Response::prepare()`), so the
         // literal body is not documented either.
@@ -424,6 +532,17 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             return null;
         }
 
+        return $this->ensureSuccessStatus($status, $method);
+    }
+
+    /**
+     * The status itself when it is a 2xx, or null (refusal, with a note) otherwise. Only a success
+     * status may claim the primary response: a straight-line non-2xx literal (`json([...], 403)`,
+     * or a `->setStatusCode(403)`) is an error response, and taking it as primary would evict the
+     * operation's success response.
+     */
+    private function ensureSuccessStatus(int $status, ReflectionMethod $method): ?int
+    {
         if ($status < 200 || $status > 299) {
             $this->note(
                 $method,

--- a/tests/Fixtures/InlineJsonFixtureController.php
+++ b/tests/Fixtures/InlineJsonFixtureController.php
@@ -63,9 +63,34 @@ class InlineJsonFixtureController extends Controller
         return response()->json(['cached' => true])->header('X-Cache', 'hit');
     }
 
-    public function statusMutatingChain(): JsonResponse
+    public function noContent(): SymfonyResponse
+    {
+        return response()->noContent();
+    }
+
+    public function setStatusCodeLiteral(): JsonResponse
     {
         return response()->json(['created' => true])->setStatusCode(201);
+    }
+
+    public function setStatusCodeConstant(): JsonResponse
+    {
+        return response()->json(['created' => true])->setStatusCode(SymfonyResponse::HTTP_CREATED);
+    }
+
+    public function setStatusCodeDynamic(Request $request): JsonResponse
+    {
+        return response()->json(['created' => true])->setStatusCode($request->integer('status'));
+    }
+
+    public function setStatusCodeNonSuccess(): JsonResponse
+    {
+        return response()->json(['error' => 'nope'])->setStatusCode(403);
+    }
+
+    public function setDataChain(): JsonResponse
+    {
+        return response()->json(['created' => true])->setData(['replaced' => true]);
     }
 
     public function integerKeyedList(): JsonResponse

--- a/tests/Fixtures/ResourceConventionLiteralController.php
+++ b/tests/Fixtures/ResourceConventionLiteralController.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Tests\Fixtures;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 /**
  * Resourceful actions whose body returns a `response()->json([...], <status>)` with an explicit
@@ -20,9 +21,21 @@ class ResourceConventionLiteralController extends Controller
         return response()->json(['id' => 1], 200);
     }
 
+    // POST store → convention says 201, but the chained ->setStatusCode(200) must win.
+    public function storeSetStatusCode(): JsonResponse
+    {
+        return response()->json(['id' => 1])->setStatusCode(200);
+    }
+
     // GET index → convention says 200, but the author wrote 201; the literal must win.
     public function index(): JsonResponse
     {
         return response()->json(['items' => []], 201);
+    }
+
+    // POST store → convention says 201, but ->noContent() must win with 204.
+    public function storeNoContent(): SymfonyResponse
+    {
+        return response()->noContent();
     }
 }

--- a/tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
+++ b/tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
@@ -122,16 +122,74 @@ it('matches a json call wrapped in a further method chain', function (): void {
     expect(inlineJsonSchema($response)['properties'])->toHaveKey('cached');
 });
 
-it('refuses a json call chained into a status-mutating method and logs a note', function (): void {
+it('refuses a json call chained into a body-mutating method and logs a note', function (): void {
     $logger = recordingLogger();
 
     $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
-        inlineJsonActionDescriptor('statusMutatingChain'),
+        inlineJsonActionDescriptor('setDataChain'),
+    );
+
+    expect($response)->toBeNull()
+        ->and($logger->records)->toHaveCount(1)
+        ->and($logger->records[0]['message'])->toContain('setData');
+});
+
+it('reads a literal ->setStatusCode() over the json chain and keeps the body', function (): void {
+    $response = inlineJsonResolver()->resolvePrimaryResponse(inlineJsonActionDescriptor('setStatusCodeLiteral'));
+
+    expect($response)->not->toBeNull()
+        ->and($response->response)->toBe('201')
+        ->and($response->description)->toBe('Created')
+        ->and(inlineJsonSchema($response)['properties'])->toHaveKey('created');
+});
+
+it('resolves a class-constant ->setStatusCode() over the json chain', function (): void {
+    $response = inlineJsonResolver()->resolvePrimaryResponse(inlineJsonActionDescriptor('setStatusCodeConstant'));
+
+    expect($response)->not->toBeNull()
+        ->and($response->response)->toBe('201')
+        ->and(inlineJsonSchema($response)['properties'])->toHaveKey('created');
+});
+
+it('refuses a non-literal ->setStatusCode() and logs a note', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
+        inlineJsonActionDescriptor('setStatusCodeDynamic'),
     );
 
     expect($response)->toBeNull()
         ->and($logger->records)->toHaveCount(1)
         ->and($logger->records[0]['message'])->toContain('setStatusCode');
+});
+
+it('refuses a literal non-2xx ->setStatusCode() and logs a note', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
+        inlineJsonActionDescriptor('setStatusCodeNonSuccess'),
+    );
+
+    expect($response)->toBeNull()
+        ->and($logger->records)->toHaveCount(1)
+        ->and($logger->records[0]['message'])->toContain('non-2xx')
+        ->and($logger->records[0]['message'])->toContain('403');
+});
+
+it('documents a 204 from ->noContent() without a body schema', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(inlineJsonActionDescriptor('noContent'));
+
+    expect($response)->not->toBeNull()
+        ->and($response->response)->toBe('204')
+        ->and($response->description)->toBe('No Content')
+        ->and($logger->records)->toBeEmpty();
+
+    /** @var array<string, mixed> $serialized */
+    $serialized = json_decode(json_encode($response, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($serialized)->not->toHaveKey('content');
 });
 
 it('documents explicit sequential integer keys as a JSON array (AST path)', function (): void {

--- a/tests/Unit/Support/Generator/OperationBuilderConventionStatusTest.php
+++ b/tests/Unit/Support/Generator/OperationBuilderConventionStatusTest.php
@@ -55,6 +55,18 @@ it('keeps a body-scan literal 201 over the index convention (200)', function ():
     expect(resourcePrimaryStatus($op))->toBe('201');
 });
 
+it('keeps a chained ->setStatusCode(200) over the store convention (201)', function (): void {
+    $op = buildResourceOperation('post', '/widgets', ResourceConventionLiteralController::class, 'storeSetStatusCode');
+
+    expect(resourcePrimaryStatus($op))->toBe('200');
+});
+
+it('keeps a ->noContent() 204 over the store convention (201)', function (): void {
+    $op = buildResourceOperation('post', '/widgets', ResourceConventionLiteralController::class, 'storeNoContent');
+
+    expect(resourcePrimaryStatus($op))->toBe('204');
+});
+
 it('still applies the resource convention when the json() call has no explicit status', function (): void {
     $op = buildResourceOperation('post', '/things', ResourceConventionDefaultController::class, 'store');
 


### PR DESCRIPTION
Closes #236

## Problem

PR #235 (#14) shipped the inline `response()->json(...)` body scan but deliberately left out two whitelisted chain shapes:

- `return response()->noContent();` → should document `204` with an empty body.
- `return response()->json($x)->setStatusCode(201);` / `->setStatusCode(Response::HTTP_CREATED)` → should document that status.

It also left a precedence gap: `OperationBuilder::applyConventionStatus()` layered the resource-action convention (`store`→201) over a resolver-produced status, so an explicit literal status that disagreed lost.

## Approach

- **`noContent()`** is matched as a distinct factory shape (`findNoContentCall`, mirroring `findJsonCall`'s returned-over-assigned preference) → `204`, no body.
- **`->setStatusCode(<literal|class-constant>)`** is read through `statusFromChain` (replacing the old boolean `chainPreservesResponse`): a literal status overrides the chain (read via `AstLiteralEvaluator`, so class constants resolve for free), `false` degrades with a NOTICE, `null` means no override. A shared `ensureSuccessStatus` 2xx guard is reused by both the `json()` status argument and the chain override. Header/cookie chains stay matched; `setData` (body mutation) stays out of scope with a NOTICE.
- **Precedence reuses the existing #240 signal** — `markStatusExplicit()` / `OperationBuilder::EXPLICIT_STATUS_EXTENSION` / `takeExplicitStatusMarker()`. Both `noContent()` and the `setStatusCode` override route through it, so convention precedence stays in one place in `OperationBuilder`. No parallel mechanism was added.

## Tests

Resolver-level: `noContent()` → 204 empty, literal/class-constant `setStatusCode` → status + body kept, **literal non-2xx `setStatusCode(403)` degrades with a note**, non-literal `setStatusCode` degrades, `setData` degrades. Convention-precedence: `store` + `setStatusCode(200)` → 200, and **`store` + `noContent()` → 204** (both beat the 201 convention); the transient marker doesn't leak into the serialized document.

## Verification

- `composer test`: 2531 passed (6362 assertions)
- `composer lint` (PHPStan level 8): No errors
- `vendor/bin/pint --test`: passed

## Follow-up

`noContent()`'s status argument is intentionally ignored (scoped to 204 per the issue), so `response()->noContent(200)` still documents 204 — filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)