### PR TITLE
chore: autonomous-team post-first-run hardening (fixes, test-gap + docs-writer)

### DIFF
--- a/.claude/skills/autonomous-team/SKILL.md
+++ b/.claude/skills/autonomous-team/SKILL.md
@@ -65,8 +65,9 @@ Anything not covered by a directive falls back to the defaults below.
    and the shared task list; post all durable annotations as GitHub comments."*
 
    Capacity ceiling (spawn up to, never beyond): `planner` ×1, `reviewer` ×2, `coder` ×3,
-   `surveyor` ×1. Scale to the directives — a `"review PR #324"` run only ever needs one
-   `reviewer` (+ a `coder` for findings).
+   `surveyor` ×1, `docs-writer` ×1. Scale to the directives — a `"review PR #324"` run only ever
+   needs one `reviewer` (+ a `coder` for findings); spawn the `docs-writer` only when a docs
+   sub-phase or a `documentation` issue actually arises.
 
    **First-time validation:** before the first real run, confirm the team idle/wake model on this
    runtime with a 2-agent spike — spawn one background teammate, let its turn end, `SendMessage`
@@ -93,8 +94,8 @@ single-active-label / closing-keyword / footer invariants.
 | `finish-pr <pr> [comment]` | lead | squash-merge + delete branch + remove worktree + comment |
 | `start-issue <type> <N> [slug]` | planner | branch off fresh `main`, empty commit, push; echoes branch |
 | `open-pr <N> <title> [body-file]` | planner | open PR with labels/`Closes`/footer/assignee (`PR_DRAFT=1` for draft) |
-| `worktree-add <branch>` | coder | add/reuse a worktree under `.claude/worktrees/`; echoes path |
-| `sync-branch` | coder | from a worktree: fetch + rebase `origin/main` + `composer check` |
+| `worktree-add <branch>` | coder / docs-writer | add/reuse a worktree under `.claude/worktrees/`; echoes path |
+| `sync-branch` | coder / docs-writer | from a worktree: fetch + rebase `origin/main` + `composer check` |
 
 Gates everywhere use **`composer check`** (= `format:check` + `lint` + `test`).
 
@@ -110,14 +111,23 @@ eligible issues remain, and any **volume cap** from the directives is not yet re
    *(If a directive seeded an existing PR at a specific entry phase, skip admission for that item
    and `set-phase` it to that phase instead.)*
 2. **Pick a process tier** for the issue (scale ceremony to the change):
-   - **Full** (default): `planning → plan-review → coding → review → survey → merge`.
-   - **Fast-path** for trivially-scoped work — docs-only, `area:cli`/`area:lint`-only, or an
-     obviously mechanical ≤20-line change: **skip planning + plan-review**, coder implements
-     directly, **one** reviewer pass, **skip survey** (non-generation-affecting), merge. If a
-     fast-pathed change turns out larger or generation-affecting once opened, promote it to Full.
+   - **Full** (default): `planning → plan-review → coding ⇄ review → [docs] → [survey] → merge`.
+   - **Fast-path** for trivially-scoped code — `area:cli`/`area:lint`-only or an obviously
+     mechanical ≤20-line change: **skip planning + plan-review**, coder implements directly, **one**
+     reviewer pass, **skip survey** (non-generation-affecting), merge. Promote to Full if it turns
+     out larger or generation-affecting once opened.
+   - **Docs-path** for a `documentation`-labeled issue: the **`docs-writer` owns it** as the
+     implementer (`planning` via `start-issue`/`open-pr` is fine, or skip straight to `docs`), then
+     **one** reviewer docs-check, **skip survey**, merge.
 3. **Drive phases** as each role reports done: reassign the task and move the phase with
    `bin/set-phase <num> <phase> "<comment>"` (it enforces the single-active-label invariant and
    posts the annotation in one step). The code⇄review loop runs between a `coder` and a `reviewer`.
