### PR TITLE
feat(#333): finish multipart/form-data file-upload request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project are documented here.
 - Restructured namespaces to separate the public extension surface (`Contracts\`) from internal infrastructure (`Support\`).
 - `PaginatorKind` recognises Spatie's `PaginatedDataCollection`; `DataResponseResolver` handles union return types as `oneOf`.
 - The inline `response()->noContent($status)` body-scan reads an explicit literal/named 2xx status (body-less); a non-literal or non-2xx status degrades. (#328)
+- A typed `UploadedFile` property on a Spatie `Data` class (transitively, through nested Data classes) emits a `multipart/form-data` body with a `format: binary` field, matching the FormRequest file-rule path; the `multipart.file-without-multipart` lint rule is reframed as a contradiction guard that fires only when a `#[RequestBody]` override forces a non-multipart media type onto a file-carrying payload. (#333)
 
 ### Fixed
 - Lint now surfaces top-level and field-level bare `oneOf` / `anyOf` schemas across components, responses, and request bodies. (#294, #318)

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -445,7 +445,7 @@ is enabled.
 | `fractal.transformer-class-missing` | 1 | A #[FractalResponse] names a transformer class that does not exist. (Fractal plugin.) |
 | `header.invalid-name` | 1 | Header name contains invalid characters. |
 | `link.invalid-operation` | 1 | Link references an operationId that doesn't exist in the document. |
-| `multipart.file-without-multipart` | 1 | Data class has a file property but the request body isn't multipart/form-data—produces an incorrect spec. |
+| `multipart.file-without-multipart` | 1 | Data class carries a file property but a #[RequestBody] override forces a non-multipart body — the spec contradicts the code. |
 | `operation.id-invalid-chars` | 1 | operationId is not a codegen-safe identifier. |
 | `operation.id-missing` | 1 | Operation has no operationId. |
 | `operation.security-missing` | 1 | Route enforces auth middleware but the operation declares no security, implying the endpoint is public. |

--- a/docs/request-bodies.md
+++ b/docs/request-bodies.md
@@ -357,3 +357,35 @@ Built-in Laravel rule classes (`Password`, `File`, `ImageFile`, `Dimensions`,
 `Rule` implementations, is dropped and reported by the `rule.unknown` lint
 rule. Inject constraints for these via a
 [schema transformer](extensions.md#schema-transformer).
+
+## File uploads → `multipart/form-data`
+
+A body that carries a file is detected on both paths and switches the whole
+request body to `multipart/form-data`; the file field becomes
+`type: string, format: binary`.
+
+- **FormRequest / inline validation** — a `file`, `image`, `mimes`,
+  `mimetypes`, `File`, `ImageFile`, or `Dimensions` rule marks the field as a
+  file (see the rule table above).
+- **Spatie `Data` class** — a typed `UploadedFile` property is auto-detected,
+  transitively through nested `Data` classes:
+
+  ```php
+  final class CreateAvatarData extends Data
+  {
+      public function __construct(
+          public string $name,
+          public UploadedFile $avatar,
+      ) {}
+  }
+  ```
+
+  produces a `multipart/form-data` body whose `avatar` field is
+  `{type: string, format: binary}` while `name` stays a plain string.
+
+Because this is automatic, you never declare multipart yourself. The
+`multipart.file-without-multipart` lint rule is therefore a **contradiction
+guard**: it fires only when a `#[RequestBody(mediaType: …)]` override forces a
+non-multipart media type onto an operation whose payload still carries a file —
+a spec that contradicts the code. Drop the override (or stop passing the file
+through that body) to clear it.

--- a/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
+++ b/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
@@ -20,9 +20,11 @@ use Spatie\LaravelData\Data;
 use function sprintf;
 
 /**
- * Reports when a controller method accepts a Data object containing an
- * `UploadedFile` property, but the corresponding OpenAPI operation does not
- * declare a `multipart/form-data` request body.
+ * Contradiction guard: the generator already emits `multipart/form-data` for any Data class that
+ * carries an `UploadedFile` property, so the auto-generated path can never trip this rule. It fires
+ * only when a `#[RequestBody]` override forces a non-multipart media type onto an operation whose
+ * Data object still carries a file — leaving a `format: binary` field under, say, `application/json`,
+ * a spec that contradicts the code.
  *
  * File-property detection is delegated to {@see SchemaFromDataClass::hasFileProperties()},
  * which uses the same TypeInfo-based traversal as schema generation and caches results
@@ -63,13 +65,13 @@ final readonly class MultipartFileWithoutMultipart implements Rule, OperationRul
             ruleId: $this->id(),
             level: $this->level(),
             message: sprintf(
-                '%s::%s() accepts an UploadedFile via a Data object, but %s %s does not declare multipart/form-data',
+                '%s::%s() accepts an UploadedFile via a Data object, but %s %s overrides the body to a non-multipart media type — the file field will not transfer',
                 $operation->descriptor->controller?->getShortName() ?? '(unknown)',
                 $operation->descriptor->method->getName(),
                 $operation->method->forDisplay(),
                 $operation->pathUri,
             ),
-            fixHint: 'Add a multipart/form-data request body to the operation, or use #[RequestBody] with the correct media type.',
+            fixHint: 'Remove the non-multipart #[RequestBody] media-type override, or stop passing the UploadedFile through this Data object.',
         );
     }
 
@@ -108,6 +110,6 @@ final readonly class MultipartFileWithoutMultipart implements Rule, OperationRul
     #[Override]
     public function description(): string
     {
-        return "Data class has a file property but the request body isn't multipart/form-data — produces an incorrect spec.";
+        return 'Data class carries a file property but a #[RequestBody] override forces a non-multipart body — the spec contradicts the code.';
     }
 }

--- a/src/Plugins/SpatieData/Support/SchemaFromDataClass.php
+++ b/src/Plugins/SpatieData/Support/SchemaFromDataClass.php
@@ -582,10 +582,6 @@ final class SchemaFromDataClass implements FilePropertyChecker
             return new OA\Schema([
                 'type' => 'string',
                 'format' => 'binary',
-                'description' => sprintf(
-                    'File upload property `%s` — multipart/form-data bodies are not yet fully modelled.',
-                    $propertyName,
-                ),
             ]);
         }
 

--- a/tests/Feature/Lint/MultipartFileGeneratedBodyTest.php
+++ b/tests/Feature/Lint/MultipartFileGeneratedBodyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Attributes\RequestBody;
+use Radiergummi\OpenApi\Enums\MediaType;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\FileUploadFixtureController;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\FileUploadFixtureData;
+
+uses()->group('openapi', 'lint', 'plugin:spatie-data');
+
+class JsonOverrideFileUploadController
+{
+    #[RequestBody(mediaType: MediaType::Json)]
+    public function upload(FileUploadFixtureData $data): void {}
+}
+
+beforeEach(function (): void {
+    // Prevent Spatie Data from querying the (non-existent) cache DB table when
+    // forgetScopedInstances() causes DataConfig to be re-resolved mid-test.
+    config()->set('data.structure_caching.enabled', false);
+
+    Route::post('lint-fixtures/multipart/upload', [FileUploadFixtureController::class, 'upload'])
+        ->name('lint.multipart.upload');
+    Route::post('lint-fixtures/multipart/json-override', [JsonOverrideFileUploadController::class, 'upload'])
+        ->name('lint.multipart.json-override');
+});
+
+it('does not fire multipart.file-without-multipart for the auto-generated multipart body', function (): void {
+    // The resolver emits multipart/form-data for a file-carrying Data class, so the contradiction
+    // guard must stay silent on the generated path — it fires only on a non-multipart override.
+    $this->artisan('openapi:lint', [
+        '--level' => 1,
+        '--only' => 'multipart.file-without-multipart',
+        '--uri' => 'lint-fixtures/multipart/upload',
+        '--format' => 'json',
+    ])->assertExitCode(0);
+});
+
+it('fires multipart.file-without-multipart when a #[RequestBody] override forces application/json', function (): void {
+    // Constructibility check: #[RequestBody(mediaType: Json)] rewrites the resolver-produced media
+    // type in place, leaving the binary file field under application/json — the spec now
+    // contradicts the code and the contradiction guard must fire.
+    $this->artisan('openapi:lint', [
+        '--level' => 1,
+        '--only' => 'multipart.file-without-multipart',
+        '--uri' => 'lint-fixtures/multipart/json-override',
+        '--format' => 'json',
+    ])->assertExitCode(1);
+});

--- a/tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php
+++ b/tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php
@@ -7,13 +7,28 @@ namespace Radiergummi\OpenApi\Tests\Feature\Plugins\SpatieData;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\FileUploadFixtureData;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\NestedFileUploadFixtureData;
 use Radiergummi\OpenApi\Tests\Fixtures\ScalarOnlyData;
+
+use function ltrim;
+use function str_replace;
 
 uses()->group('openapi', 'plugin:spatie-data');
 
 class DataClassRequestController extends Controller
 {
     public function store(ScalarOnlyData $data): JsonResponse
+    {
+        return new JsonResponse();
+    }
+
+    public function upload(FileUploadFixtureData $data): JsonResponse
+    {
+        return new JsonResponse();
+    }
+
+    public function uploadNested(NestedFileUploadFixtureData $data): JsonResponse
     {
         return new JsonResponse();
     }
@@ -39,3 +54,62 @@ it('registers the Data class as a component schema', function (): void {
 
     expect($spec['components']['schemas'])->toHaveKey('ScalarOnlyData');
 });
+
+// region File uploads — multipart/form-data body
+
+function spatieSchemaNameFromRef(string $ref): string
+{
+    return ltrim(str_replace('#/components/schemas/', '', $ref), '/');
+}
+
+it('emits a multipart/form-data body when a Data class carries an UploadedFile field', function (): void {
+    Route::post('/spatie-data/upload', [DataClassRequestController::class, 'upload']);
+
+    $spec = generateSpec();
+
+    $body = $spec['paths']['/spatie-data/upload']['post']['requestBody'] ?? null;
+
+    expect($body)->not->toBeNull()
+        ->and($body['content'])->toHaveKey('multipart/form-data')
+        ->and($body['content'])->not->toHaveKey('application/json');
+});
+
+it('emits the file field as type=string format=binary while scalars keep their type', function (): void {
+    Route::post('/spatie-data/upload', [DataClassRequestController::class, 'upload']);
+
+    $spec = generateSpec();
+
+    $body       = $spec['paths']['/spatie-data/upload']['post']['requestBody'];
+    $schemaName = spatieSchemaNameFromRef($body['content']['multipart/form-data']['schema']['$ref']);
+    $props      = $spec['components']['schemas'][$schemaName]['properties'];
+
+    expect($props['file']['type'])->toBe('string')
+        ->and($props['file']['format'])->toBe('binary')
+        ->and($props['name']['type'])->toBe('string')
+        ->and($props['name'])->not->toHaveKey('format');
+});
+
+it('emits multipart/form-data when the file lives in a nested Data class', function (): void {
+    Route::post('/spatie-data/upload-nested', [DataClassRequestController::class, 'uploadNested']);
+
+    $spec = generateSpec();
+
+    $body = $spec['paths']['/spatie-data/upload-nested']['post']['requestBody'] ?? null;
+
+    expect($body)->not->toBeNull()
+        ->and($body['content'])->toHaveKey('multipart/form-data')
+        ->and($body['content'])->not->toHaveKey('application/json');
+});
+
+it('keeps the body as application/json for a file-free Data class', function (): void {
+    Route::post('/spatie-data/request', [DataClassRequestController::class, 'store']);
+
+    $spec = generateSpec();
+
+    $body = $spec['paths']['/spatie-data/request']['post']['requestBody'];
+
+    expect($body['content'])->toHaveKey('application/json')
+        ->and($body['content'])->not->toHaveKey('multipart/form-data');
+});
+
+// endregion

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
@@ -98,7 +98,9 @@ it('reports its id and level', function (): void {
         ->and($rule->level())->toBe(1);
 });
 
-it('emits a finding when a file-upload Data class is used without multipart content type', function (): void {
+it('emits a finding when a #[RequestBody] override forces a non-multipart body on a file Data class', function (): void {
+    // The generator always emits multipart for a file-carrying Data class; this models the only
+    // way the body ends up non-multipart — a #[RequestBody] media-type override.
     $descriptor = ActionDescriptorFactory::forControllerMethod(FileUploadFixtureController::class, 'upload', '/upload', ['POST']);
 
     $requestBody = new RequestBodyNode(
@@ -126,7 +128,7 @@ it('emits a finding when a file-upload Data class is used without multipart cont
         ->and($findings[0]->level)->toBe(1)
         ->and($findings[0]->message)->toContain('FileUploadFixtureController')
         ->and($findings[0]->message)->toContain('upload')
-        ->and($findings[0]->message)->toContain('multipart/form-data');
+        ->and($findings[0]->message)->toContain('non-multipart');
 });
 
 it('emits no finding when a file-upload Data class is used with multipart content type', function (): void {


### PR DESCRIPTION
Closes #333

## Summary

Issue #333 asks us to *generate* a `multipart/form-data` request body when a request DTO carries
an `UploadedFile` field, and to retire/soften the `multipart.file-without-multipart` lint rule
once generation exists.

**Investigation finding: generation already ships, on both paths.** The issue's "current state"
is stale (it predates the resolvers wiring this up). Verified directly:

- **SpatieData** — `Plugins/SpatieData/Resolvers/DataClassRequestSchemaResolver.php:54-59` already
  returns `ResolvedSchema(mediaType: MediaType::MultipartFormData)` when
  `SchemaFromDataClass::hasFileProperties()` is true (transitive, cached, nested-aware).
  `SchemaFromDataClass::resolveObjectSchema()` (`:581`) emits `{type: string, format: binary}` for
  an `UploadedFile` property.
- **Core FormRequest** — `Plugins/Core/Resolvers/FormRequestRequestSchemaResolver.php:55-60` does
  the same via `SchemaFromFormRequest::hasFileFields()`; `ValidationRulesToSchema::applyFile()`
  (`:439`) maps `file|image|mimes|mimetypes` (and the `File`/`Dimensions` rule objects) to
  `format: binary` + `isFile`.
- `RequestBodyExtractor::buildRequestBody()` keys `content` by the resolved `MediaType`, so the
  multipart content-type string is already emitted.

So the **feature exists**. This issue is "finishing started work + closing the gaps," exactly as
the issue's own Notes section hedges. Scope is therefore narrow and surgical.

**Tier:** Tier-0. Pure reflection/signature reads (typed `UploadedFile` property; `file`/`image`
validation-rule strings). No body parsing, no dataflow. Nothing here climbs to Tier-1/2.

## What is actually missing

1. **SpatieData has no end-to-end test** that the Data-class path emits a `multipart/form-data`
   body with a binary field. `tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php`
   and `SchemaFromDataClassTest.php` have **zero** file/multipart coverage; the only SpatieData
   file coverage is the *lint-rule* test (`hasFileProperties`), which never asserts the generated
   body. The Core path is well covered (`FormRequestSchemaTest.php:74-118` — file/image/mimes/
   dimensions + multipart + the plain-string-stays-string negative).
2. **Stale, now-false comment** in `SchemaFromDataClass.php:586`: the binary-field description still
   reads *"File upload property `%s` — multipart/form-data bodies are not yet fully modelled."*
   That sentence ships into every generated spec and is no longer true.
3. **Lint rule framing.** `multipart.file-without-multipart` reads the *generated* request-body node
   (`$operation->requestBody?->isMultipart`, rule `:58`). Because the resolvers now always emit
   multipart for a detected file, the **auto-generated path can no longer trip it**. It can only
   fire when a user `#[RequestBody]` attribute overrides the body with a non-multipart media type
   while the underlying DTO carries a file — i.e. exactly the "contradiction guard" the issue says
   it may survive as. So the rule's *behaviour* is already correct; its *self-description and
   message* still frame it as "you forgot to declare multipart," which is misleading now that we
   generate it. Reword (not remove) so it reads as a contradiction guard.
4. **Bookkeeping** — `docs/` + `CHANGELOG.md`. `docs/request-bodies.md` already documents file →
   multipart for both paths (`:24`, `:312-319`); confirm it covers the typed-`UploadedFile`
   Data-class case explicitly and the lint-rule reframing. `docs/linting.md` catalog row (`:448`)
   gets its description updated to match the reworded rule.

## Plan (TDD — failing test first)

### 1. Close the SpatieData generation test gap

`tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php` (add cases; reuse the
existing fixtures `tests/Fixtures/Lint/FileUploadFixtureData.php` (file + scalar) and
`NestedFileUploadFixtureData.php`):

- **Single + mixed:** a Data class with an `UploadedFile` field and scalars → request body has a
  `multipart/form-data` content type; the file property is `{type: string, format: binary}`; the
  scalar property stays its inferred type (mirror of the Core `:115` negative).
- **Nested:** a Data class referencing another Data class that carries the file → top-level body is
  `multipart/form-data` (the resolver keys media type off the *top-level* DTO via the transitive
  `hasFileProperties`).
- **Negative:** a file-free Data class → body stays `application/json` (guards against multipart
  leaking onto non-file DTOs).

These should pass immediately (feature exists) — they are **characterization tests** locking in the
behaviour the issue wants, and the regression guard for the lint reframing. Note in the PR that
they pass on first run by design; that is the correct TDD outcome when the asserted behaviour is
the *target* and the gap was coverage, not code.

### 2. Fix the stale binary-field description

`src/Plugins/SpatieData/Support/SchemaFromDataClass.php:585-588` — replace the "not yet fully
modelled" sentence with an accurate one (e.g. drop the description entirely, or
`'File upload field.'`). Decision to record in PR: prefer **dropping** the synthetic description —
a bare `{type: string, format: binary}` is the conventional OpenAPI file-field shape and needs no
prose; the old text only existed to flag the unfinished state. Update/extend
`SchemaFromDataClassTest.php` if it asserts the old string (grep shows it does not today).

### 3. Reframe the lint rule (soften, do not remove)

`src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php`:

- `description()` (`:109`) and the `Finding` message (`:65`) + `fixHint` (`:72`) reworded from
  "you must declare multipart" to a **contradiction guard**: the body is *not* multipart despite a
  detected file field — which now only happens when a `#[RequestBody]`/override forces a different
  media type, so the spec contradicts the code. fixHint → "Remove the non-multipart `#[RequestBody]`
  override, or make the DTO not carry an `UploadedFile`."
- **Keep id `multipart.file-without-multipart`, level 1, and the `OperationRule` visitor wiring**
  unchanged — the ID is stable and the detection logic is already correct.
- Update `MultipartFileWithoutMultipartTest.php`: the existing "emits finding when file Data used
  without multipart" case (`:101`) now models the *override-contradiction* scenario; adjust its
  setup comment + assertion message to match the reframing. Add/confirm a **regression case**: a
  vanilla file-Data operation with **no** override → the auto-generated body is multipart → rule is
  **silent** (this is the issue's required "no longer fires for the generated case" guard).

Whether the override case is reachable in practice depends on `#[RequestBody]` precedence over the
resolver. **Open question to verify during implementation:** confirm `#[RequestBody]` actually
replaces the resolver-produced body (so a non-multipart override is constructible). If it does
*not* — i.e. the rule is now strictly unreachable — escalate: the honest move is then to **remove**
the rule and its row, not reword it. Flagged below as the controversial point.

### 4. Bookkeeping

- `docs/request-bodies.md` — ensure the typed-`UploadedFile` Data-class → multipart path is stated
  alongside the existing FormRequest rows (`:24`, `:312-319`); note the lint rule is now a
  contradiction guard.
- `docs/linting.md:448` — update the `multipart.file-without-multipart` catalog row description to
  the reworded text.
- `CHANGELOG.md [Unreleased]` — under **Changed** (not Added — the feature already shipped): a line
  noting the `UploadedFile`/file-rule multipart body is documented/finished and the lint rule is
  reframed as a contradiction guard.

## Files

- *Test (new cases):* `tests/Feature/Plugins/SpatieData/DataClassRequestSchemaResolverTest.php`
- *Code:* `src/Plugins/SpatieData/Support/SchemaFromDataClass.php` (description fix),
  `src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php` (reframe)
- *Test (reframe):* `tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php`
- *Docs/bookkeeping:* `docs/request-bodies.md`, `docs/linting.md`, `CHANGELOG.md`

No changes to `src/Contracts/**`, no new config key, no stage-order change, no public-signature
change.

## Verification

- `composer test` green (new SpatieData cases + reworded lint test).
- `vendor/bin/pint --test` clean; `composer lint` (PHPStan L8) clean.
- `docs/linting.md` row matches the live `openapi:lint --list` output for the rule.

## Controversial / escalation flags

- **The lint-rule decision (reword vs. remove)** hinges on whether a non-multipart `#[RequestBody]`
  override over a file-carrying DTO is constructible. If the rule is genuinely unreachable now,
  removing it is the honest call but is a **catalog/behaviour change** a human should sign off — I'll
  surface the verification result as a PR comment before finalizing.
- Everything else is surgical: a test gap, a stale string, and doc/changelog edits. No structural
  or contract surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
