### PR TITLE
feat(#345): field-level `additionalProperties:` override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented here.
 - String-keyed array/collection properties on Spatie `Data` classes (`array<string, T>`) emit `additionalProperties` (a map) instead of a bare array. (#334)
 - `#[CookieParam]` authoring attribute documenting an `in: cookie` parameter read off the request at runtime. (#335)
 - `x:` vendor-extension passthrough on the field attributes (`#[ResponseField]`, `#[RequestField]`, `#[QueryParam]`, `#[PathParam]`, `#[CookieParam]`): attach `x-*` specification extensions to a field's schema, co-located with the field (the field-level analogue of `openapi.overrides`). (#336)
+- `additionalProperties:` override on the field attributes (`#[ResponseField]`, `#[RequestField]`, `#[QueryParam]`, `#[PathParam]`): set a field's map behaviour to a bool or a typed value schema; applied last, it wins over inferred `array<string, T>` map values. (#345)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -55,7 +55,7 @@ target. The wrong scope is caught by `field.attribute-wrong-scope`.
 |---|---|---|---|
 | `RequestField` | property, parameter, class-constant | Request-body input fields | Place on a Spatie Data class property / promoted constructor parameter, or on a `FormRequest` field constant. Supports `writeOnly` and `default`. No `readOnly` (a request field is never read-only). |
 | `ResponseField` | class-constant, property | Response output fields | Place on a response class field constant or property. Supports `readOnly` and `conditional`. `conditional: true` keeps the field in `properties` but removes it from `required`. Use for conditionally-present fields. |
-| `PathParam` | parameter | URI path parameters | Place on a controller action parameter for a route-bound model or scalar segment. Only `description`, `example`, `format`, `pattern`, and `x` apply (type is inferred from the binding). |
+| `PathParam` | parameter | URI path parameters | Place on a controller action parameter for a route-bound model or scalar segment. Only `description`, `example`, `format`, `pattern`, `x`, and `additionalProperties` apply (type is inferred from the binding). |
 | `QueryParam` | class, method | Ad-hoc query parameters | See operation-level table above. |
 | `CookieParam` | class, method | Cookie parameters | See operation-level table above. |
 
@@ -66,9 +66,9 @@ All five subclasses share the same JSON Schema field surface inherited from
 type), `default`, `nullable`, `enum`, `minimum` / `maximum`,
 `exclusiveMinimum` / `exclusiveMaximum`, `multipleOf`, `minLength` /
 `maxLength`, `pattern`, `minItems` / `maxItems`, `uniqueItems`, `readOnly`,
-`writeOnly`, `x` (where applicable to the scope — e.g. `RequestField` has no
-`readOnly`, `PathParam` only `description` / `example` / `format` / `pattern` /
-`x`).
+`writeOnly`, `x`, `additionalProperties` (where applicable to the scope — e.g.
+`RequestField` has no `readOnly`, `PathParam` only `description` / `example` /
+`format` / `pattern` / `x` / `additionalProperties`).
 
 ### Vendor extensions (`x-*`)
 
@@ -90,6 +90,28 @@ This is the field-level analogue of the `openapi.overrides` config key: use the
 attribute when the extension is **co-located with the field and should travel
 with refactors**; use `openapi.overrides` for **document-level** `x-*` targeted
 at code you can't or won't annotate (third-party routes, generated controllers).
+
+### `additionalProperties` override
+
+The `additionalProperties:` argument overrides the schema's open/closed map
+behaviour. Pass a bool, or a type string wrapped into a nested value schema
+(mirroring `items:`):
+
+```php
+#[ResponseField(additionalProperties: false)]    // forbid extra keys
+#[ResponseField(additionalProperties: 'string')] // values are strings → {type: string}
+```
+
+It **wins over inference**: a property typed `array<string, Foo>` is otherwise
+inferred to `additionalProperties: {$ref: Foo}` (the [map inference](auto-derivation.md)),
+and the attribute — applied last — replaces that inferred value. Leave the
+argument off (`null`) to keep the inferred map untouched; `additionalProperties:
+false` is distinct from unset and emits a closed map.
+
+A free-form `schema:` knob is intentionally **not** offered: every keyword
+`OA\Schema` models as a scalar is already an individually-overridable field
+argument, and composition keywords (`oneOf`/`allOf`/…) belong to the class-level
+schema-body escape hatch, not a field knob.
 
 ### Enum from a backed-enum class-string
 

--- a/src/Attributes/FieldAttribute.php
+++ b/src/Attributes/FieldAttribute.php
@@ -39,38 +39,45 @@ abstract readonly class FieldAttribute
      * @param null|non-empty-string                                                        $description
      * @param null|class-string|OpenApiPrimitiveType                                       $type
      * @param null|non-empty-string                                                        $format
-     * @param null|array<int, BackedEnum|int|string>|class-string<BackedEnum>|FieldDefault $enum        A list of
-     *                                                                                                  allowed values,
-     *                                                                                                  or a
-     *                                                                                                  backed-enum
-     *                                                                                                  class-string
-     *                                                                                                  resolved to its
-     *                                                                                                  cases.
+     * @param null|array<int, BackedEnum|int|string>|class-string<BackedEnum>|FieldDefault $enum                 A list of
+     *                                                                                                           allowed values,
+     *                                                                                                           or a
+     *                                                                                                           backed-enum
+     *                                                                                                           class-string
+     *                                                                                                           resolved to its
+     *                                                                                                           cases.
      * @param null|int<0, max>                                                             $minLength
      * @param null|int<0, max>                                                             $maxLength
      * @param null|non-empty-string                                                        $pattern
      * @param null|int<0, max>                                                             $minItems
      * @param null|int<0, max>                                                             $maxItems
-     * @param bool                                                                         $conditional When true, the
-     *                                                                                                  field is kept
-     *                                                                                                  in
-     *                                                                                                  `properties`
-     *                                                                                                  but removed
-     *                                                                                                  from `required`
-     *                                                                                                  — used by
-     *                                                                                                  response fields
-     *                                                                                                  emitted via
-     *                                                                                                  `$this->when()`
-     *                                                                                                  /
-     *                                                                                                  `$this->whenLoaded()`.
-     * @param null|array<string, mixed>                                                    $x           Vendor extensions
-     *                                                                                                  (`x-*`); keys are
-     *                                                                                                  written with the
-     *                                                                                                  `x-` prefix and
-     *                                                                                                  emitted verbatim,
-     *                                                                                                  matching the
-     *                                                                                                  `openapi.overrides`
-     *                                                                                                  contract.
+     * @param bool                                                                         $conditional          When true, the
+     *                                                                                                           field is kept
+     *                                                                                                           in
+     *                                                                                                           `properties`
+     *                                                                                                           but removed
+     *                                                                                                           from `required`
+     *                                                                                                           — used by
+     *                                                                                                           response fields
+     *                                                                                                           emitted via
+     *                                                                                                           `$this->when()`
+     *                                                                                                           /
+     *                                                                                                           `$this->whenLoaded()`.
+     * @param null|array<string, mixed>                                                    $x                    Vendor extensions
+     *                                                                                                           (`x-*`); keys are
+     *                                                                                                           written with the
+     *                                                                                                           `x-` prefix and
+     *                                                                                                           emitted verbatim,
+     *                                                                                                           matching the
+     *                                                                                                           `openapi.overrides`
+     *                                                                                                           contract.
+     * @param null|bool|string                                                             $additionalProperties Map-value
+     *                                                                                                           override: `true`/
+     *                                                                                                           `false`, or a type
+     *                                                                                                           string wrapped into
+     *                                                                                                           a nested value
+     *                                                                                                           schema. Wins over
+     *                                                                                                           inferred map values.
      *
      * @throws InvalidArgumentException When `$enum` is a string that is not a backed-enum class-string.
      */
@@ -99,6 +106,7 @@ abstract readonly class FieldAttribute
         public ?bool $writeOnly = null,
         public bool $conditional = false,
         public ?array $x = null,
+        public bool|string|null $additionalProperties = null,
     ) {
         // A backed-enum class-string is resolved to its cases here, so every downstream reader
         // (descriptor, lint rules) sees a uniform value list rather than a bare class name.
@@ -191,6 +199,7 @@ abstract readonly class FieldAttribute
             readOnly: $this->readOnly,
             writeOnly: $this->writeOnly,
             x: $this->x,
+            additionalProperties: $this->additionalProperties,
         );
     }
 }