+   **Docs sub-phase (conditional):** after code review approves, judge the change's documentation
+   impact. If it's **material** — new public surface, authoring attribute, config key, lint rule, or
+   a conceptual change the coder's inline edit didn't fully cover — `set-phase <pr> docs` and hand
+   to the `docs-writer`; when it reports back, route to a `reviewer` for a docs-check, then continue
+   to `[survey]`/merge. If the doc impact is trivial (the coder's inline page edit + the reviewer's
+   docs-gap check sufficed), skip the docs sub-phase.
 4. **Merge or escalate** (below) when a PR reaches the end of its tier.
 5. **Self-feed.** Any agent may `gh issue create` for out-of-scope problems/ideas it finds;
    those become future eligible issues. Never fold them into the current PR.

--- a/.claude/skills/autonomous-team/SKILL.md
+++ b/.claude/skills/autonomous-team/SKILL.md
@@ -89,7 +89,7 @@ single-active-label / closing-keyword / footer invariants.
 | `bootstrap-labels` | lead | idempotently create the `agent:*` labels |
 | `eligible-issues` | lead | issues the team may admit (filters + tier sort) |
 | `resume-scan` | lead | rebuild the in-flight pipeline from GitHub on startup |
-| `set-phase <num> <phase> [comment]` | lead | move phase: enforce one `agent:*` label + post annotation |
+| `set-phase <num> <phase> [comment]` | lead | move phase: enforce one `agent:*` label + post annotation; on a PR, also clears the closed issue's stale label (issue→PR migration) |
 | `finish-pr <pr> [comment]` | lead | squash-merge + delete branch + remove worktree + comment |
 | `start-issue <type> <N> [slug]` | planner | branch off fresh `main`, empty commit, push; echoes branch |
 | `open-pr <N> <title> [body-file]` | planner | open PR with labels/`Closes`/footer/assignee (`PR_DRAFT=1` for draft) |
@@ -144,7 +144,9 @@ Auto-squash-merge **only when ALL hold**:
   - touches `src/Contracts/**` or changes registry/pipeline **stage order** (`area:core`)
   - adds/changes a **config key** or a lint-rule **default severity**
   - changes a **public method signature** or removes a public symbol
-  - diff exceeds **~150 changed lines** (tunable)
+  - the **`src/` diff** exceeds **~150 changed lines** (tunable) — count production code only;
+    tests, fixtures, `docs/`, and `CHANGELOG.md` do **not** count toward the threshold
+    (`gh pr diff <pr> --name-only` + per-file `git diff --numstat`, summing `src/**` only)
 
 On merge: `bin/finish-pr <pr> "<closing comment>"` — squash-merges, deletes the branch (the PR's
 `Closes #N` auto-closes the issue), removes the worktree, prunes, posts the closing annotation.

--- a/.claude/skills/autonomous-team/bin/bootstrap-labels
+++ b/.claude/skills/autonomous-team/bin/bootstrap-labels
@@ -15,3 +15,4 @@ create "agent:coding"      "0e8a16" "Autonomous team: coder is implementing in a
 create "agent:in-review"   "fbca04" "Autonomous team: reviewer is in the adversarial code loop"
 create "agent:survey"      "1d76db" "Autonomous team: surveyor is running the Layer A gate"
 create "agent:needs-human" "b60205" "Autonomous team: escalated — a human decision is required"
+create "human-task"        "d4c5f9" "Not agent-implementable (needs a human, e.g. outreach/permissions) — never admitted"

--- a/.claude/skills/autonomous-team/bin/bootstrap-labels
+++ b/.claude/skills/autonomous-team/bin/bootstrap-labels
@@ -13,6 +13,7 @@ create "agent:planning"    "5319e7" "Autonomous team: planner is drafting the PR
 create "agent:plan-review" "8a63d2" "Autonomous team: reviewer is vetting the plan"
 create "agent:coding"      "0e8a16" "Autonomous team: coder is implementing in a worktree"
 create "agent:in-review"   "fbca04" "Autonomous team: reviewer is in the adversarial code loop"
+create "agent:docs"        "c2e0c6" "Autonomous team: docs-writer is authoring/updating documentation"
 create "agent:survey"      "1d76db" "Autonomous team: surveyor is running the Layer A gate"
 create "agent:needs-human" "b60205" "Autonomous team: escalated — a human decision is required"
 create "human-task"        "d4c5f9" "Not agent-implementable (needs a human, e.g. outreach/permissions) — never admitted"

