### PR TITLE
feat: read explicit status argument on response()->noContent($status)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project are documented here.
 - Pipeline order is expressed as a single ordered sequence in `BaselineRegistration::assemble()`; resolver fault isolation is centralized in `ResolverFaultBoundary`; pipeline classes are scoped singletons (Octane-safe).
 - Restructured namespaces to separate the public extension surface (`Contracts\`) from internal infrastructure (`Support\`).
 - `PaginatorKind` recognises Spatie's `PaginatedDataCollection`; `DataResponseResolver` handles union return types as `oneOf`.
+- The inline `response()->noContent($status)` body-scan reads an explicit literal/named 2xx status (body-less); a non-literal or non-2xx status degrades. (#328)
 
 ### Fixed
 - Lint now surfaces top-level and field-level bare `oneOf` / `anyOf` schemas across components, responses, and request bodies. (#294, #318)
@@ -49,7 +50,6 @@ All notable changes to this project are documented here.
 ### Documentation
 - New [Migrating from L5-Swagger](docs/migrating-from-l5-swagger.md) guide and [CI integration](docs/ci.md) guide. (#123, #158)
 - Documentation restructure: the monolithic `docs/usage.md` is split into focused pages, with an accuracy sweep across the set.
-- The inline `response()->noContent($status)` body-scan now reads an explicit literal/named 2xx status argument (a body-less `202` etc.); a non-literal or non-2xx status degrades. (#328)
 
 ## [0.1.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project are documented here.
 ### Documentation
 - New [Migrating from L5-Swagger](docs/migrating-from-l5-swagger.md) guide and [CI integration](docs/ci.md) guide. (#123, #158)
 - Documentation restructure: the monolithic `docs/usage.md` is split into focused pages, with an accuracy sweep across the set.
+- The inline `response()->noContent($status)` body-scan now reads an explicit literal/named 2xx status argument (a body-less `202` etc.); a non-literal or non-2xx status degrades. (#328)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -286,7 +286,10 @@ A status you wrote in the call wins over the resource-action
 With no status argument the response documents as `200` and the convention
 still applies, so a conventional `store` with no explicit status is promoted to
 `201`. A literal `204` documents as `204 No Content` without a body schema — the
-runtime strips the body — as does a bare `response()->noContent()`. A chained
+runtime strips the body — as does a bare `response()->noContent()`. A
+`response()->noContent($status)` is read at its status argument
+(`noContent(202)` / `noContent(status: 202)` documents `202`, still body-less);
+a non-literal or non-2xx status degrades. A chained
 `->setStatusCode(<literal>)` — `response()->json([...])->setStatusCode(201)`,
 class constants such as `Response::HTTP_CREATED` included — overrides the status
 and likewise wins over the convention. When several calls match, a **returned**

--- a/src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php
+++ b/src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php
@@ -320,12 +320,16 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
         return !($namespacedName instanceof Name && function_exists($namespacedName->toString()));
     }
 
-    private function note(ReflectionMethod $method, string $reason): void
-    {
+    private function note(
+        ReflectionMethod $method,
+        string $reason,
+        string $callExpression = 'response()->json()',
+    ): void {
         $this->logger->notice(
             sprintf(
-                'response()->json() call in %s::%s %s; no response inferred. '
+                '%s call in %s::%s %s; no response inferred. '
                 . 'Annotate the action with #[Response] to document it.',
+                $callExpression,
                 $method->getDeclaringClass()->getName(),
                 $method->getName(),
                 $reason,
@@ -438,13 +442,14 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             }
 
             if (is_int($status)) {
-                return $this->ensureSuccessStatus($status, $method) ?? false;
+                return $this->ensureSuccessStatus($status, $method, 'response()->noContent()') ?? false;
             }
         }
 
         $this->note(
             $method,
             'has no statically readable status code, so the body must not be documented under a guessed status',
+            'response()->noContent()',
         );
 
         return false;
@@ -588,8 +593,11 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
      * or a `->setStatusCode(403)`) is an error response, and taking it as primary would evict the
      * operation's success response.
      */
-    private function ensureSuccessStatus(int $status, ReflectionMethod $method): ?int
-    {
+    private function ensureSuccessStatus(
+        int $status,
+        ReflectionMethod $method,
+        string $callExpression = 'response()->json()',
+    ): ?int {
         if ($status < 200 || $status > 299) {
             $this->note(
                 $method,
@@ -597,6 +605,7 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
                     'has a literal non-2xx status (%d) — an error response must not claim the primary response',
                     $status,
                 ),
+                $callExpression,
             );
 
             return null;

--- a/src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php
+++ b/src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php
@@ -65,7 +65,8 @@ use function strtolower;
  * status may claim the primary response: a straight-line non-2xx literal (the guarded-success +
  * terminal-error-fallback idiom) degrades with a note rather than evicting the operation's
  * success response. A 204 documents without content — the runtime strips the body. A
- * `response()->noContent()` is matched directly as a 204 with no body. A chained
+ * `response()->noContent(<status>)` is matched as a body-less response at its status argument
+ * (204 when absent, the literal 2xx otherwise); a non-literal or non-2xx status degrades. A chained
  * `->setStatusCode(<literal|class-constant>)` overrides the status (and beats the resource-action
  * convention); a non-literal `->setStatusCode()` or a body-mutating `->setData()` degrades the
  * call. Header/cookie chains stay matched.
@@ -136,8 +137,20 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
         $noContentCall = $this->findNoContentCall($statements);
 
         if ($noContentCall instanceof MethodCall) {
+            $status = $this->statusFromNoContent($noContentCall, $method);
+
+            if ($status === false) {
+                return null;
+            }
+
+            // Writing noContent() at all is an affirmative choice of a body-less success response,
+            // so it beats the resource-action convention regardless of whether a status argument
+            // is present (absent → 204; literal 2xx → that status). Only the value varies.
             return $this->markStatusExplicit(
-                new OA\Response(['response' => '204', 'description' => 'No Content']),
+                new OA\Response([
+                    'response' => (string) $status,
+                    'description' => HttpFoundationResponse::$statusTexts[$status] ?? sprintf('HTTP %d', $status),
+                ]),
                 true,
             );
         }
@@ -238,7 +251,7 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
     /**
      * The matched `response()->noContent()` call, preferring a *returned* call over one only
      * assigned to a variable, mirroring {@see self::findJsonCall}. `noContent()` always documents
-     * a 204 with no body, so its (defaulted) status argument is not read.
+     * a body-less response; {@see self::statusFromNoContent()} reads its status argument.
      *
      * @param list<Stmt> $statements
      */
@@ -398,6 +411,40 @@ final readonly class InlineJsonResponseResolver implements PrimaryResponseResolv
             $method,
             'is chained into ->setStatusCode() with no statically readable status code, '
             . 'so the body must not be documented under a guessed status',
+        );
+
+        return false;
+    }
+
+    /**
+     * The status of a matched `response()->noContent(<status>)`: 204 when the argument is absent
+     * (the helper default), the literal/class-constant 2xx status when present, or false (degrade
+     * with a note) when the argument is non-literal or a non-2xx literal — the same contract
+     * {@see self::statusFromSetStatusCode()} follows. The response stays body-less either way.
+     */
+    private function statusFromNoContent(MethodCall $call, ReflectionMethod $method): int|false
+    {
+        $statusArgument = $this->argument($call->getArgs(), 'status', 0);
+
+        if ($statusArgument === null) {
+            return 204;
+        }
+
+        if (!$statusArgument->unpack) {
+            try {
+                $status = AstLiteralEvaluator::evaluate($statusArgument->value);
+            } catch (NonLiteralValueException) {
+                $status = null;
+            }
+
+            if (is_int($status)) {
+                return $this->ensureSuccessStatus($status, $method) ?? false;
+            }
+        }
+
+        $this->note(
+            $method,
+            'has no statically readable status code, so the body must not be documented under a guessed status',
         );
 
         return false;

--- a/tests/Fixtures/InlineJsonFixtureController.php
+++ b/tests/Fixtures/InlineJsonFixtureController.php
@@ -68,6 +68,26 @@ class InlineJsonFixtureController extends Controller
         return response()->noContent();
     }
 
+    public function noContentExplicitStatus(): SymfonyResponse
+    {
+        return response()->noContent(200);
+    }
+
+    public function noContentNamedStatus(): SymfonyResponse
+    {
+        return response()->noContent(status: 202);
+    }
+
+    public function noContentDynamicStatus(Request $request): SymfonyResponse
+    {
+        return response()->noContent($request->integer('status'));
+    }
+
+    public function noContentNonSuccess(): SymfonyResponse
+    {
+        return response()->noContent(404);
+    }
+
     public function setStatusCodeLiteral(): JsonResponse
     {
         return response()->json(['created' => true])->setStatusCode(201);

--- a/tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
+++ b/tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
@@ -231,7 +231,8 @@ it('degrades a non-literal status argument on ->noContent() with a note', functi
     );
 
     expect($response)->toBeNull()
-        ->and($logger->records)->toHaveCount(1);
+        ->and($logger->records)->toHaveCount(1)
+        ->and($logger->records[0]['message'])->toContain('response()->noContent()');
 });
 
 it('degrades a non-2xx literal status on ->noContent() with a note', function (): void {
@@ -243,7 +244,8 @@ it('degrades a non-2xx literal status on ->noContent() with a note', function ()
 
     expect($response)->toBeNull()
         ->and($logger->records)->toHaveCount(1)
-        ->and($logger->records[0]['message'])->toContain('404');
+        ->and($logger->records[0]['message'])->toContain('404')
+        ->and($logger->records[0]['message'])->toContain('response()->noContent()');
 });
 
 it('documents explicit sequential integer keys as a JSON array (AST path)', function (): void {

--- a/tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
+++ b/tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
@@ -192,6 +192,60 @@ it('documents a 204 from ->noContent() without a body schema', function (): void
     expect($serialized)->not->toHaveKey('content');
 });
 
+it('reads a literal status argument on ->noContent() and stays body-less', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
+        inlineJsonActionDescriptor('noContentExplicitStatus'),
+    );
+
+    expect($response)->not->toBeNull()
+        ->and($response->response)->toBe('200')
+        ->and($response->description)->toBe('OK')
+        ->and($logger->records)->toBeEmpty();
+
+    /** @var array<string, mixed> $serialized */
+    $serialized = json_decode(json_encode($response, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($serialized)->not->toHaveKey('content');
+});
+
+it('reads a named status argument on ->noContent()', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
+        inlineJsonActionDescriptor('noContentNamedStatus'),
+    );
+
+    expect($response)->not->toBeNull()
+        ->and($response->response)->toBe('202')
+        ->and($response->description)->toBe('Accepted')
+        ->and($logger->records)->toBeEmpty();
+});
+
+it('degrades a non-literal status argument on ->noContent() with a note', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
+        inlineJsonActionDescriptor('noContentDynamicStatus'),
+    );
+
+    expect($response)->toBeNull()
+        ->and($logger->records)->toHaveCount(1);
+});
+
+it('degrades a non-2xx literal status on ->noContent() with a note', function (): void {
+    $logger = recordingLogger();
+
+    $response = inlineJsonResolver($logger)->resolvePrimaryResponse(
+        inlineJsonActionDescriptor('noContentNonSuccess'),
+    );
+
+    expect($response)->toBeNull()
+        ->and($logger->records)->toHaveCount(1)
+        ->and($logger->records[0]['message'])->toContain('404');
+});
+
 it('documents explicit sequential integer keys as a JSON array (AST path)', function (): void {
     $response = inlineJsonResolver()->resolvePrimaryResponse(inlineJsonActionDescriptor('integerKeyedList'));
 


### PR DESCRIPTION
Closes #328

## Tier

**Tier-1** — extends the existing bounded body-scan in `InlineJsonResponseResolver`. It reuses
the `AstLiteralEvaluator` + `ensureSuccessStatus` path the `json(..., status:)` and
`->setStatusCode()` branches already use. No variable tracking, no dataflow. Built at the lowest
tier that captures the idiom.

## Problem

The `noContent()` matcher (added in #236 / PR #327) hard-codes `204` and intentionally ignores
the call's status argument:

```php
return response()->noContent(200);   // documented as 204, not 200
```

`Illuminate\Routing\ResponseFactory::noContent(int $status = 204, array $headers = [])` accepts a
status, and an author writing `noContent(202)` means it. We should read it.

## Approach

The only behaviour to change is the no-content branch in
`InlineJsonResponseResolver::resolvePrimaryResponse()` (currently lines 138-143), which builds a
fixed `204`. Replace the fixed status with a small helper that reads the first positional /
`status:` named argument of the matched `noContent()` call:

- **Absent argument** → `204` (the helper default), explicit-status marker = `false` (still the
  helper default, the resource convention may override it — same rule the `json()` default-200
  branch follows at line 453). The response is `204 No Content`, body-less.
- **Literal / class-constant 2xx** → that status, explicit-status marker = `true` (the author
  wrote it; it must beat the resource-action convention per #240). The response stays **body-less**
  regardless of the status — `noContent()` strips the body, so e.g. `noContent(200)` documents a
  `200` response with no `content`.
- **Non-literal** (`noContent($request->integer('status'))`) → degrade: skip + note, exactly the
  contract `resolveStatus()` / `statusFromSetStatusCode()` already enforce ("no statically
  readable status code").
- **Non-2xx literal** (`noContent(404)`) → degrade via `ensureSuccessStatus()` + its existing
  non-2xx note. An error status must not claim the primary response.

`ensureSuccessStatus()` already returns the status for 2xx and `null` (with a note) otherwise, so
the success-status guard is reused as-is.

### Reusing the helpers

`argument()` resolves by position-or-name but is currently `private` and keyed to the json()
signature constants — it is signature-agnostic, so it can be called directly with
`('status', 0)`. `AstLiteralEvaluator::evaluate()` + `is_int` + `ensureSuccessStatus()` mirror the
`statusFromSetStatusCode()` shape. The new helper is essentially `statusFromSetStatusCode()`'s
structure with a `204` default instead of a degrade-when-absent, returning `int|null` (status, or
`null`/degrade) plus a flag for whether the status was author-written.

Concretely, add a private `statusFromNoContent(MethodCall $call, ReflectionMethod $method): int|false`
that returns the resolved 2xx status (`204` when absent), or `false` to degrade (non-literal or
non-2xx, both already noted by the reused evaluator/`ensureSuccessStatus`). The branch then:

```
$status = $this->statusFromNoContent($noContentCall, $method);
if ($status === false) { return null; }
$explicit = $this->argument($noContentCall->getArgs(), 'status', 0) !== null;
return $this->markStatusExplicit(
    new OA\Response(['response' => (string) $status, 'description' => HttpFoundationResponse::$statusTexts[$status] ?? sprintf('HTTP %d', $status)]),
    $explicit,
);
```

(Argument-spread/`unpack` guard: `noContent(...$args)` is non-literal anyway — the evaluator on a
non-literal-readable arg degrades; an explicit `unpack` check is unnecessary for a single scalar
status arg, matching `statusFromSetStatusCode()` which already guards `unpack`. Mirror that
`unpack` guard for consistency.)

## Files

- **Modify** `src/Plugins/Core/Resolvers/InlineJsonResponseResolver.php`
  - Rework the no-content branch in `resolvePrimaryResponse()` to read the status.
  - Add private `statusFromNoContent()` (modeled on `statusFromSetStatusCode()`).
  - Update the two class-level docblock sentences that assert `noContent()` is "matched directly
    as a 204 ... its (defaulted) status argument is not read" (lines ~68 and ~240-243) to reflect
    that the explicit status is now read.
- **Modify** `tests/Fixtures/InlineJsonFixtureController.php` — add fixtures:
  - `noContentExplicitStatus(): SymfonyResponse` → `return response()->noContent(200);`
  - `noContentNamedStatus(): SymfonyResponse` → `return response()->noContent(status: 202);`
  - `noContentDynamicStatus(Request $request): SymfonyResponse` →
    `return response()->noContent($request->integer('status'));`
  - `noContentNonSuccess(): SymfonyResponse` → `return response()->noContent(404);`
  - (keep the existing `noContent()` → defaults-to-204 fixture as the absent-arg case.)
- **Modify** `tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php` — add the proving
  tests (below). The existing `noContent()`→204 test stays green (regression guard for the default).

## Proving tests (TDD — write first, watch them fail)

In `InlineJsonResponseResolverTest.php`, alongside the existing no-content test:

1. **explicit 2xx is read and is body-less**: `noContentExplicitStatus` →
   `$response->response === '200'`, `description === 'OK'`, serialized has no `content` key,
   logger empty. (This is the headline failing test — currently emits `204`.)
2. **named `status:` argument**: `noContentNamedStatus` → `'202'`, `'Accepted'`, body-less.
3. **non-literal status degrades with a note**: `noContentDynamicStatus` → `null`, one note
   containing "status".
4. **non-2xx literal degrades**: `noContentNonSuccess` → `null`, one note containing "404".
5. **absent argument still defaults to 204** (regression): the existing
   `'documents a 204 from ->noContent() without a body schema'` test already covers this; keep it.

Optionally extend `OperationBuilderConventionStatusTest.php` only if the explicit-status →
convention precedence needs a no-content case; the json() path already covers the #240 marker, and
the unit `markStatusExplicit` flag assertion is sufficient — **skip** unless review asks.

## Verify

```
vendor/bin/pest tests/Unit/Core/Inference/InlineJsonResponseResolverTest.php
composer test            # full suite
vendor/bin/pint --test   # style
composer lint            # PHPStan level 8
```

## Bookkeeping

- **CHANGELOG.md** `[Unreleased]` → `Changed` (or `Added`): one line —
  "Inline response scan: `response()->noContent($status)` now documents an explicit literal 2xx
  status (and `status:` named arg); absent → 204, non-literal/non-2xx degrade per the body-scan
  contract."
- **docs/** — the inline response-scan behaviour is documented in the responses page (the same
  page that covers `response()->json()` body scanning). Add one sentence to the `noContent()`
  note that an explicit literal 2xx status is honored (still body-less). Locate via the existing
  `noContent` mention; if no observable doc covers `noContent()` yet, add the sentence where the
  inline json status argument is described.

## Controversy / merge gate

**Low.** Pure extension of an existing Core-plugin resolver; no `Contracts/**`, no stage-order
change, no new config key, no public-signature change. Reuses established helpers and the existing
degradation + #240 explicit-status contract. Should be an auto-merge candidate once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
