### PR TITLE
chore(skill): make autonomous-team open-pr helper portable on bash 3.2

### DIFF
--- a/.claude/skills/autonomous-team/bin/open-pr
+++ b/.claude/skills/autonomous-team/bin/open-pr
@@ -38,15 +38,13 @@ fi
 
 # Mirror the issue's durable labels onto the PR: keep kind/area/tier/plugin-candidate,
 # drop planning-only labels that should never travel to a PR.
-mapfile -t labels < <(
+label_args=()
+while IFS= read -r label; do
+  [ -n "$label" ] && label_args+=(--label "$label")
+done < <(
   gh issue view "$issue" --json labels --jq '.labels[].name' \
     | grep -viE '^(spec|epic|blocked|deferred|agent:)' || true
 )
-
-label_args=()
-for label in "${labels[@]}"; do
-  [ -n "$label" ] && label_args+=(--label "$label")
-done
 
 draft_args=()
 [ "${PR_DRAFT:-0}" = "1" ] && draft_args+=(--draft)


### PR DESCRIPTION
Replaces `mapfile` (bash 4+) with a portable `while read` loop in `.claude/skills/autonomous-team/bin/open-pr` so the helper runs on macOS's system bash 3.2. Pure tooling fix; no package code, no behaviour change.

Surfaced by the autonomous-team planner when `bin/open-pr` failed with `mapfile: command not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)