--- a/.claude/skills/autonomous-team/bin/eligible-issues
+++ b/.claude/skills/autonomous-team/bin/eligible-issues
@@ -5,7 +5,7 @@
 # Output: JSON array of {number,title,labels}.
 set -euo pipefail
 
-EXCLUDE='["blocked","deferred","spec","epic","human-task","agent:planning","agent:plan-review","agent:coding","agent:in-review","agent:survey","agent:needs-human"]'
+EXCLUDE='["blocked","deferred","spec","epic","human-task","agent:planning","agent:plan-review","agent:coding","agent:in-review","agent:docs","agent:survey","agent:needs-human"]'
 
 # Issue numbers already claimed by an open PR (via closing keywords in the PR body).
 CLAIMED=$(gh pr list --state open --limit 200 --json body \

--- a/.claude/skills/autonomous-team/bin/eligible-issues
+++ b/.claude/skills/autonomous-team/bin/eligible-issues
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Emit open issues the team may pick up, lowest-numbered first, tier-0 before tier-1.
-# Excludes: blocked/deferred/spec/epic, anything already in an agent:* phase,
+# Excludes: blocked/deferred/spec/epic/human-task, anything already in an agent:* phase,
 # and any issue already referenced (Closes/Fixes/Resolves #N) by an open PR.
 # Output: JSON array of {number,title,labels}.
 set -euo pipefail
 
-EXCLUDE='["blocked","deferred","spec","epic","agent:planning","agent:plan-review","agent:coding","agent:in-review","agent:survey","agent:needs-human"]'
+EXCLUDE='["blocked","deferred","spec","epic","human-task","agent:planning","agent:plan-review","agent:coding","agent:in-review","agent:survey","agent:needs-human"]'
 
 # Issue numbers already claimed by an open PR (via closing keywords in the PR body).
 CLAIMED=$(gh pr list --state open --limit 200 --json body \

--- a/.claude/skills/autonomous-team/bin/set-phase
+++ b/.claude/skills/autonomous-team/bin/set-phase
@@ -3,11 +3,15 @@
 # (remove any others, add the target) and post the transition comment. Works on both
 # issues and PRs — the GitHub API treats PRs as issues for labels/comments.
 #
+# When <number> is a PR, this also clears stale `agent:*` labels from the issue(s) the PR
+# closes — so the phase locus migrates cleanly from issue → PR once the PR exists, with no
+# double-counting on resume-scan.
+#
 # Usage: set-phase <number> <phase> [comment...]
 #   <phase>  planning | plan-review | coding | in-review | survey | needs-human | clear
 #   comment  optional; posted verbatim as the transition annotation
 #
-# Example: set-phase 236 coding "🤖 **[lead]** plan approved → coding (coder-1)."
+# Example: set-phase 330 plan-review "🤖 **[lead]** plan looks tight → plan-review."
 set -euo pipefail
 
 num="${1:?usage: set-phase <number> <phase> [comment...]}"
@@ -20,10 +24,24 @@ case "$phase" in
   *) echo "error: bad phase '$phase'" >&2; exit 2 ;;
 esac
 
-# Drop every agent:* phase label currently set (ignore 'not present' 404s).
-for label in agent:planning agent:plan-review agent:coding agent:in-review agent:survey agent:needs-human; do
-  gh api -X DELETE "repos/{owner}/{repo}/issues/${num}/labels/${label}" >/dev/null 2>&1 || true
-done
+PHASE_LABELS="agent:planning agent:plan-review agent:coding agent:in-review agent:survey agent:needs-human"
+
+clear_phase_labels() { # <number>
+  local target="$1" label
+  for label in $PHASE_LABELS; do
+    gh api -X DELETE "repos/{owner}/{repo}/issues/${target}/labels/${label}" >/dev/null 2>&1 || true
+  done
+}
+
+# Clear phase labels from the target itself.
+clear_phase_labels "$num"
+
+# If the target is a PR, also clear them from the issue(s) it closes — migrate the locus.
+if gh api "repos/{owner}/{repo}/issues/${num}" --jq '.pull_request // empty' 2>/dev/null | grep -q .; then
+  while read -r linked; do
+    [ -n "$linked" ] && clear_phase_labels "$linked"
+  done < <(gh pr view "$num" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' 2>/dev/null || true)
+fi
 
 # Add the target phase label (unless clearing).
 if [ "$phase" != "clear" ]; then

--- a/.claude/skills/autonomous-team/bin/set-phase
+++ b/.claude/skills/autonomous-team/bin/set-phase
@@ -20,11 +20,11 @@ shift 2 || true
 comment="$*"
 
 case "$phase" in
-  planning|plan-review|coding|in-review|survey|needs-human|clear) ;;
+  planning|plan-review|coding|in-review|docs|survey|needs-human|clear) ;;
   *) echo "error: bad phase '$phase'" >&2; exit 2 ;;
 esac
 
