### PR TITLE
feat(#335): add #[CookieParam] authoring attribute (in: cookie)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project are documented here.
 - Default route filters for first-party operational packages (Horizon, Pulse, Nova, Telescope, Ignition, Passport, and the library's own routes via `SkipSelfRoutes`).
 - `openapi:diff:config` command reporting drift between the published config and the package default.
 - String-keyed array/collection properties on Spatie `Data` classes (`array<string, T>`) emit `additionalProperties` (a map) instead of a bare array. (#334)
+- `#[CookieParam]` authoring attribute documenting an `in: cookie` parameter read off the request at runtime. (#335)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -31,6 +31,7 @@ Attach to controller classes or methods.
 | `Example` | method | yes | Named example payload for the request body. |
 | `ResponseExample` | method | yes | Named example for a specific response status. |
 | `Header` | class, method | yes | Document a custom request header parameter on the operation. |
+| `CookieParam` | class, method | yes | Document a cookie parameter read off the request at runtime (`$request->cookie('…')`). Each instance defines one `in: cookie` parameter; the schema type defaults to `string`. |
 | `ResponseHeader` | class, method | yes | Document a custom response header. Set `status:` to scope to a specific response status (defaults to the primary 2xx). |
 | `Security` | class, method | yes | Override the auto-derived scopes. Pass an empty list for "token required, no specific scope". `scheme:` targets a specific scheme name from `openapi.security_schemes` (or one of the Passport-derived defaults); omit for the project default. Stack multiple instances to advertise OR-alternatives (any one set of credentials satisfies the operation). See [Declare custom security schemes](recipes.md#declare-custom-security-schemes). |
 | `PublicEndpoint` | class, method | no | Mark as public (no auth advertised) even if middleware would imply otherwise. |
@@ -47,7 +48,7 @@ Attach to controller classes or methods.
 
 ## Field-enrichment attributes
 
-`FieldAttribute` has four scoped subclasses. Pick the one matching the
+`FieldAttribute` has five scoped subclasses. Pick the one matching the
 target. The wrong scope is caught by `field.attribute-wrong-scope`.
 
 | Attribute | Target | Scope | Notes |
@@ -56,8 +57,9 @@ target. The wrong scope is caught by `field.attribute-wrong-scope`.
 | `ResponseField` | class-constant, property | Response output fields | Place on a response class field constant or property. Supports `readOnly` and `conditional`. `conditional: true` keeps the field in `properties` but removes it from `required`. Use for conditionally-present fields. |
 | `PathParam` | parameter | URI path parameters | Place on a controller action parameter for a route-bound model or scalar segment. Only `description`, `example`, `format`, and `pattern` apply (type is inferred from the binding). |
 | `QueryParam` | class, method | Ad-hoc query parameters | See operation-level table above. |
+| `CookieParam` | class, method | Cookie parameters | See operation-level table above. |
 
-All four subclasses share the same JSON Schema field surface inherited from
+All five subclasses share the same JSON Schema field surface inherited from
 `FieldAttribute`:
 
 `title`, `description`, `example`, `type`, `format`, `items` (array element
@@ -84,8 +86,8 @@ one, and the literal-array form keeps working as an override.
 
 ### Inline description directives
 
-The `description` argument of `#[RequestField]`, `#[QueryParam]`, `#[ResponseField]`, and
-`#[PathParam]` accepts three keyword directives, each on its own line. The `@` prefix is required —
+The `description` argument of `#[RequestField]`, `#[QueryParam]`, `#[CookieParam]`,
+`#[ResponseField]`, and `#[PathParam]` accepts three keyword directives, each on its own line. The `@` prefix is required —
 it keeps directives visibly distinct from prose so a sentence like `Enum: see docs at /enums` is
 not silently parsed as a directive.
 

--- a/src/Attributes/CookieParam.php
+++ b/src/Attributes/CookieParam.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Attributes;
+
+use Attribute;
+use BackedEnum;
+use Radiergummi\OpenApi\Support\Attributes\FieldDefault;
+
+/**
+ * Documents a cookie parameter read off the request at runtime (`$request->cookie('x')`).
+ * Cookies are never typed in the action signature, so this attribute supplies the name and the
+ * documented shape that reflection cannot recover. Repeatable; method-level wins over class-level
+ * on `name` collision.
+ *
+ * ```php
+ * #[CookieParam('session', description: 'Opaque session token.')]
+ * #[CookieParam('theme', enum: Theme::class)]
+ * ```
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final readonly class CookieParam extends FieldAttribute
+{
+    /**
+     * @param non-empty-string                                                             $name
+     * @param null|non-empty-string                                                        $title
+     * @param null|non-empty-string                                                        $description
+     * @param null|OpenApiPrimitiveType                                                    $type
+     * @param null|non-empty-string                                                        $format
+     * @param null|array<int, BackedEnum|int|string>|class-string<BackedEnum>|FieldDefault $enum        Allowed values,
+     *                                                                                                  or a backed-enum
+     *                                                                                                  class-string; renders as a
+     *                                                                                                  dropdown.
+     * @param null|int<0, max>                                                             $minLength
+     * @param null|int<0, max>                                                             $maxLength
+     * @param null|non-empty-string                                                        $pattern
+     * @param null|int<0, max>                                                             $minItems
+     * @param null|int<0, max>                                                             $maxItems
+     */
+    public function __construct(
+        public string $name,
+        public bool $required = false,
+        public bool $deprecated = false,
+        ?string $title = null,
+        ?string $description = null,
+        mixed $example = FieldDefault::Unset,
+        ?string $type = null,
+        ?string $format = null,
+        ?string $items = null,
+        ?bool $nullable = null,
+        mixed $default = null,
+        array|string|FieldDefault|null $enum = FieldDefault::Unset,
+        int|float|null $minimum = null,
+        int|float|null $maximum = null,
+        int|float|null $exclusiveMinimum = null,
+        int|float|null $exclusiveMaximum = null,
+        int|float|null $multipleOf = null,
+        ?int $minLength = null,
+        ?int $maxLength = null,
+        ?string $pattern = null,
+        ?int $minItems = null,
+        ?int $maxItems = null,
+        ?bool $uniqueItems = null,
+    ) {
+        parent::__construct(
+            title: $title,
+            description: $description,
+            example: $example,
+            type: $type,
+            format: $format,
+            items: $items,
+            nullable: $nullable,
+            default: $default,
+            enum: $enum,
+            minimum: $minimum,
+            maximum: $maximum,
+            exclusiveMinimum: $exclusiveMinimum,
+            exclusiveMaximum: $exclusiveMaximum,
+            multipleOf: $multipleOf,
+            minLength: $minLength,
+            maxLength: $maxLength,
+            pattern: $pattern,
+            minItems: $minItems,
+            maxItems: $maxItems,
+            uniqueItems: $uniqueItems,
+        );
+    }
+}

--- a/src/Support/Generator/OperationBuilder.php
+++ b/src/Support/Generator/OperationBuilder.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 use Radiergummi\OpenApi\Attributes\BaseExample as BaseExampleAttribute;
+use Radiergummi\OpenApi\Attributes\CookieParam as CookieParamAttribute;
 use Radiergummi\OpenApi\Attributes\Deprecated as DeprecatedAttribute;
 use Radiergummi\OpenApi\Attributes\Description as DescriptionAttribute;
 use Radiergummi\OpenApi\Attributes\Example as ExampleAttribute;
@@ -163,6 +164,7 @@ final readonly class OperationBuilder
 
         $security = $this->resolveSecurity($action);
         $headerParams = $this->readHeaderAttributes($action);
+        $cookieParams = $this->readCookieAttributes($action);
         $requestBody = $this->bodyExtractor->extractFromMethod($action);
         $requestBody = $this->applyRequestBodyOverride($action, $requestBody);
         $this->applyRequestExamples($action, $requestBody);
@@ -263,7 +265,7 @@ final readonly class OperationBuilder
             summary: $summary ?: null,
             description: $description ?: null,
             tags: $this->mergeTags($baseTags, $additionalTags),
-            parameters: [...$pathParams, ...$queryParams, ...$headerParams],
+            parameters: [...$pathParams, ...$queryParams, ...$headerParams, ...$cookieParams],
             security: $security,
             responses: $responses,
             requestBody: $requestBody,
@@ -365,6 +367,29 @@ final readonly class OperationBuilder
         }
 
         return array_values(array_map($this->buildHeaderParameter(...), $byName));
+    }
+
+    /**
+     * Method-level entries win on name collision; declaration order is otherwise preserved.
+     *
+     * @return list<OA\Parameter>
+     */
+    private function readCookieAttributes(ActionDescriptor $descriptor): array
+    {
+        /** @var array<string, CookieParamAttribute> $byName */
+        $byName = [];
+
+        foreach (
+            [
+                ...$descriptor->controllerAttributes(CookieParamAttribute::class),
+                ...$descriptor->actionAttributes(CookieParamAttribute::class),
+            ] as $attribute
+        ) {
+            $instance = $attribute->newInstance();
+            $byName[$instance->name] = $instance;
+        }
+
+        return array_values(array_map($this->buildCookieParameter(...), $byName));
     }
 
     /**
@@ -1006,6 +1031,30 @@ final readonly class OperationBuilder
 
         if ($header->deprecated !== null) {
             $props['deprecated'] = $header->deprecated;
+        }
+
+        return new OA\Parameter($props);
+    }
+
+    private function buildCookieParameter(CookieParamAttribute $cookie): OA\Parameter
+    {
+        $schema = $cookie->descriptor()->toSchema();
+
+        // Cookies are string-valued on the wire; default the schema type when the author left it
+        // unset and it could not be inferred from an enum.
+        if ($schema->type === Generator::UNDEFINED) {
+            $schema->type = 'string';
+        }
+
+        $props = [
+            'name' => $cookie->name,
+            'in' => 'cookie',
+            'required' => $cookie->required,
+            'schema' => $schema,
+        ];
+
+        if ($cookie->deprecated) {
+            $props['deprecated'] = true;
         }
 
         return new OA\Parameter($props);

--- a/tests/Feature/CookieParamTest.php
+++ b/tests/Feature/CookieParamTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Tests\Fixtures\CookieParamFixtureController;
+
+uses()->group('openapi');
+
+beforeEach(function (): void {
+    Route::get('/oa-fixture/cookie/simple', [CookieParamFixtureController::class, 'simpleAction']);
+    Route::get('/oa-fixture/cookie/required', [CookieParamFixtureController::class, 'requiredAction']);
+    Route::get('/oa-fixture/cookie/enum', [CookieParamFixtureController::class, 'enumAction']);
+    Route::get('/oa-fixture/cookie/described', [CookieParamFixtureController::class, 'describedAction']);
+    Route::get('/oa-fixture/cookie/multiple', [CookieParamFixtureController::class, 'multipleAction']);
+    Route::get('/oa-fixture/cookie/override', [CookieParamFixtureController::class, 'overrideAction']);
+
+    $this->spec = generateSpec();
+});
+
+/**
+ * @param array<int, array<string, mixed>> $parameters
+ *
+ * @return array<string, array<string, mixed>>
+ */
+function cookieParameters(array $parameters): array
+{
+    return array_column(
+        array_filter(
+            $parameters,
+            static fn(array $p): bool => ($p['in'] ?? null) === 'cookie',
+        ),
+        null,
+        'name',
+    );
+}
+
+it('emits a single optional, string-typed cookie parameter', function (): void {
+    $cookies = cookieParameters($this->spec['paths']['/oa-fixture/cookie/simple']['get']['parameters'] ?? []);
+
+    expect($cookies)->toHaveKey('session')
+        ->and($cookies['session']['in'])->toBe('cookie')
+        ->and($cookies['session']['required'])->toBeFalse()
+        ->and($cookies['session']['schema']['type'])->toBe('string');
+});
+
+it('honors required and an explicit type', function (): void {
+    $cookies = cookieParameters($this->spec['paths']['/oa-fixture/cookie/required']['get']['parameters'] ?? []);
+
+    expect($cookies['uid']['required'])->toBeTrue()
+        ->and($cookies['uid']['schema']['type'])->toBe('integer');
+});
+
+it('forwards a backed-enum class-string into schema.enum', function (): void {
+    $cookies = cookieParameters($this->spec['paths']['/oa-fixture/cookie/enum']['get']['parameters'] ?? []);
+
+    expect($cookies['theme']['schema']['enum'])->toBe(['active', 'archived', 'draft'])
+        ->and($cookies['theme']['schema']['type'])->toBe('string');
+});
+
+it('forwards description and example', function (): void {
+    $cookies = cookieParameters($this->spec['paths']['/oa-fixture/cookie/described']['get']['parameters'] ?? []);
+
+    expect($cookies['locale']['schema']['description'])->toBe('Preferred UI locale.')
+        ->and($cookies['locale']['schema']['example'])->toBe('en-US');
+});
+
+it('emits one entry per cookie, declaration order preserved', function (): void {
+    // The class-level `tracking` cookie precedes the two method-level entries; assert the
+    // method-level pair keeps its declaration order.
+    $names = array_column(
+        array_filter(
+            $this->spec['paths']['/oa-fixture/cookie/multiple']['get']['parameters'] ?? [],
+            static fn(array $p): bool => ($p['in'] ?? null) === 'cookie',
+        ),
+        'name',
+    );
+
+    $cookies = cookieParameters($this->spec['paths']['/oa-fixture/cookie/multiple']['get']['parameters'] ?? []);
+
+    expect(array_values(array_intersect($names, ['first', 'second'])))->toBe(['first', 'second'])
+        ->and($cookies['second']['required'])->toBeTrue()
+        ->and($cookies['first']['required'])->toBeFalse();
+});
+
+it('lets a method-level cookie override the class-level entry of the same name', function (): void {
+    $cookies = cookieParameters($this->spec['paths']['/oa-fixture/cookie/override']['get']['parameters'] ?? []);
+
+    // Class-level `tracking` is optional; the method-level one wins and is required.
+    expect($cookies)->toHaveCount(1)
+        ->and($cookies['tracking']['required'])->toBeTrue();
+});
+
+it('never guesses cookies when the action carries no #[CookieParam]', function (): void {
+    Route::get('/oa-fixture/cookie/bare', static fn(): array => []);
+
+    $cookies = cookieParameters(
+        generateSpec()['paths']['/oa-fixture/cookie/bare']['get']['parameters'] ?? [],
+    );
+
+    expect($cookies)->toBe([]);
+});

--- a/tests/Fixtures/CookieParamFixtureController.php
+++ b/tests/Fixtures/CookieParamFixtureController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures;
+
+use Illuminate\Routing\Controller;
+use Radiergummi\OpenApi\Attributes\CookieParam;
+
+/**
+ * Test fixture — exercises `#[CookieParam]` across the surface mirrored from `#[QueryParam]`.
+ *
+ * Routes are wired up in {@see \Radiergummi\OpenApi\Tests\Feature\CookieParamTest}'s `beforeEach`.
+ */
+#[CookieParam('tracking', description: 'Anonymous tracking identifier.')]
+class CookieParamFixtureController extends Controller
+{
+    /** A single optional, string-typed cookie with no extra surface. */
+    #[CookieParam('session')]
+    public function simpleAction(): array
+    {
+        return [];
+    }
+
+    /** Required, integer-typed cookie. */
+    #[CookieParam('uid', type: 'integer', required: true)]
+    public function requiredAction(): array
+    {
+        return [];
+    }
+
+    /** Cookie constrained to a backed-enum's cases. */
+    #[CookieParam('theme', enum: StatusFixtureEnum::class)]
+    public function enumAction(): array
+    {
+        return [];
+    }
+
+    /** Cookie carrying a human description and an example. */
+    #[CookieParam('locale', description: 'Preferred UI locale.', example: 'en-US')]
+    public function describedAction(): array
+    {
+        return [];
+    }
+
+    /** Two cookies on one action, declaration order preserved. */
+    #[CookieParam('first')]
+    #[CookieParam('second', required: true)]
+    public function multipleAction(): array
+    {
+        return [];
+    }
+
+    /** Method-level entry overrides the class-level `tracking` cookie on name collision. */
+    #[CookieParam('tracking', required: true)]
+    public function overrideAction(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Closes #335

## Summary

Add a `#[CookieParam]` authoring attribute — the `in: cookie` sibling of the existing parameter
family — so an action can document a cookie parameter that Laravel only ever reads at runtime
(`$request->cookie('x')`).

**Tier: 2 → attribute (healthy escape hatch).** Cookies are read via untyped runtime calls; deriving
them is Tier-2 dataflow, which the library refuses. Per the inference ladder, "where only Tier 2
would close a case, that case is the authoring attribute's job." This attribute supplies something
the code genuinely cannot express (the cookie name + its documented shape), so it is a *healthy*
attribute, not a smell. **No inference, no config, no Contracts change.**

## How the existing parameter family actually works (verified)

`OA\Parameter` entries are assembled in `OperationBuilder::buildOperation()` and spread together at
`src/Support/Generator/OperationBuilder.php:266`:

```php
parameters: [...$pathParams, ...$queryParams, ...$headerParams],
```

The three sources differ in mechanism:

- **`$pathParams`** — `UriParametersExtractor` (route URI + `#[PathParam]` on the *parameter*).
- **`$queryParams`** — `QueryParameterResolver` plugins (Core reads `#[QueryParam]`); `#[QueryParam]`
  extends `FieldAttribute`, is repeatable on method/class, and emits `in: 'query'`.
- **`$headerParams`** — `readHeaderAttributes()` (`:352-368`) collects `#[Header]` from controller +
  action (method wins on name), each built into an `OA\Parameter` with `in: 'header'` by
  `buildHeaderParameter()` (`:984-1012`). `#[Header]` is a **standalone** attribute (NOT a
  `FieldAttribute` subclass), repeatable on `TARGET_CLASS|TARGET_METHOD|TARGET_FUNCTION`.

**Cookie params are action/controller-scoped, name-keyed, repeatable — structurally identical to
`#[Header]`, not to the property-level `FieldAttribute` machinery.** That distinction drives the one
design decision below.

## Design decision to confirm — base class: `Header`-style vs. `FieldAttribute` subclass

The issue specifies "a concrete subclass of `FieldAttribute`." But the emission path that fits a
cookie parameter is the **`#[Header]` path**, and `#[Header]` is deliberately *not* a `FieldAttribute`
subclass. The fork:

- **Option A — mirror `#[Header]` (standalone attribute) — RECOMMENDED.** Smallest, most consistent
  with the actual `in:`-parameter mechanism. `FieldAttribute` and its lint family
  (`AbstractFieldRule` at `src/Lint/Rules/AbstractFieldRule.php:83`) scan `FieldAttribute` instances
  **on payload-class properties** — the action-level header/cookie parameters do *not* flow through
  that machinery today, so subclassing `FieldAttribute` would buy no lint coverage and would mismatch
  how `#[Header]` (the true sibling) is modelled. A cookie parameter's surface is the same as a
  header's (name, type, format, example, required, deprecated, description) — so the constructor is a
  near-verbatim copy of `Header.php`.
- **Option B — subclass `FieldAttribute` (as the issue literally says), mirroring `#[QueryParam]`.**
  Gives the full JSON-Schema surface (enum, min/max, pattern, …) and matches the issue text. But it
  introduces an action-level `FieldAttribute` whose constraints are *not* read by the
  property-scoped field-lint rules, so the richer surface is partly inert unless `buildCookieParameter`
  forwards it explicitly — more code, and a subtle inconsistency with `#[Header]`.

**Recommendation: Option A** (mirror `#[Header]`), because cookies and headers are the same kind of
opaque scalar request input and consistency with the existing `in:`-sibling is the surgical win.
This *deviates from the issue's literal "FieldAttribute subclass" wording*, so per the workflow it's
recorded here and will be posted as a PR comment; **flagged for the lead/maintainer to confirm**
before the coder commits. If the maintainer prefers Option B, the plan's file list is unchanged —
only `CookieParam.php`'s parent and `buildCookieParameter()`'s field-forwarding grow.

The rest of this plan is written for Option A and notes Option B deltas inline.

## Plan (TDD — failing tests first)

### 1. Tests first — `tests/Feature/.../CookieParamTest.php`

(Place beside the existing header/param feature tests — confirm location during impl; likely
`tests/Feature/` next to the `#[Header]` coverage. Reuse a fixture controller pattern.)

- `#[CookieParam('session')]` on an action → operation `parameters[]` has one entry with
  `in: cookie`, `name: session`, `required: false` default, `schema.type: string` default.
- **Required + typed:** `#[CookieParam('uid', type: 'integer', required: true)]` → `required: true`,
  `schema.type: integer`.
- **Enum (string-backed enum class or value list):** forwarded into `schema.enum` (Option A: only if
  we forward enum; if mirroring `#[Header]` exactly, `#[Header]` has no enum — so **scope cookie's
  surface to exactly `#[Header]`'s**: name, type, format, example, required, deprecated, description.
  Drop the issue's "enum" bullet unless Option B is chosen. Note in PR.)
- **Description + example:** forwarded to `description` / `schema.example`.
- **Multiple cookie params on one action** → two `in: cookie` entries, declaration order preserved.
- **Method-over-class precedence on name collision** (mirror `readHeaderAttributes` semantics).
- **Negative:** an action with no `#[CookieParam]` → zero `in: cookie` parameters (we never guess
  cookies — the whole point of the Tier-2→attribute decision).

### 2. Attribute — `src/Attributes/CookieParam.php` (new)

Near-verbatim copy of `src/Attributes/Header.php`: `final readonly class CookieParam`, target
`TARGET_CLASS | TARGET_METHOD | TARGET_FUNCTION | IS_REPEATABLE`, constructor
`(string $name, ?string $description, string $type = 'string', ?string $format, mixed $example,
bool $required = false, ?bool $deprecated)`. Docblock states it documents a cookie read at runtime.
*(Option B: extend `FieldAttribute` and mirror `QueryParam`'s constructor instead.)*

### 3. Assembly — `src/Support/Generator/OperationBuilder.php`

- Add `readCookieAttributes(ActionDescriptor)` mirroring `readHeaderAttributes()` (`:352-368`):
  collect controller + action `CookieParam` attributes, last-wins by name.
- Add `buildCookieParameter(CookieParam)` mirroring `buildHeaderParameter()` (`:984-1012`) but with
  `'in' => 'cookie'`.
- Assign `$cookieParams = $this->readCookieAttributes($action);` and extend the spread at `:266`:
  `parameters: [...$pathParams, ...$queryParams, ...$headerParams, ...$cookieParams]`.
- Add the `use` import for the new attribute.

### 4. Bookkeeping

- `docs/attributes.md` — add `#[CookieParam]` to the parameter-family section, alongside
  `#[QueryParam]` / `#[Header]` / `#[PathParam]`, with a short example.
- `docs/README.md` — update the index only if a new section anchor is added (likely just a row in the
  existing attributes section — no new page).
- `CHANGELOG.md [Unreleased]` — under **Added**: `#[CookieParam]` authoring attribute (`in: cookie`).

## Out of scope (explicitly)

- **No lint rule.** `#[Header]` has `HeaderInvalidName`/duplicate guards; the issue does not ask for a
  cookie-name lint rule and none is needed for a first cut. If a `CookieParamDuplicate` is later
  wanted it mirrors `QueryParamDuplicate` — note as a possible follow-up, do not build now.
- **No inference / no `$request->cookie()` scan** — that is the refused Tier-2 the attribute exists
  to replace.

## Files

- *New:* `src/Attributes/CookieParam.php`
- *Modified:* `src/Support/Generator/OperationBuilder.php` (read + build + spread + import)
- *New test:* `tests/Feature/.../CookieParamTest.php` (+ fixture controller)
- *Docs:* `docs/attributes.md`, `docs/README.md` (index, if needed), `CHANGELOG.md`

No `src/Contracts/**` change, no config key, no stage-order change, no public-signature change.

## Verification

- `composer test` green (new cookie cases + negative).
- `vendor/bin/pint --test` clean; `composer lint` (PHPStan L8) clean.
- Generated `OA\Parameter` with `in: cookie` validates on both swagger-php 5.8 and 6.x (it's a stock
  OAS parameter location — no unmodeled-keyword risk).

## Controversial / escalation flags

1. **Base-class choice (Option A vs. B)** — the recommendation (mirror `#[Header]`, standalone)
   deviates from the issue's literal "subclass of `FieldAttribute`" wording. Surgical and consistent
   with the real `in:`-parameter path, but it's a documented deviation → **maintainer confirm.** Will
   be posted as a PR comment.
2. **Surface scope** — Option A scopes cookie's fields to exactly `#[Header]`'s set (no enum/min/max);
   the issue's tests mention `enum`. If the richer surface is wanted, that's Option B. Tied to (1).

Both are design-shape questions, not implementation risk; no public surface or contract is touched
either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)