### PR TITLE
QueryBuilder chain reader: unwrap fluent modifier calls on value-object constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project are documented here.
 ### Documentation
 - New [Migrating from L5-Swagger](docs/migrating-from-l5-swagger.md) guide and [CI integration](docs/ci.md) guide. (#123, #158)
 - Documentation restructure: the monolithic `docs/usage.md` is split into focused pages, with an accuracy sweep across the set.
+- The query-builder chain reader sees value-object constructors wrapped in fluent modifiers, so `AllowedFilter::exact('healthy')->nullable()` is read as `filter[healthy]` instead of dropped. (#257)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -260,7 +260,11 @@ are read from string literals (class-constant strings included) and from
 Spatie's value-object static constructors (`AllowedFilter::exact(…)`,
 `AllowedSort::field(…)`, `AllowedInclude::relationship(…)`, …) — the first
 argument is the public wire name; internal names and `->defaultSort(…)` are
-server-side detail and not modelled. Both the array and the variadic form
+server-side detail and not modelled. Fluent modifiers on a value-object element
+(`->nullable()`, `->default()`, `->ignore()`, `->delimiter()`,
+`->defaultDirection()`) are walked through — they change server-side behaviour,
+not the wire name, so `AllowedFilter::exact('healthy')->nullable()` still reads
+as `filter[healthy]`. Both the array and the variadic form
 (`allowedSorts('name', 'created_at')`) work, and so does a chain assigned to
 a variable in one expression. A chain-derived filter gets a `string` schema —
 use `#[AllowedFilter]` where a filter needs a type, format, or description.

--- a/src/Plugins/QueryBuilder/Support/QueryBuilderChainReader.php
+++ b/src/Plugins/QueryBuilder/Support/QueryBuilderChainReader.php
@@ -47,9 +47,11 @@ use function ltrim;
  * Allow-list elements resolve from string literals (via {@see AstLiteralEvaluator}, so
  * class-constant strings work too) and from Spatie's value-object static constructors
  * (`AllowedFilter::exact('status')`, `AllowedSort::field('created_at')`, …), whose first
- * argument is always the public wire name. Spatie's variadic form
- * (`allowedSorts('name', 'created_at')`) reads the same way. A non-literal element is dropped
- * and the remaining ones kept; the call is reported as partially unreadable.
+ * argument is always the public wire name. Fluent instance modifiers on such a constructor
+ * (`->nullable()`, `->default()`, `->ignore()`, `->delimiter()`, `->defaultDirection()`) are
+ * walked through — they change server-side semantics, never the wire name. Spatie's variadic
+ * form (`allowedSorts('name', 'created_at')`) reads the same way. A non-literal element is
+ * dropped and the remaining ones kept; the call is reported as partially unreadable.
  *
  * @internal
  */
@@ -290,10 +292,21 @@ final class QueryBuilderChainReader
      */
     private function elementName(Expr $element, string $kind): ?string
     {
-        if ($element instanceof StaticCall) {
-            return $this->valueObjectName($element, $kind);
+        // Spatie's instance modifiers (->nullable(), ->default(), ->ignore(), ->delimiter(),
+        // AllowedSort::...->defaultDirection()) wrap the value-object constructor but never
+        // change the wire name — walk the method-call spine to the underlying constructor,
+        // exactly as the chain receiver is walked in rootsAtBuilder().
+        $root = $element;
+
+        while ($root instanceof MethodCall) {
+            $root = $root->var;
         }
 
+        if ($root instanceof StaticCall) {
+            return $this->valueObjectName($root, $kind);
+        }
+
+        // A bare literal element carries no spine, so evaluate the original node directly.
         try {
             $value = AstLiteralEvaluator::evaluate($element);
         } catch (NonLiteralValueException) {

--- a/tests/Unit/Plugins/QueryBuilder/QueryBuilderParameterResolverTest.php
+++ b/tests/Unit/Plugins/QueryBuilder/QueryBuilderParameterResolverTest.php
@@ -20,6 +20,7 @@ use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
 use Spatie\QueryBuilder\AllowedFilter as SpatieAllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude as SpatieAllowedInclude;
 use Spatie\QueryBuilder\AllowedSort as SpatieAllowedSort;
+use Spatie\QueryBuilder\Enums\SortDirection;
 use Spatie\QueryBuilder\QueryBuilder;
 
 use function array_find;
@@ -150,6 +151,35 @@ class QbChainFixtureController
     {
         return QueryBuilder::for(Author::class)
             ->allowedSorts('name', 'created_at')
+            ->get();
+    }
+
+    public function modifiedValueObjectChain(): mixed
+    {
+        return QueryBuilder::for(Author::class)
+            ->allowedFilters([
+                SpatieAllowedFilter::exact('healthy')->nullable(),
+                SpatieAllowedFilter::exact('q')->default('x')->ignore(null),
+            ])
+            ->allowedSorts([SpatieAllowedSort::field('-created_at')->defaultDirection(SortDirection::Ascending)])
+            ->get();
+    }
+
+    public function mixedModifierAllowListChain(): mixed
+    {
+        return QueryBuilder::for(Author::class)
+            ->allowedFilters([
+                'status',
+                SpatieAllowedFilter::exact('origin'),
+                SpatieAllowedFilter::exact('healthy')->nullable(),
+            ])
+            ->get();
+    }
+
+    public function modifiedImpostorChain(): mixed
+    {
+        return QueryBuilder::for(Author::class)
+            ->allowedFilters(['status', QbImpostorQueryBuilder::for('x')->get()])
             ->get();
     }
 
@@ -351,6 +381,27 @@ it('reads the variadic allow-list form', function (): void {
         ->and($sort->schema->items->enum)->toBe(['name', 'created_at']);
 });
 
+it('reads through fluent modifiers wrapping value-object constructors', function (): void {
+    $descriptor = chainDescriptor(QbChainFixtureController::class, 'modifiedValueObjectChain');
+    $params = makeQueryBuilderParameterResolver()->resolveQueryParameters($descriptor);
+
+    $sort = array_find($params, static fn(OA\Parameter $p): bool => $p->name === 'sort');
+
+    expect(parameterNames($params))->toContain('filter[healthy]')
+        ->and(parameterNames($params))->toContain('filter[q]')
+        ->and($sort)->not->toBeNull()
+        ->and($sort->schema->items->enum)->toBe(['created_at']);
+});
+
+it('keeps literal, bare and modifier-wrapped elements together without a partial drop', function (): void {
+    $logger = recordingLogger();
+    $descriptor = chainDescriptor(QbChainFixtureController::class, 'mixedModifierAllowListChain');
+    $params = makeQueryBuilderParameterResolver($logger)->resolveQueryParameters($descriptor);
+
+    expect(parameterNames($params))->toBe(['filter[status]', 'filter[origin]', 'filter[healthy]'])
+        ->and($logger->records)->toBe([]);
+});
+
 // endregion
 
 // region Graceful degradation
@@ -358,6 +409,16 @@ it('reads the variadic allow-list form', function (): void {
 it('keeps readable elements and drops non-literal ones with a notice', function (): void {
     $logger = recordingLogger();
     $descriptor = chainDescriptor(QbChainFixtureController::class, 'partiallyReadableChain');
+    $params = makeQueryBuilderParameterResolver($logger)->resolveQueryParameters($descriptor);
+
+    expect(parameterNames($params))->toBe(['filter[status]'])
+        ->and(implode("\n", array_map(static fn(array $r): string => $r['message'], $logger->records)))
+        ->toContain('allowedFilters');
+});
+
+it('drops a modifier-wrapped non-Spatie root while keeping the readable element', function (): void {
+    $logger = recordingLogger();
+    $descriptor = chainDescriptor(QbChainFixtureController::class, 'modifiedImpostorChain');
     $params = makeQueryBuilderParameterResolver($logger)->resolveQueryParameters($descriptor);
 
     expect(parameterNames($params))->toBe(['filter[status]'])


### PR DESCRIPTION
## Plan

Closes #257.

### Problem

`QueryBuilderChainReader::elementName()` reads an allow-list element only when the element expression **is** a whitelisted value-object static constructor (`StaticCall`). Spatie's fluent instance modifiers wrap that constructor in a `MethodCall`:

```php
->allowedFilters([
    AllowedFilter::exact('healthy')->nullable(),  // MethodCall(var: StaticCall, name: nullable)
])
```

so the element is seen as non-`StaticCall`, falls through to the literal evaluator, fails, and is dropped (partial-keep + the `request.query.parameters` degrade NOTICE). The wire name is fully determined by the underlying constructor's first argument; the modifier (`->nullable()`, `->default()`, `->ignore()`, `->delimiter()`, `AllowedSort::defaultDirection()`) only changes server-side semantics and can never rename the parameter.

### Tier

**Tier 1, no widening.** This is a pure AST-shape fix inside the existing bounded chain reader — unwrapping a method-call spine to its root expression, exactly the walk `rootsAtBuilder()` already performs on the chain receiver (`QueryBuilderChainReader.php:227`). No method-name whitelist for the modifiers is needed (the name is fixed in the constructor, so any modifier is safe to walk through), no variable tracking, no new statement budget. It stays well inside the Tier-1 envelope.

### Change

One file: `src/Plugins/QueryBuilder/Support/QueryBuilderChainReader.php`.

In `elementName()` (currently `:291`), before the `instanceof StaticCall` check, unwrap any `MethodCall` spine down to its root expression — mirroring `rootsAtBuilder()`:

```php
private function elementName(Expr $element, string $kind): ?string
{
    // Spatie's instance modifiers (->nullable(), ->default(), ->ignore(), ->delimiter(),
    // AllowedSort::...->defaultDirection()) wrap the value-object constructor but never
    // change the wire name — walk the method-call spine to the underlying constructor.
    $root = $element;

    while ($root instanceof MethodCall) {
        $root = $root->var;
    }

    if ($root instanceof StaticCall) {
        return $this->valueObjectName($root, $kind);
    }

    // A bare literal element is read directly (no spine), so evaluate the original node.
    try {
        $value = AstLiteralEvaluator::evaluate($element);
    } catch (NonLiteralValueException) {
        return null;
    }

    return is_string($value) ? $this->normaliseName($value, $kind) : null;
}
```

Note the literal path keeps evaluating `$element` (the original), not `$root`: a string literal is never a `MethodCall`, so `$root === $element` there; using `$root` for the static-call branch and `$element` for the literal branch keeps each branch reading the node it expects.

`valueObjectName()` already enforces the FQCN + constructor whitelist, so a non-Spatie method chain whose root happens to be some other `StaticCall` still returns `null` and is dropped — no false positives.

### Tests (TDD — failing first)

Feature-level, matching the existing pattern in `tests/Feature/Plugins/QueryBuilder/QueryBuilderChainDetectionTest.php` (controller fixture → `generateSpec()` → assert `parameters[].name`). Add fixtures + cases:

1. **Single modifier on a filter constructor** — `AllowedFilter::exact('healthy')->nullable()` yields `filter[healthy]`. (The headline regression from the issue's SpeedtestTracker evidence.)
2. **Chained modifiers** — `AllowedFilter::exact('q')->default('x')->ignore(null)` yields `filter[q]` (spine of length > 1 walked fully).
3. **Sort modifier** — `AllowedSort::field('created_at')->defaultDirection(...)` yields the `created_at` sort, with the `-` normalisation still applied.
4. **Mixed allow-list** — a list combining a plain literal, a bare constructor, and a modifier-wrapped constructor keeps **all three** (no partial-drop NOTICE) — guards the "literal branch still reads `$element`" invariant.
5. **Negative / degrade preserved** — a `MethodCall` rooted at a non-Spatie static call (or a dynamic expression) is still dropped and still triggers the partial-keep behaviour; the existing degrade test for a genuinely non-literal element must stay green.

I'll also confirm the existing `QueryBuilderChainDetectionTest` and `QueryBuilderParameterTest` suites stay green (the bare-constructor and literal paths are unchanged).

### Docs + changelog

- **`docs/plugins.md`** (QueryBuilder value-object paragraph, ~`:260`): the text currently lists the value-object constructors as readable but is silent on instance modifiers. Add a sentence: Spatie's fluent modifiers on a value-object element (`->nullable()`, `->default()`, `->ignore()`, `->delimiter()`, `->defaultDirection()`) are walked through — they change server-side behaviour, not the wire name.
- **`CHANGELOG.md` `[Unreleased]`**: #15's chain-reader bullet already exists. Append a short "Changed"/"Fixed"-style note that chain reading now sees value-object constructors wrapped in fluent modifiers (so `AllowedFilter::exact('x')->nullable()` is documented, not dropped), referencing #257.
- **No lint-rule change**, no config key, no `src/Contracts/**` touch, no stage-order change, no public-signature change.

### Controversy assessment

Low. Single internal `@internal` file, one private method, no public surface, no config, no contract change. The walk is identical in spirit to the already-shipped `rootsAtBuilder()` spine walk. Safe auto-merge candidate once tests + Pint + PHPStan are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)