-PHASE_LABELS="agent:planning agent:plan-review agent:coding agent:in-review agent:survey agent:needs-human"
+PHASE_LABELS="agent:planning agent:plan-review agent:coding agent:in-review agent:docs agent:survey agent:needs-human"
 
 clear_phase_labels() { # <number>
   local target="$1" label

--- a/.claude/skills/autonomous-team/reference/state-machine.md
+++ b/.claude/skills/autonomous-team/reference/state-machine.md
@@ -36,7 +36,9 @@ When a role finishes its phase it (a) posts a comment, (b) `SendMessage`s the le
 **lead** moves the label and reassigns the task. Roles do not relabel across phases themselves —
 the lead owns transitions so there is a single writer. The lead transitions with
 `bin/set-phase <num> <phase> "<comment>"`, which removes any other `agent:*` label and posts the
-annotation atomically — keeping the single-active-label invariant intact.
+annotation atomically — keeping the single-active-label invariant intact. Once the PR exists,
+transition the **PR** number: `set-phase` detects a PR and also clears the stale label from the
+issue(s) it closes, so the phase locus migrates issue → PR with no double-count on `resume-scan`.
 
 Issues carrying any of `blocked`, `deferred`, `spec`, `epic`, or `agent:needs-human` are
 **never** picked up.

--- a/.claude/skills/autonomous-team/reference/state-machine.md
+++ b/.claude/skills/autonomous-team/reference/state-machine.md
@@ -7,19 +7,28 @@ last role comment.
 ## Phases
 
 ```
-Full:      planning ─▶ plan-review ─▶ coding ⇄ review ─▶ [survey] ─▶ merge ─▶ done
-           planner     reviewer       coder   reviewer    surveyor    lead
-                                         ▲______│ (≤3 rounds)
+Full:      planning ─▶ plan-review ─▶ coding ⇄ review ─▶ [docs] ─▶ [survey] ─▶ merge ─▶ done
+           planner     reviewer       coder   reviewer  docs-writer surveyor    lead
+                                         ▲______│ (≤3 rounds)  └▶ reviewer docs-check
 
 Fast-path:                              coding ──▶ review ──────────▶ merge ─▶ done
-(docs / area:cli / area:lint /          coder      reviewer (×1)      lead
+(area:cli / area:lint /                 coder      reviewer (×1)      lead
  ≤20-line mechanical)
+
+Docs-path:  [planning] ─▶ docs ──▶ review ──▶ merge ─▶ done
+(documentation issue)   docs-writer  reviewer    lead
 ```
 
 - **`[survey]` is conditional:** run only for generation-affecting areas (`area:core`,
   `area:responses`, `area:params`, `area:requests`, `area:plugins`, `area:security`,
   `area:multi-spec`). Skipped for lint/cli/docs. The lead picks the tier when admitting; a
   fast-pathed item that turns out larger/generation-affecting is promoted to Full.
+- **`[docs]` is conditional:** after code review, the lead inserts a docs sub-phase only when the
+  change has **material** documentation impact (new public surface, authoring attribute, config
+  key, lint rule, or a conceptual change). The `docs-writer` updates the pages on the same branch,
+  then a `reviewer` docs-checks. Trivial doc impact is handled inline by the coder + the reviewer's
+  docs-gap duty — no sub-phase. A `documentation`-labeled issue uses the Docs-path, owned by the
+  `docs-writer`.
 
 ## Label map (one active phase label at a time)
 
@@ -28,9 +37,10 @@ Fast-path:                              coding ──▶ review ─────�
 | planning     | `agent:planning`    | planner    | draft    |
 | plan-review  | `agent:plan-review` | reviewer   | draft    |
 | coding       | `agent:coding`      | coder      | draft    |
-| review       | `agent:in-review`   | reviewer   | ready    |
-| survey       | `agent:survey`      | surveyor   | ready    |
-| escalated    | `agent:needs-human` | (human)    | ready    |
+| review       | `agent:in-review`   | reviewer    | ready    |
+| docs         | `agent:docs`        | docs-writer | ready    |
+| survey       | `agent:survey`      | surveyor    | ready    |
+| escalated    | `agent:needs-human` | (human)     | ready    |
 
 When a role finishes its phase it (a) posts a comment, (b) `SendMessage`s the lead, then the
 **lead** moves the label and reassigns the task. Roles do not relabel across phases themselves —
@@ -40,8 +50,8 @@ annotation atomically — keeping the single-active-label invariant intact. Once
 transition the **PR** number: `set-phase` detects a PR and also clears the stale label from the
 issue(s) it closes, so the phase locus migrates issue → PR with no double-count on `resume-scan`.
 
-Issues carrying any of `blocked`, `deferred`, `spec`, `epic`, or `agent:needs-human` are
-**never** picked up.
+Issues carrying any of `blocked`, `deferred`, `spec`, `epic`, `human-task`, or `agent:needs-human`
+are **never** picked up.
 
 ## Comment protocol (durable annotations)
 

--- a/.claude/skills/autonomous-team/roles/coder.md
+++ b/.claude/skills/autonomous-team/roles/coder.md
@@ -8,9 +8,14 @@ and respond to review findings. Read `../reference/state-machine.md` and the pro
 1. **Worktree.** `path=$(bin/worktree-add <branch>)` — adds (or reuses) a worktree under
    `.claude/worktrees/` for the PR's branch and echoes its path. `cd "$path"` and work only there.
    Never touch `main` or another agent's worktree.
-2. **TDD.** Write the failing test first (per the plan), then the minimal implementation that
-   makes it pass. Match surrounding style. No speculative abstraction — minimum code that solves
+2. **TDD.** Write the failing test(s) first (per the plan), then the minimal implementation that
+   makes them pass. Match surrounding style. No speculative abstraction — minimum code that solves
    the issue; if you write 200 lines and it could be 50, rewrite it.
+   **Cover the edges, not just the happy path:** before implementing, enumerate the branches and
+   boundaries the change introduces — null/empty/union/nullable inputs, error/degrade paths, the
+   default vs. explicit cases — and write a test for each consumer-visible one. The reviewer will
+   actively hunt for uncovered cases, so close them now. Aim for a resilient suite over the public
+   surface; don't pad with tests for trivial private glue (we're not chasing 100%).
 3. **Conventions** (project `CLAUDE.md` + global rules): strict-types header; modern PHP 8.4;
    no abbreviations; concise concrete comments (no issue numbers in code); 100-char soft width;
    `@internal` where apt.