--- a/src/Attributes/PathParam.php
+++ b/src/Attributes/PathParam.php
@@ -28,7 +28,8 @@ final readonly class PathParam extends FieldAttribute
      * @param null|non-empty-string     $description
      * @param null|non-empty-string     $format
      * @param null|non-empty-string     $pattern
-     * @param null|array<string, mixed> $x           Vendor extensions (`x-*`).
+     * @param null|array<string, mixed> $x                    Vendor extensions (`x-*`).
+     * @param null|bool|string          $additionalProperties Map-value override.
      */
     public function __construct(
         ?string $description = null,
@@ -36,6 +37,7 @@ final readonly class PathParam extends FieldAttribute
         ?string $format = null,
         ?string $pattern = null,
         ?array $x = null,
+        bool|string|null $additionalProperties = null,
     ) {
         parent::__construct(
             description: $description,
@@ -43,6 +45,7 @@ final readonly class PathParam extends FieldAttribute
             format: $format,
             pattern: $pattern,
             x: $x,
+            additionalProperties: $additionalProperties,
         );
     }
 }

--- a/src/Attributes/QueryParam.php
+++ b/src/Attributes/QueryParam.php
@@ -27,16 +27,17 @@ final readonly class QueryParam extends FieldAttribute
      * @param null|non-empty-string                                                        $description
      * @param null|OpenApiPrimitiveType                                                    $type
      * @param null|non-empty-string                                                        $format