--- a/.claude/skills/autonomous-team/roles/docs-writer.md
+++ b/.claude/skills/autonomous-team/roles/docs-writer.md
@@ -1,0 +1,46 @@
+# Role: docs-writer
+
+You keep the package documentation correct, complete, and readable. You are pulled in two ways:
+
+- **Docs sub-phase of a code PR** — the lead routes a PR to you after code review when the change
+  has **material documentation impact** (new public surface, attribute, config key, or a
+  conceptual change) that the coder's inline edit didn't fully cover. You improve the docs on the
+  **same PR branch**, then it goes back for a reviewer docs-check.
+- **A `documentation`-labeled issue** — you own it end-to-end (you are the implementer): branch,
+  write the docs, review, merge. Treat the issue body as the spec.
+
+Read `../reference/state-machine.md` (comment protocol) and the project `CLAUDE.md`. The docs page
+index is `docs/README.md`; the lint-rule catalog is the hand-maintained block in `docs/linting.md`.
+
+## What good documentation means here
+
+- **Cover the public surface.** Every consumer-facing capability the change introduces or touches —
+  public methods, authoring attributes (`src/Attributes/`), config keys, lint rules, CLI flags —
+  must be discoverable and explained on the right `docs/` page.
+- **Vanilla-first framing.** Lead with plain Laravel usage (typed model + return); show
+  integration stories (Spatie Data, API Resources, etc.) after, grounded in real generated output —
+  not invented snippets. Match the existing docs voice.
+- **Honest, no marketing.** State what the generator does and its boundaries (the tier ladder —
+  "type your returns or annotate them to get response schemas"). Never overclaim. No back-compat /
+  migration framing — the package is pre-1.0 and unpublished.
+- **Keep the index + catalog current.** Add a `docs/README.md` entry for a new page; add the
+  `docs/linting.md` catalog row for a new lint rule (id + summary).
+- **Concrete and concise.** Real examples over prose; short, accurate sentences; 100-char soft
+  width; modern PHP 8.4 in code samples.
+
+## Workflow
+
+1. **Worktree.** `path=$(bin/worktree-add <branch>)`, `cd "$path"`. (For the docs sub-phase, reuse
+   the PR's existing branch; for a docs issue, the planner/`start-issue` flow created the branch.)
+2. Identify every page the change affects (`docs/README.md` is the map). Update or add pages so the
+   public surface is fully covered; update the index/catalog as needed.
+3. Run `composer check` before pushing (docs changes can still trip Pint on code fences / examples,
+   and you must not break the suite). Push.
+4. Post `🤖 **[docs-writer]** <pages updated + what>` on the PR/issue and `SendMessage` the lead;
+   the lead routes it back to a reviewer for the docs-check.
+
+## Scope discipline
+
+Document what this change requires — don't rewrite unrelated pages. If you spot a separate docs
+gap (an existing under-documented feature), `gh issue create` it with the `documentation` label
+rather than expanding the current PR. Never modify `src/` to make docs easier — docs follow code.

--- a/.claude/skills/autonomous-team/roles/planner.md
+++ b/.claude/skills/autonomous-team/roles/planner.md
@@ -29,7 +29,9 @@ Read `../reference/state-machine.md` for the label/comment protocol. Read the pr
   idiom. If only Tier 2 (full dataflow) would solve it, say so: that case is the authoring
   attribute's job, not inference. Flag for escalation.
 - Files to create/modify, named.
-- The test(s) that will prove it (TDD: the failing test comes first).
+- The test(s) that will prove it (TDD: the failing test comes first) — list the edge cases and
+  branches to cover (null/empty/union, error/degrade paths, default vs. explicit), not just the
+  happy path, so coverage of the public surface is planned up front.
 - Observable behaviour changes → which `docs/` page and `CHANGELOG.md [Unreleased]` entry.
 - If it adds a lint rule: the rule ID and the `docs/linting.md` catalog row.
 - Anything that would make this **controversial** to merge (touches `src/Contracts/**`, changes

--- a/.claude/skills/autonomous-team/roles/reviewer.md
+++ b/.claude/skills/autonomous-team/roles/reviewer.md
@@ -28,6 +28,18 @@ Review the pushed diff adversarially. Reject unless **all** hold:
 - **Correctness:** logic is right; edge cases (null/empty/union/nullable, error paths) covered by
   tests. Try to find the input that breaks it.
 - **Tests:** new behaviour has tests that would fail without the change. TDD was followed.
+- **Test-suite gaps (actively hunt — this is a first-class review duty, not a footnote):** don't
+  just confirm the happy path is tested — enumerate the behaviours this change touches and look for
+  what is *left uncovered*. For the changed code, walk every branch, boundary, and error/degrade
+  path and ask "what input would exercise this, and is there a test for it?". Then widen to the
+  **public surface** the change affects (the public methods/attributes/options a package consumer
+  relies on) and flag any consumer-visible behaviour or edge case with no test. A missing but
+  important case is a **finding**, written as a concrete test to add (name the input and expected
+  output), not a vague "add more tests". Optionally consult `composer test:coverage` and inspect
+  the touched files to spot untested branches — but judge by edge-case/public-surface reasoning,
+  **not** a coverage percentage. The goal is a resilient suite covering the public surface and its
+  edges; we are explicitly **not** chasing 100% — don't demand tests for trivial/private glue or
+  unreachable states.
 - **Conventions (project `CLAUDE.md` + global rules):** strict-types header; **modern PHP 8.4**;
   **no abbreviations** in names; **concise, concrete comments** (no restating code, no issue
   numbers in code); **100-char soft line width**; `@internal` on internal-only classes; verbose

--- a/.claude/skills/autonomous-team/roles/reviewer.md
+++ b/.claude/skills/autonomous-team/roles/reviewer.md
@@ -47,8 +47,16 @@ Review the pushed diff adversarially. Reject unless **all** hold:
 - **Boundaries:** `src/Support/` and `src/Contracts/` don't depend on any plugin/third-party
   convention package; nothing config-driven leaks into `src/Plugins/Core/`; no host-app runtime
   mutation.
-- **Bookkeeping:** `CHANGELOG.md [Unreleased]` entry present; affected `docs/` page updated if the
-  change is observable; `docs/linting.md` catalog row added for any new rule.
+- **Bookkeeping:** `CHANGELOG.md [Unreleased]` entry present; `docs/linting.md` catalog row added
+  for any new rule.
+- **Documentation gaps (actively check — like test gaps, a first-class duty):** don't just confirm
+  *a* docs line exists — ask whether the **public surface** this change introduces or alters is
+  properly documented for a consumer: the right `docs/` page updated, the `docs/README.md` index
+  current, examples accurate, the tier/boundary framing honest. If the change has **material** doc
+  impact (new public method, authoring attribute, config key, lint rule, or a conceptual change)
+  that the inline edit under-covers, flag it — the lead will route a **docs sub-phase** to the
+  `docs-writer`. Trivial/observable tweaks the coder handled inline are fine; judge by
+  consumer-visibility, not page count.
 - **No scope creep / no deviation from the agreed plan** (if it deviated, the coder must have
   documented why as a PR comment).
 


### PR DESCRIPTION
Follow-ups to the `autonomous-team` skill (#329), driven by the supervised first run (which took issue #328 → PR #330 cleanly end-to-end) and two further requests from Moritz. Skill-only changes — no `src/`.

## 1 — Fixes surfaced by the #330 run
- **`set-phase` migrates the phase locus issue→PR automatically.** When given a PR, it now also clears the stale `agent:*` label from the issue(s) it closes — no manual two-step, no `resume-scan` double-count. (Had to do this by hand during the run.)
- **`human-task` exclusion.** Added a `human-task` label (created by `bootstrap-labels`, excluded by `eligible-issues`); #328's neighbour #159 — a human-only "email maintainers for permission" task — slipped the filter labelled only `documentation`. #159 tagged.
- **Controversiality threshold counts `src/` only.** The ~150-line auto-merge ceiling no longer counts tests/fixtures/`docs/`/`CHANGELOG.md` (#330 hit 154 with a tiny logic change).

## 2 — Test-suite gap hunting is now a first-class reviewer duty
TDD was already required of coders, but the reviewer only checked that new code *had* tests. Now the reviewer actively walks every branch/boundary/error path and the public surface the change touches, flagging uncovered cases as concrete tests to add. Judged by edge-case/public-surface reasoning, **not** a coverage percentage — explicitly not chasing 100%. Coder enumerates edges up front; planner lists them in the plan.

## 3 — On-demand `docs-writer` role
Per-PR docs stay inline + atomic (coder writes, reviewer gates — now with an active docs-gap duty). New `docs-writer`:
- **owns `documentation`-labeled issues end-to-end** (Docs-path), and
- is pulled in as a conditional **`[docs]` sub-phase** after code review when a PR has *material* doc impact (new public surface / attribute / config key / lint rule / concept), then a reviewer docs-checks.

Trivial doc impact stays with the coder. New `agent:docs` phase/label; state-machine, roster, loop, and helper table updated. The docs-writer brief encodes house style (vanilla-first, honest/no-marketing, no back-compat framing, keep the `docs/README.md` index + `docs/linting.md` catalog current).

## Validation
All `bin/` scripts syntax-check; `set-phase` PR-detection, `human-task` exclusion, and `agent:docs` label creation verified against the live repo. The idle/wake model itself was validated in the first run (a re-engaged teammate kept context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)