-     * @param null|array<int, BackedEnum|int|string>|class-string<BackedEnum>|FieldDefault $enum        Allowed values,
-     *                                                                                                  or a backed-enum
-     *                                                                                                  class-string; renders as a
-     *                                                                                                  dropdown.
+     * @param null|array<int, BackedEnum|int|string>|class-string<BackedEnum>|FieldDefault $enum                 Allowed values,
+     *                                                                                                           or a backed-enum
+     *                                                                                                           class-string; renders as a
+     *                                                                                                           dropdown.
      * @param null|int<0, max>                                                             $minLength
      * @param null|int<0, max>                                                             $maxLength
      * @param null|non-empty-string                                                        $pattern
      * @param null|int<0, max>                                                             $minItems
      * @param null|int<0, max>                                                             $maxItems
-     * @param null|array<string, mixed>                                                    $x           Vendor extensions (`x-*`).
+     * @param null|array<string, mixed>                                                    $x                    Vendor extensions (`x-*`).
+     * @param null|bool|string                                                             $additionalProperties Map-value override.
      */
     public function __construct(
         public string $name,
@@ -63,6 +64,7 @@ final readonly class QueryParam extends FieldAttribute
         ?int $maxItems = null,
         ?bool $uniqueItems = null,
         ?array $x = null,
+        bool|string|null $additionalProperties = null,
     ) {
         parent::__construct(
             title: $title,
@@ -86,6 +88,7 @@ final readonly class QueryParam extends FieldAttribute
             maxItems: $maxItems,
             uniqueItems: $uniqueItems,
             x: $x,
+            additionalProperties: $additionalProperties,
         );
     }
 }

--- a/src/Attributes/RequestField.php
+++ b/src/Attributes/RequestField.php
@@ -32,10 +32,10 @@ use Radiergummi\OpenApi\Support\Attributes\FieldDefault;
 final readonly class RequestField extends FieldAttribute
 {
     /**
-     * @param null|non-empty-string                                                        $name        Field name; required
-     *                                                                                                  on a method, derived
-     *                                                                                                  from the target
-     *                                                                                                  otherwise
+     * @param null|non-empty-string                                                        $name                 Field name; required
+     *                                                                                                           on a method, derived
+     *                                                                                                           from the target
+     *                                                                                                           otherwise
      * @param null|non-empty-string                                                        $title
      * @param null|non-empty-string                                                        $description
      * @param null|OpenApiPrimitiveType                                                    $type
@@ -46,7 +46,8 @@ final readonly class RequestField extends FieldAttribute
      * @param null|non-empty-string                                                        $pattern
      * @param null|int<0, max>                                                             $minItems
      * @param null|int<0, max>                                                             $maxItems
-     * @param null|array<string, mixed>                                                    $x           Vendor extensions (`x-*`).
+     * @param null|array<string, mixed>                                                    $x                    Vendor extensions (`x-*`).
+     * @param null|bool|string                                                             $additionalProperties Map-value override.
      */
     public function __construct(
         public ?string $name = null,
@@ -73,6 +74,7 @@ final readonly class RequestField extends FieldAttribute
         ?bool $uniqueItems = null,
         ?bool $writeOnly = null,
         ?array $x = null,
+        bool|string|null $additionalProperties = null,
     ) {
         parent::__construct(
             title: $title,
@@ -97,6 +99,7 @@ final readonly class RequestField extends FieldAttribute
             uniqueItems: $uniqueItems,
             writeOnly: $writeOnly,
             x: $x,
+            additionalProperties: $additionalProperties,
         );
     }
 }

--- a/src/Attributes/ResponseField.php
+++ b/src/Attributes/ResponseField.php
@@ -37,7 +37,8 @@ final readonly class ResponseField extends FieldAttribute
      * @param null|non-empty-string                                                        $pattern
      * @param null|int<0, max>                                                             $minItems
      * @param null|int<0, max>                                                             $maxItems
-     * @param null|array<string, mixed>                                                    $x           Vendor extensions (`x-*`).
+     * @param null|array<string, mixed>                                                    $x                    Vendor extensions (`x-*`).
+     * @param null|bool|string                                                             $additionalProperties Map-value override.
      */
     public function __construct(
         ?string $title = null,
@@ -62,6 +63,7 @@ final readonly class ResponseField extends FieldAttribute
         ?bool $readOnly = null,
         bool $conditional = false,
         ?array $x = null,
+        bool|string|null $additionalProperties = null,
     ) {
         parent::__construct(
             title: $title,
@@ -86,6 +88,7 @@ final readonly class ResponseField extends FieldAttribute
             readOnly: $readOnly,
             conditional: $conditional,
             x: $x,
+            additionalProperties: $additionalProperties,
         );
     }
 }

--- a/src/Support/Extraction/UriParametersExtractor.php
+++ b/src/Support/Extraction/UriParametersExtractor.php
@@ -72,6 +72,7 @@ final readonly class UriParametersExtractor
             $schema->example = $fieldDescriptor->example;
         }
 
+        $fieldDescriptor?->applyAdditionalProperties($schema);
         $fieldDescriptor?->applyVendorExtensions($schema);
 
         // OpenAPI 3.x §4.8.12.1: path parameters MUST have `required: true`. Laravel's `{param?}`

--- a/src/Support/Generator/SchemaDescriptor.php
+++ b/src/Support/Generator/SchemaDescriptor.php
@@ -11,6 +11,7 @@ use Radiergummi\OpenApi\Attributes\QueryParam;
 use Radiergummi\OpenApi\Attributes\RequestField;
 use Radiergummi\OpenApi\Attributes\ResponseField;
 
+use function is_bool;
 use function Radiergummi\OpenApi\is_undefined;
 use function str_starts_with;
 use function substr;
@@ -29,10 +30,15 @@ final readonly class SchemaDescriptor
 {
     /**
      * @param null|list<BackedEnum|bool|float|int|string> $enum
-     * @param null|array<string, mixed>                   $x    Vendor extensions; keys are passed
-     *                                                          with the `x-` prefix and stored
-     *                                                          stripped (swagger-php re-adds it on
-     *                                                          serialize), matching `OverridesStage`.
+     * @param null|array<string, mixed>                   $x                    Vendor extensions; keys are passed
+     *                                                                          with the `x-` prefix and stored
+     *                                                                          stripped (swagger-php re-adds it on
+     *                                                                          serialize), matching `OverridesStage`.
+     * @param null|bool|string                            $additionalProperties Map-value override: `true`/`false`
+     *                                                                          for the boolean form, or a type/
+     *                                                                          class-string wrapped into a nested
+     *                                                                          value schema (mirroring `$items`).
+     *                                                                          `null` leaves inference untouched.
      */
     public function __construct(
         public ?string $title = null,
@@ -58,6 +64,7 @@ final readonly class SchemaDescriptor
         public ?bool $readOnly = null,
         public ?bool $writeOnly = null,
         public ?array $x = null,
+        public bool|string|null $additionalProperties = null,
     ) {}
 
     /**
@@ -83,6 +90,7 @@ final readonly class SchemaDescriptor
             NullableSchema::applyTo($schema);
         }
 
+        $this->applyAdditionalProperties($schema);
         $this->applyVendorExtensions($schema);
 
         return $schema;
@@ -125,6 +133,20 @@ final readonly class SchemaDescriptor
     }
 
     /**
+     * The `additionalProperties` value for a map override: a bool passes through; a type string is
+     * wrapped into a nested value schema (mirroring {@see itemsSchema()}). `null` means "not set",
+     * leaving any inferred value in place.
+     */
+    private function additionalPropertiesValue(): bool|OA\AdditionalProperties|null
+    {
+        return match (true) {
+            $this->additionalProperties === null => null,
+            is_bool($this->additionalProperties) => $this->additionalProperties,
+            default => new OA\AdditionalProperties(['type' => $this->additionalProperties]),
+        };
+    }
+
+    /**
      * The `items` schema for an `array` type. Always present for an array (a permissive `{}` when
      * no element type is declared), because swagger-php rejects an items-less array and would
      * hard-fail generation.
@@ -163,7 +185,26 @@ final readonly class SchemaDescriptor
             NullableSchema::applyTo($property);
         }
 
+        $this->applyAdditionalProperties($property);
         $this->applyVendorExtensions($property);
+    }
+
+    /**
+     * Writes an explicit `additionalProperties` override onto the target, unconditionally when the
+     * descriptor carries one. The write must overwrite — an inferred map value (e.g. from
+     * `array<string, T>` map inference) is already on the property by the time this runs, and the
+     * author's override wins by being applied last; a skip-if-defined guard would invert that.
+     *
+     * Public so callers that build a parameter schema directly ({@see UriParametersExtractor})
+     * can honor a `#[PathParam]` override without routing through {@see applyTo()}.
+     */
+    public function applyAdditionalProperties(OA\Schema|OA\Property $target): void
+    {
+        $value = $this->additionalPropertiesValue();
+
+        if ($value !== null) {
+            $target->additionalProperties = $value;
+        }
     }
 
     /**

--- a/src/Support/Generator/SchemaDescriptor.php
+++ b/src/Support/Generator/SchemaDescriptor.php
@@ -35,10 +35,10 @@ final readonly class SchemaDescriptor
      *                                                                          stripped (swagger-php re-adds it on
      *                                                                          serialize), matching `OverridesStage`.
      * @param null|bool|string                            $additionalProperties Map-value override: `true`/`false`
-     *                                                                          for the boolean form, or a type/
-     *                                                                          class-string wrapped into a nested
-     *                                                                          value schema (mirroring `$items`).
-     *                                                                          `null` leaves inference untouched.
+     *                                                                          for the boolean form, or a type string
+     *                                                                          wrapped into a nested value schema
+     *                                                                          (mirroring `$items`). `null` leaves
+     *                                                                          inference untouched.
      */
     public function __construct(
         public ?string $title = null,

--- a/tests/Feature/AdditionalPropertiesOverrideTest.php
+++ b/tests/Feature/AdditionalPropertiesOverrideTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Attributes\PathParam;
+use Radiergummi\OpenApi\Tests\Fixtures\AdditionalPropertiesOverrideFixtureData;
+
+use function array_column;
+use function array_filter;
+
+uses()->group('openapi', 'plugin:spatie-data');
+
+class AdditionalPropertiesOverrideController extends Controller
+{
+    public function map(): AdditionalPropertiesOverrideFixtureData
+    {
+        return new AdditionalPropertiesOverrideFixtureData(closedMap: [], retypedMap: []);
+    }
+
+    public function show(
+        #[PathParam(description: 'The widget.', additionalProperties: false)]
+        string $widget,
+    ): JsonResponse {
+        return new JsonResponse();
+    }
+}
+
+it('lets an explicit additionalProperties: false override #334 map inference', function (): void {
+    Route::get('/additional-props/map', [AdditionalPropertiesOverrideController::class, 'map']);
+
+    $props = generateSpec()['components']['schemas']['AdditionalPropertiesOverrideFixtureData']['properties'];
+
+    // #334 would infer additionalProperties: {$ref: AddressFixtureData}; the attribute runs last.
+    expect($props['closedMap']['additionalProperties'])->toBeFalse();
+});
+
+it('lets an explicit additionalProperties type-string override #334 map inference', function (): void {
+    Route::get('/additional-props/map', [AdditionalPropertiesOverrideController::class, 'map']);
+
+    $props = generateSpec()['components']['schemas']['AdditionalPropertiesOverrideFixtureData']['properties'];
+
+    expect($props['retypedMap']['additionalProperties'])->toBe(['type' => 'string']);
+});
+
+it('honors #[PathParam(additionalProperties:)] on the parameter schema via toSchema()', function (): void {
+    Route::get('/additional-props/{widget}', [AdditionalPropertiesOverrideController::class, 'show']);
+
+    $operation = generateSpec()['paths']['/additional-props/{widget}']['get'];
+
+    $widget = array_column(
+        array_filter(
+            $operation['parameters'] ?? [],
+            static fn(array $parameter): bool => ($parameter['in'] ?? null) === 'path',
+        ),
+        null,
+        'name',
+    )['widget'] ?? null;
+
+    // Near-meaningless on a scalar path param; the assertion guards that toSchema() does not drop
+    // the field (the UriParametersExtractor path bypasses applyTo()).
+    expect($widget)->not->toBeNull()
+        ->and($widget['schema']['additionalProperties'])->toBeFalse();
+});

--- a/tests/Fixtures/AdditionalPropertiesOverrideFixtureData.php
+++ b/tests/Fixtures/AdditionalPropertiesOverrideFixtureData.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures;
+
+use Radiergummi\OpenApi\Attributes\ResponseField;
+use Spatie\LaravelData\Data;
+
+/**
+ * Exercises the field-level `additionalProperties:` override against #334's map inference.
+ * Both properties are `array<string, AddressFixtureData>` (inferred to
+ * `additionalProperties: {$ref: AddressFixtureData}`); the attribute must win, running last.
+ */
+final class AdditionalPropertiesOverrideFixtureData extends Data
+{
+    public function __construct(
+        /** @var array<string, AddressFixtureData> */
+        #[ResponseField(additionalProperties: false)]
+        public array $closedMap,
+
+        /** @var array<string, AddressFixtureData> */
+        #[ResponseField(additionalProperties: 'string')]
+        public array $retypedMap,
+    ) {}
+}

--- a/tests/Unit/Support/Generator/SchemaDescriptorTest.php
+++ b/tests/Unit/Support/Generator/SchemaDescriptorTest.php
@@ -86,3 +86,53 @@ it('does not touch $x when no extensions are given', function (): void {
 });
 
 // endregion
+
+// region additionalProperties override
+
+it('emits additionalProperties: false on a property via applyTo()', function (): void {
+    $descriptor = new SchemaDescriptor(type: 'object', additionalProperties: false);
+    $property = new OA\Property(['property' => 'meta', '_context' => new Context()]);
+
+    $descriptor->applyTo($property);
+    $serialized = serializeAnnotation($property);
+
+    expect($serialized['additionalProperties'])->toBeFalse();
+});
+
+it('emits additionalProperties: true on a property via applyTo()', function (): void {
+    $descriptor = new SchemaDescriptor(type: 'object', additionalProperties: true);
+    $property = new OA\Property(['property' => 'meta', '_context' => new Context()]);
+
+    $descriptor->applyTo($property);
+    $serialized = serializeAnnotation($property);
+
+    expect($serialized['additionalProperties'])->toBeTrue();
+});
+
+it('wraps a type-string additionalProperties value into a nested schema', function (): void {
+    $descriptor = new SchemaDescriptor(type: 'object', additionalProperties: 'string');
+    $property = new OA\Property(['property' => 'meta', '_context' => new Context()]);
+
+    $descriptor->applyTo($property);
+    $serialized = serializeAnnotation($property);
+
+    expect($serialized['additionalProperties'])->toBe(['type' => 'string']);
+});
+
+it('emits additionalProperties on a standalone schema via toSchema()', function (): void {
+    $descriptor = new SchemaDescriptor(type: 'object', additionalProperties: false);
+    $serialized = serializeAnnotation($descriptor->toSchema());
+
+    expect($serialized['additionalProperties'])->toBeFalse();
+});
+
+it('does not touch additionalProperties when the descriptor does not carry it', function (): void {
+    $descriptor = new SchemaDescriptor(type: 'object');
+    $property = new OA\Property(['property' => 'meta', '_context' => new Context()]);
+
+    $descriptor->applyTo($property);
+
+    expect($property->additionalProperties)->toBe(Generator::UNDEFINED);
+});
+
+// endregion


### PR DESCRIPTION
Closes #345

## Recommendation up front: ship `additionalProperties:` now; do NOT build the free-form `schema:` knob

Issue #345 proposes two field-level knobs on `FieldAttribute`: `additionalProperties:` and a `schema:` merge knob. After reading the merged Sub-item A pattern and #334's inference, I recommend implementing **`additionalProperties:` only**, and **dropping `schema:`** (not merely deferring it), with the reasoning recorded for the maintainer.

**Why drop `schema:`** (per the inference philosophy — an attribute is healthy only when it supplies something the code cannot express):

- `FieldAttribute` *already* exposes every JSON-Schema keyword `OA\Schema` models as a typed, individually-overridable constructor param (`type`, `format`, `minimum`/`maximum`, `pattern`, `minItems`, `enum`, `nullable`, …). And `SchemaDescriptor::applyTo()` is **already a shallow overlay** — it writes each non-null field onto the inferred `OA\Property`, so the author already wins per-keyword. There is no "merge-semantics gap" for the modeled keywords.
- The *only* thing a free-form `schema: array` adds beyond the typed params is **unmodeled/composed keywords** (`if`/`then`/`else`, `dependent*`, exotic compositions) — which are exactly the #140 wall + IR (#189) territory, and the class-level literal-body case is **Sub-item B's** job (#344). A field-level free-form `schema:` would (a) re-introduce the keyword-validation/lint burden #345 itself flags, (b) duplicate B's surface at field scope, and (c) be a second way to set keywords the typed params already cover — the *smell* the philosophy warns against.
- So `schema:` is either redundant (modeled keywords) or blocked (unmodeled). Building it now would add public surface that mostly re-states existing capability. **Drop it**; if a concrete unmodeled-keyword case appears, it rides the IR work, not a field knob.

This is a deliberate scope decision (narrower than the issue's literal two-knob framing) and will be posted as a PR comment for maintainer confirmation.

## Tier & boundary

`additionalProperties:` is **Tier-2 → attribute** (an explicit override the code can't always express) and respects the `openapi.overrides` boundary unchanged: the attribute is co-located with the class and travels with refactors; `overrides` is document-level for code you can't annotate. No Contracts change, no config key, no stage reorder.

## The merged A pattern this builds on (verified)

Sub-item A (#343, merged) established the exact chokepoint:

- `FieldAttribute` base constructor carries the knob (e.g. `public ?array $x`), forwarded into `descriptor()` → `SchemaDescriptor`.
- `SchemaDescriptor::applyTo(OA\Property)` (`:152`) overlays `toOpenApi()` fields, then calls `applyVendorExtensions()`; `SchemaDescriptor::toSchema()` (`:72`) is the parallel path for callers that build a `Schema` directly (parameter resolvers), also ending in `applyVendorExtensions()`.
- The **`UriParametersExtractor` caveat**: path params build a `Schema` via `toSchema()`/a direct call rather than `applyTo()`, so any new descriptor field that must reach path params has to be honored in **both** `applyTo()` and `toSchema()` (A added `applyVendorExtensions()` to both for exactly this reason).
- A exposed the knob on the four core concrete attributes: `ResponseField`, `RequestField`, `QueryParam`, `PathParam` (each forwards `x: $x` to `parent::__construct`).

## How `additionalProperties:` interacts with #334 (design question 2 — resolved)

#334 (merged) sets `additionalProperties` on the property schema **during inference**
(`SchemaFromDataClass::resolveCollectionSchema()` → `{type: object, additionalProperties: …}` for a string-keyed map). The attribute overlay runs **after** inference: `applyValidationRules()` → then `applyPropertyAttribute()` (`SchemaFromDataClass.php:212/807`) calls `descriptor()->applyTo($property)`. So **the explicit override naturally wins** by running last — no special arbitration needed, identical to how every other field keyword already overrides inference. The plan just has to make `applyTo()`/`toSchema()` write `additionalProperties` when the descriptor carries it. **Explicit author value wins over #334's inferred map value — spelled out, and locked by a test.**

`swagger-php` types `OA\Schema::$additionalProperties` as `bool|AdditionalProperties`
(`JsonSchemaTrait.php:126`) — so the descriptor carries either a `bool` (`true`/`false`) or a nested schema. **Scope the attribute arg to what's expressible in an attribute literal:** `bool` (the common `additionalProperties: true|false` case) plus an optional value-type as a `class-string`/primitive-type-string that we wrap into an `OA\AdditionalProperties([...])` (mirroring how `items:` already takes a type string in `FieldAttribute`/`itemsSchema()`). Final arg shape to confirm in review — recommend starting with **`bool|string|null`**: `true`/`false` for the boolean form, a primitive type string (`'string'`/`'integer'`) or class-string for a typed map value; `null` = not set (inference stands).

## Plan (TDD — failing tests first)

### 1. Tests first

`tests/Unit/Support/Generator/SchemaDescriptorTest.php` + a feature test/fixture:

- **Unit:** `SchemaDescriptor(additionalProperties: true)` → `applyTo($property)` sets `$property->additionalProperties === true`; same via `toSchema()`. `false` → `false`. A typed   value (`'string'`) → `$property->additionalProperties` is an `OA\AdditionalProperties`/`OA\Schema` with `type: string`.
- **Feature — override beats inference (#334 interaction):** a Data property typed `array<string, Foo>` (which #334 infers to `additionalProperties: {$ref: Foo}`) carrying `#[ResponseField(additionalProperties: false)]` → emitted `additionalProperties: false` (author wins). And `#[ResponseField(additionalProperties: 'string')]` → `additionalProperties: {type: string}`.
- **Feature — no inference present:** a plain `object`-typed field with `#[ResponseField(type: 'object', additionalProperties: true)]` → `additionalProperties: true`.
- **PathParam path (UriParametersExtractor caveat):** `#PathParam(additionalProperties: …)]` reaches the emitted parameter schema via `toSchema()` (proves both apply paths honor the field). (Edge: path params are scalar — this mainly guards that `toSchema()` doesn't drop the field; keep the assertion minimal.)
- **Negative / default:** no `additionalProperties:` arg → property unchanged; #334 inference (when present) survives untouched.

### 2. Thread `additionalProperties` through the chokepoint

- `src/Support/Generator/SchemaDescriptor.php` — add `public bool|string|null $additionalProperties = null` to the constructor. Add a private `additionalPropertiesValue(): bool|OA\Schema|null` helper (bool passes through; a type/class-string wraps into `OA\AdditionalProperties`/an `OA\Schema` with `type`/`$ref`, mirroring `itemsSchema()`). In **both** `applyTo()` and `toSchema()`, after the existing field application, set `$target->additionalProperties` when the helper returns non-null. (Two apply paths because of the `UriParametersExtractor` caveat.) Do **not** put it in `toOpenApi()` — like `items`/`nullable`/`x`, it's a structural field set directly.
- `src/Attributes/FieldAttribute.php` — add `public bool|string|null $additionalProperties = null` to the base constructor; forward into `descriptor()`.

### 3. Expose `additionalProperties:` on the core field attributes

Add the `additionalProperties:` param (forwarding to `parent::__construct`) on the same four core attributes A used: `ResponseField`, `RequestField`, `QueryParam`, `PathParam`. (PathParam's value is nearly always scalar, but exposing it keeps the surface symmetric with A and costs one line; note in PR if review prefers omitting it there.)

Plugin-owned subclasses (`ResourceField`/`TransformerField`/`AllowedFilter`) inherit base support but don't expose the param — same trivial follow-up line as A left for them.

### 4. Bookkeeping

- `docs/attributes.md` — document `additionalProperties:` on the field family, with the override-beats-inference note (links to #334's map inference) and the `openapi.overrides` boundary. State that free-form `schema:` is intentionally **not** offered (typed params + the IR/Sub-item B cover that ground).
- `CHANGELOG.md [Unreleased]` — under **Added**: field-level `additionalProperties:` override on field attributes.
- **No `docs/linting.md` row** — dropping `schema:` means no `schema.raw-keyword-unsupported` rule is needed for C (the bool/typed `additionalProperties` value can't carry unmodeled keywords). That lint rule lands with Sub-item B (#344) where free-form keyword arrays actually appear.

### Files

- *Modified:* `src/Support/Generator/SchemaDescriptor.php`, `src/Attributes/FieldAttribute.php`, `src/Attributes/ResponseField.php`, `src/Attributes/RequestField.php`, `src/Attributes/QueryParam.php`, `src/Attributes/PathParam.php`
- *Tests:* `tests/Unit/Support/Generator/SchemaDescriptorTest.php`, a feature test + fixture
- *Docs:* `docs/attributes.md`, `CHANGELOG.md`

No `src/Contracts/**`, no config key, no stage-order change.

## Verification

- `composer test` green; `vendor/bin/pint --test` clean; `composer lint` (PHPStan L8) clean.
- Emitted `additionalProperties` (bool + nested `OA\AdditionalProperties`) validates on swagger-php **5.8 and 6.x** — both forms are core swagger-php (the envelope strategies and #334 already emit the nested form), so no #140 risk.

## Controversial / escalation flags (escalation-bound: new public surface, area:core)

1. **Public authoring-surface addition** — a new `additionalProperties:` constructor param on the public `FieldAttribute` base + four public attributes. Human gate; lands ready-but-escalated for Moritz. Expected.
2. **Dropping the `schema:` knob** — narrower than the issue's two-knob framing. Recorded as a deliberate "healthy-attribute" decision (typed params already cover modeled keywords; unmodeled keywords are #189/#344). **Maintainer confirm** whether to proceed `additionalProperties`-only.
3. **Attribute arg shape for `additionalProperties`** (`bool|string|null`, with string = type/ class-string wrapped into a nested schema) — one design choice for review to confirm.

All three are design/surface questions, not implementation risk; no Contracts seam, no stage reorder, no host-app runtime mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)