### PR TITLE
feat(#344): class-level #[Schema] body replacement (Sub-item B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project are documented here.
 - `#[CookieParam]` authoring attribute documenting an `in: cookie` parameter read off the request at runtime. (#335)
 - `x:` vendor-extension passthrough on the field attributes (`#[ResponseField]`, `#[RequestField]`, `#[QueryParam]`, `#[PathParam]`, `#[CookieParam]`): attach `x-*` specification extensions to a field's schema, co-located with the field (the field-level analogue of `openapi.overrides`). (#336)
 - `additionalProperties:` override on the field attributes (`#[ResponseField]`, `#[RequestField]`, `#[QueryParam]`, `#[PathParam]`): set a field's map behaviour to a bool or a typed value schema; applied last, it wins over inferred `array<string, T>` map values. (#345)
+- `#[RawSchema]` class-level attribute replaces a payload class's inferred component body with a literal JSON Schema (Spatie Data, API Resource, FormRequest); keywords are bounded to what swagger-php serialises, with unsupported keywords dropped-and-logged and flagged by the new `schema.raw-keyword-unsupported` lint rule. (#344)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -188,6 +188,7 @@ Resource, a `FormRequest`, an Eloquent model).
 | Attribute | Target | Purpose |
 |---|---|---|
 | `SchemaName` | class | Override the component key the class maps to in `#/components/schemas/{key}`. |
+| `RawSchema` | class | Replace the inferred component body with a literal JSON Schema. Skips all convention inference and field attributes on the class. |
 
 By default the key is derived from the class basename (disambiguated with namespace segments, or a
 short hash as a last resort). That key is a public, consumer-facing contract — it becomes the type
@@ -208,6 +209,48 @@ restates what derivation already produces. The name still goes through the `comp
 lint rule, so keep it consistent with the rest of the document (PascalCase by default). Two distinct
 classes declaring the same name is an unresolvable conflict: generation throws
 `DuplicateSchemaNameException`.
+
+### Replace a component body with a literal schema (`#[RawSchema]`)
+
+When the shape a class produces genuinely cannot be derived — a hand-tuned composition, a body the
+runtime assembles dynamically — `#[RawSchema]` lets you supply the component body verbatim. The
+array becomes the component schema; the generator does not read the class's properties, `rules()`,
+`toArray()`, or any field-level attribute on it.
+
+```php
+use Radiergummi\OpenApi\Attributes as OpenApi;
+
+#[OpenApi\RawSchema([
+    'type' => 'object',
+    'required' => ['kind'],
+    'properties' => [
+        'kind' => ['type' => 'string', 'enum' => ['circle', 'square']],
+        'shape' => ['oneOf' => [
+            ['$ref' => '#/components/schemas/Circle'],
+            ['$ref' => '#/components/schemas/Square'],
+        ]],
+    ],
+])]
+final class ShapeData extends Data { … }
+```
+
+**Class-level wins.** Because the literal body replaces inference outright, any `#[ResponseField]`,
+`#[RequestField]`, etc. on the same class are ignored — there is no merge.
+
+**Bounded keyword set.** Keywords are limited to what swagger-php can serialise: `type`, `enum`,
+`const`, `not`, `oneOf`/`anyOf`/`allOf`, `properties`, `required`, `additionalProperties`,
+`patternProperties`, `propertyNames`, `contains`, `items`, the numeric/string/array constraints,
+`default`, `title`, `description`, `format`, plus any `x-*` extension. Unsupported keywords —
+`if`/`then`/`else`, `dependentRequired`/`dependentSchemas`, and the draft-07 `dependencies` (OpenAPI
+3.1 splits it into the two `dependent*` keywords; accepting only the deprecated spelling would be
+dialect-inconsistent) — are **dropped from the output and logged**, and the
+`schema.raw-keyword-unsupported` lint rule flags them so the loss is never silent.
+
+**Boundaries.** `#[RawSchema]` is co-located with the class and travels with it through refactors;
+use `openapi.overrides` instead for **document-level, operation-targeted** edits (it cannot address a
+component body). It is also distinct from the SwaggerPhp plugin's harvester, which ingests
+hand-authored `#[OA\Schema]` annotations wholesale — `#[RawSchema]` is a terse first-party knob
+scoped to the validated keyword set.
 
 ## Exception-level attribute
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -463,6 +463,7 @@ is enabled.
 | `schema.allof-type-conflict` | 1 | allOf members declare conflicting type values. |
 | `schema.enum-empty` | 1 | A schema declares an empty enum (enum: []) and is unsatisfiable. |
 | `schema.nullable-via-deprecated-keyword` | 1 | Schema uses the deprecated OpenAPI 3.0 nullable: true keyword instead of a type array. |
+| `schema.raw-keyword-unsupported` | 1 | A #[RawSchema] uses a keyword swagger-php cannot serialise (if/then/else, dependentRequired/dependentSchemas, dependencies); it is silently dropped from the output. |
 | `security.invalid-scope` | 1 | Operation requires a scope not declared in securitySchemes. |
 | `streaming.no-content-type` | 1 | Streaming operation has no content-type: text/event-stream response. |
 | `throws.transitive-missing` | 1 | An action's handler declares @throws exceptions not redeclared on the controller method. |

--- a/src/Attributes/RawSchema.php
+++ b/src/Attributes/RawSchema.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Attributes;
+
+use Attribute;
+
+/**
+ * Replaces a class's inferred component schema body with a literal JSON Schema. Placed on a
+ * payload class the generator would otherwise introspect (a Spatie Data class, an API Resource,
+ * or a FormRequest), it short-circuits that inference entirely: the array given here becomes the
+ * component body verbatim, and any field-level attributes on the class are ignored.
+ *
+ * ```php
+ * #[OpenApi\RawSchema([
+ *     'type' => 'object',
+ *     'required' => ['kind'],
+ *     'properties' => [
+ *         'kind' => ['type' => 'string', 'enum' => ['a', 'b']],
+ *     ],
+ * ])]
+ * final class WidgetData extends Data { … }
+ * ```
+ *
+ * Keywords are bounded to what swagger-php can serialise (see {@see \Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema::ACCEPTED_KEYWORDS}).
+ * Unsupported keywords (`if`/`then`/`else`, `dependentRequired`/`dependentSchemas`,
+ * `dependencies`) are dropped at build time and flagged by the `schema.raw-keyword-unsupported`
+ * lint rule.
+ *
+ * For document-level, operation-targeted overrides use `openapi.overrides` instead; `#[RawSchema]`
+ * is co-located with the class and travels with it through refactors.
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class RawSchema
+{
+    /**
+     * @param array<string, mixed> $schema A literal JSON Schema definition.
+     */
+    public function __construct(
+        public array $schema,
+    ) {}
+}

--- a/src/Lint/Rules/SchemaRawKeywordUnsupported.php
+++ b/src/Lint/Rules/SchemaRawKeywordUnsupported.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Rules;
+
+use Override;
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\LintContext;
+use Radiergummi\OpenApi\Lint\Tree\OperationNode;
+use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
+use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
+use ReflectionClass;
+use ReflectionNamedType;
+
+use function class_exists;
+use function implode;
+use function sprintf;
+
+/**
+ * Flags a `#[RawSchema]` whose definition carries a keyword swagger-php cannot serialise
+ * ({@see ExplicitClassSchema::ACCEPTED_KEYWORDS}). Such keywords are silently dropped at build
+ * time, so without this rule a `#[RawSchema(['if' => …])]` would produce a quietly-wrong spec.
+ *
+ * Discovers `#[RawSchema]`-bearing classes by reflecting each operation's request-payload
+ * candidates ({@see PayloadParameterScanner}) and its action return type. The rule keys off the
+ * attribute, not any plugin, so it lives in the baseline rule set.
+ */
+final class SchemaRawKeywordUnsupported implements OperationRuleVisitor, Rule
+{
+    public const string ID = 'schema.raw-keyword-unsupported';
+
+    /**
+     * Classes already inspected this run, so a `#[RawSchema]` referenced by several operations is
+     * reported once. The rule is scoped per generation run, so the set resets with the instance.
+     *
+     * @var array<class-string, true>
+     */
+    private array $seen = [];
+
+    public function __construct(
+        private readonly PayloadParameterScanner $scanner,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return self::ID;
+    }
+
+    #[Override]
+    public function level(): int
+    {
+        return 1;
+    }
+
+    #[Override]
+    public function description(): string
+    {
+        return 'A #[RawSchema] uses a keyword swagger-php cannot serialise '
+            . '(if/then/else, dependentRequired/dependentSchemas, dependencies).';
+    }
+
+    /**
+     * @return iterable<Finding>
+     */
+    #[Override]
+    public function checkOperation(OperationNode $operation, LintContext $context): iterable
+    {
+        $method = $operation->descriptor?->method;
+
+        if ($method === null) {
+            return;
+        }
+
+        $candidates = $this->scanner->candidates($method);
+
+        $returnType = $method->getReturnType();
+
+        if ($returnType instanceof ReflectionNamedType && !$returnType->isBuiltin()) {
+            /** @var class-string $returnClass */
+            $returnClass = $returnType->getName();
+            $candidates[] = $returnClass;
+        }
+
+        foreach ($candidates as $className) {
+            yield from $this->checkClass($className);
+        }
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @return iterable<Finding>
+     */
+    private function checkClass(string $className): iterable
+    {
+        if (isset($this->seen[$className]) || !class_exists($className)) {
+            return;
+        }
+
+        $this->seen[$className] = true;
+
+        $reflection = new ReflectionClass($className);
+        $attributes = $reflection->getAttributes(RawSchema::class);
+
+        if ($attributes === []) {
+            return;
+        }
+
+        $unsupported = ExplicitClassSchema::unsupportedKeywords($attributes[0]->newInstance()->schema);
+
+        if ($unsupported === []) {
+            return;
+        }
+
+        yield new Finding(
+            ruleId: self::ID,
+            level: $this->level(),
+            message: sprintf(
+                '#[RawSchema] on %s uses unsupported keyword(s): %s.',
+                $className,
+                implode(', ', $unsupported),
+            ),
+            fixHint: 'swagger-php cannot serialise these keywords; remove them or express the '
+                . 'shape with a supported keyword (see docs/attributes.md). Arbitrary keywords '
+                . 'await the IR (#189).',
+            context: [Finding::CONTEXT_SOURCE_CLASS => $className],
+        );
+    }
+}

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -546,6 +546,7 @@ class OpenApiServiceProvider extends ServiceProvider
                     wrappedModelLocator: $app->make(Plugins\ApiResources\Support\WrappedModelLocator::class),
                     modelToSchema: $app->make(Support\Extraction\EloquentModelToSchema::class),
                     logger: $app->make(LoggerInterface::class),
+                    explicitSchema: $app->make(Support\Generator\ExplicitClassSchema::class),
                 );
             },
         );

--- a/src/Plugins/ApiResources/Support/SchemaFromResource.php
+++ b/src/Plugins/ApiResources/Support/SchemaFromResource.php
@@ -16,6 +16,7 @@ use Radiergummi\OpenApi\Plugins\ApiResources\Resolvers\ResourceRefSchemaResolver
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
 use Radiergummi\OpenApi\Support\Extraction\FieldReferenceProperty;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use ReflectionClass;
 use ReflectionException;
 
@@ -68,6 +69,7 @@ final class SchemaFromResource
         private readonly WrappedModelLocator $wrappedModelLocator,
         private readonly EloquentModelToSchema $modelToSchema,
         private readonly LoggerInterface $logger,
+        private readonly ExplicitClassSchema $explicitSchema,
     ) {}
 
     /**
@@ -163,6 +165,11 @@ final class SchemaFromResource
     private function buildSchema(string $resourceClass): OA\Schema
     {
         $reflection = new ReflectionClass($resourceClass);
+
+        // #[RawSchema] replaces the inferred body wholesale; field-level attributes are ignored.
+        if (($rawSchema = $this->explicitSchema->read($reflection)) !== null) {
+            return $this->explicitSchema->toSchema($rawSchema, $reflection);
+        }
 
         /** @var list<OA\Property> $properties */
         $properties = [];

--- a/src/Plugins/Core/Support/SchemaFromFormRequest.php
+++ b/src/Plugins/Core/Support/SchemaFromFormRequest.php
@@ -18,6 +18,7 @@ use Radiergummi\OpenApi\Support\Extraction\FakerExampleSynthesiser;
 use Radiergummi\OpenApi\Support\Extraction\FieldDescriptor;
 use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionClassConstant;
@@ -53,6 +54,7 @@ final readonly class SchemaFromFormRequest
         private LoggerInterface $logger,
         private FakerExampleSynthesiser $synthesiser,
         private FindingsCollector $findings,
+        private ExplicitClassSchema $explicitSchema,
     ) {}
 
     /**
@@ -88,6 +90,15 @@ final readonly class SchemaFromFormRequest
     private function buildSchema(string $formRequestClass): OA\Schema
     {
         $basename = class_basename($formRequestClass);
+
+        // #[RawSchema] replaces the inferred body wholesale; the rules() read below is skipped.
+        $reflection = new ReflectionClass($formRequestClass);
+
+        if (($rawSchema = $this->explicitSchema->read($reflection)) !== null) {
+            $this->registry->setHasFileFields($formRequestClass, false);
+
+            return $this->explicitSchema->toSchema($rawSchema, $reflection);
+        }
 
         if (!method_exists($formRequestClass, 'rules')) {
             $this->registry->setHasFileFields($formRequestClass, false);

--- a/src/Plugins/SpatieData/Support/SchemaFromDataClass.php
+++ b/src/Plugins/SpatieData/Support/SchemaFromDataClass.php
@@ -20,6 +20,7 @@ use Radiergummi\OpenApi\Support\Extraction\RequestBodyExtractor;
 use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentReference;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\Generator\NullableSchema;
 use ReflectionAttribute;
@@ -89,6 +90,7 @@ final class SchemaFromDataClass implements FilePropertyChecker
         private readonly DataConfig $dataConfig,
         private readonly LoggerInterface $logger,
         private readonly FakerExampleSynthesiser $synthesiser,
+        private readonly ExplicitClassSchema $explicitSchema,
     ) {}
 
     /**
@@ -115,6 +117,12 @@ final class SchemaFromDataClass implements FilePropertyChecker
     private function buildSchema(string $dataClass): OA\Schema
     {
         $reflection = new ReflectionClass($dataClass);
+
+        // #[RawSchema] replaces the inferred body wholesale; field-level attributes are ignored.
+        if (($rawSchema = $this->explicitSchema->read($reflection)) !== null) {
+            return $this->explicitSchema->toSchema($rawSchema, $reflection);
+        }
+
         $title = $this->readClassAttributeValue($reflection, SummaryAttribute::class);
         $description = $this->readClassAttributeValue($reflection, DescriptionAttribute::class);
 

--- a/src/Support/Generator/BaselineRegistration.php
+++ b/src/Support/Generator/BaselineRegistration.php
@@ -87,6 +87,7 @@ use Radiergummi\OpenApi\Lint\Rules\SchemaEnumEmpty;
 use Radiergummi\OpenApi\Lint\Rules\SchemaEnumTypeMismatch;
 use Radiergummi\OpenApi\Lint\Rules\SchemaExampleMissing;
 use Radiergummi\OpenApi\Lint\Rules\SchemaNullableViaDeprecatedKeyword;
+use Radiergummi\OpenApi\Lint\Rules\SchemaRawKeywordUnsupported;
 use Radiergummi\OpenApi\Lint\Rules\SchemaRequiredWithoutProperty;
 use Radiergummi\OpenApi\Lint\Rules\ScopeOverlyBroad;
 use Radiergummi\OpenApi\Lint\Rules\SecurityInvalidScope;
@@ -183,6 +184,7 @@ final class BaselineRegistration
         ResponseRedirectWithoutLocation::class,
         OperationIdMissing::class,
         SchemaAllOfTypeConflict::class,
+        SchemaRawKeywordUnsupported::class,
         ParameterQueryNoSchema::class,
         TagDuplicate::class,
         ResponseDescriptionMissing::class,

--- a/src/Support/Generator/ExplicitClassSchema.php
+++ b/src/Support/Generator/ExplicitClassSchema.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Generator;
+
+use Illuminate\Container\Attributes\Scoped;
+use OpenApi\Annotations as OA;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use ReflectionClass;
+
+use function array_filter;
+use function array_keys;
+use function array_values;
+use function implode;
+use function in_array;
+use function sprintf;
+use function str_starts_with;
+
+use const ARRAY_FILTER_USE_KEY;
+
+/**
+ * Reads a class-level `#[RawSchema]` attribute and turns its literal definition into an
+ * `OA\Schema`, bounded to the keyword set swagger-php can serialise.
+ *
+ * The plugin extractors (Spatie Data, API Resource, FormRequest) each call {@see read()} at the
+ * top of their `buildSchema()` and, when it returns an attribute, {@see toSchema()} to produce the
+ * component body — short-circuiting all convention inference. Keeping that logic here means the
+ * three plugins share one keyword boundary and one degrade-and-log behaviour without `Support/`
+ * touching any plugin type.
+ *
+ * @internal
+ */
+#[Scoped]
+final readonly class ExplicitClassSchema
+{
+    /**
+     * Keywords swagger-php's `OA\Schema` models and serialises. A `#[RawSchema]` may use these
+     * plus any `x-*` extension key. Everything else is dropped at build time (and flagged by the
+     * `schema.raw-keyword-unsupported` lint rule); this constant is the single source of truth for
+     * both paths.
+     *
+     * Notably absent: `if`/`then`/`else`, `dependentRequired`/`dependentSchemas` (the #140 wall —
+     * `OA\Schema` does not model them), and `dependencies` (the draft-07 spelling; OpenAPI 3.1 uses
+     * JSON-Schema 2020-12, where it is split into the two `dependent*` keywords — accepting only the
+     * deprecated form would be dialect-inconsistent).
+     *
+     * @var list<string>
+     */
+    public const array ACCEPTED_KEYWORDS = [
+        'type',
+        'enum',
+        'const',
+        'not',
+        'allOf',
+        'anyOf',
+        'oneOf',
+        'properties',
+        'required',
+        'additionalProperties',
+        'patternProperties',
+        'propertyNames',
+        'contains',
+        'items',
+        'minimum',
+        'maximum',
+        'exclusiveMinimum',
+        'exclusiveMaximum',
+        'multipleOf',
+        'minLength',
+        'maxLength',
+        'pattern',
+        'minItems',
+        'maxItems',
+        'minProperties',
+        'maxProperties',
+        'uniqueItems',
+        'default',
+        'title',
+        'description',
+        'format',
+        'example',
+        'deprecated',
+        'readOnly',
+        'writeOnly',
+        'nullable',
+        'discriminator',
+    ];
+
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Returns the `#[RawSchema]` instance declared on the class, or null when absent.
+     *
+     * @template T of object
+     *
+     * @param ReflectionClass<T> $class
+     */
+    public function read(ReflectionClass $class): ?RawSchema
+    {
+        $attributes = $class->getAttributes(RawSchema::class);
+
+        return $attributes === [] ? null : $attributes[0]->newInstance();
+    }
+
+    /**
+     * Builds the literal component schema, dropping (and logging) any keyword swagger-php cannot
+     * serialise so a non-linted run still produces a valid document.
+     *
+     * @template T of object
+     *
+     * @param ReflectionClass<T> $class The declaring class, for the log context.
+     */
+    public function toSchema(RawSchema $attribute, ReflectionClass $class): OA\Schema
+    {
+        $unsupported = self::unsupportedKeywords($attribute->schema);
+
+        if ($unsupported !== []) {
+            $this->logger->warning(sprintf(
+                'ExplicitClassSchema: dropping unsupported keyword(s) [%s] from #[RawSchema] on %s '
+                . '— swagger-php cannot serialise them.',
+                implode(', ', $unsupported),
+                $class->getName(),
+            ), ['class' => $class->getName(), 'keywords' => $unsupported]);
+        }
+
+        $definition = array_filter(
+            $attribute->schema,
+            static fn(string $key): bool => self::isAccepted($key),
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        return SchemaFromArrayDefinition::build($definition);
+    }
+
+    /**
+     * Returns the keywords in a `#[RawSchema]` definition that swagger-php cannot serialise.
+     * Pure (no logging) so the lint rule can reuse it.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return list<string>
+     */
+    public static function unsupportedKeywords(array $schema): array
+    {
+        return array_values(array_filter(
+            array_keys($schema),
+            static fn(string $key): bool => !self::isAccepted($key),
+        ));
+    }
+
+    private static function isAccepted(string $keyword): bool
+    {
+        return in_array($keyword, self::ACCEPTED_KEYWORDS, true) || str_starts_with($keyword, 'x-');
+    }
+}

--- a/src/Support/Generator/SchemaFromArrayDefinition.php
+++ b/src/Support/Generator/SchemaFromArrayDefinition.php
@@ -7,13 +7,17 @@ namespace Radiergummi\OpenApi\Support\Generator;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
 
+use function array_map;
+use function array_values;
 use function is_array;
 
 /**
  * Builds an `OA\Schema` from a literal JSON-Schema array definition, recursively converting
- * `properties` into `OA\Property` and `items` into `OA\Items`. swagger-php 5.x rejects a raw
- * array left under `properties`/`items` (`properties is an object literal`), failing validation;
- * a proper object graph validates on both the 5.x and 6.x lines.
+ * `properties` into `OA\Property`, `items` into `OA\Items`, the `oneOf`/`anyOf`/`allOf`
+ * composition keywords into `OA\Schema[]`, and `not` into a nested `OA\Schema`. swagger-php
+ * rejects a raw array left under any of these (`properties is an object literal`,
+ * `allOf must be an array of @OA\Schema`), failing validation on both the 5.x and 6.x lines;
+ * a proper object graph validates on both.
  *
  * Every node with `type: array` is guaranteed an `items` object (an unconstrained one when the
  * definition carries none): swagger-php's validator rejects an items-less array on both
@@ -67,6 +71,23 @@ final readonly class SchemaFromArrayDefinition
                 $items = new OA\Items([]);
                 self::apply($items, $value);
                 $node->items = $items;
+
+                continue;
+            }
+
+            if (($key === 'oneOf' || $key === 'anyOf' || $key === 'allOf') && is_array($value)) {
+                $node->{$key} = array_map(
+                    static fn(mixed $member): OA\Schema => is_array($member)
+                        ? self::build($member)
+                        : new OA\Schema([]),
+                    array_values($value),
+                );
+
+                continue;
+            }
+
+            if ($key === 'not' && is_array($value)) {
+                $node->not = self::build($value);
 
                 continue;
             }

--- a/tests/Feature/DeprecatedFieldTest.php
+++ b/tests/Feature/DeprecatedFieldTest.php
@@ -11,6 +11,7 @@ use Radiergummi\OpenApi\Plugins\SpatieData\Support\SchemaFromDataClass;
 use Radiergummi\OpenApi\Support\Extraction\FakerExampleSynthesiser;
 use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Tests\Fixtures\DeprecatedAttributeFieldFixtureData;
 use Radiergummi\OpenApi\Tests\Fixtures\DeprecatedFieldFixtureData;
@@ -55,6 +56,7 @@ function makeDeprecatedSchemaBuilder(?ComponentSchemaRegistry $registry = null):
         dataConfig: app(DataConfig::class),
         logger: new NullLogger(),
         synthesiser: new FakerExampleSynthesiser(enabled: false),
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
 }
 

--- a/tests/Feature/Examples/FakerSynthesisIntegrationTest.php
+++ b/tests/Feature/Examples/FakerSynthesisIntegrationTest.php
@@ -12,6 +12,7 @@ use Radiergummi\OpenApi\Plugins\Core\Support\SchemaFromFormRequest;
 use Radiergummi\OpenApi\Support\Extraction\FakerExampleSynthesiser;
 use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 
 uses()->group('openapi', 'examples');
 
@@ -41,6 +42,7 @@ function fakerSynthesisBuildSchema(bool $synthesise): OA\Schema
         logger: new NullLogger(),
         synthesiser: new FakerExampleSynthesiser(enabled: $synthesise, seed: 1234),
         findings: new ArrayFindingsCollector(),
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
 
     $builder->build(fakerSynthesisMakeEmailFormRequest());
@@ -129,6 +131,7 @@ it('does not overwrite an authored example from a #[RequestField] attribute', fu
         logger: new NullLogger(),
         synthesiser: new FakerExampleSynthesiser(enabled: true, seed: 1234),
         findings: new ArrayFindingsCollector(),
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
 
     $builder->build($request::class);

--- a/tests/Feature/RawSchemaAttributeTest.php
+++ b/tests/Feature/RawSchemaAttributeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Tests\Fixtures\RawSchema\RawSchemaController;
+
+uses()->group('openapi');
+
+/**
+ * Resolves the component schema body referenced by a request body or response.
+ *
+ * @param array<string, mixed> $spec
+ *
+ * @return array<string, mixed>
+ */
+function rawSchemaComponentFor(array $spec, string $ref): array
+{
+    $name = basename(str_replace('#/components/schemas/', '', $ref));
+
+    return $spec['components']['schemas'][$name] ?? [];
+}
+
+it('replaces a Spatie Data body with the literal #[RawSchema] and skips inference', function (): void {
+    Route::post('/oa-fixture/raw-data', [RawSchemaController::class, 'data']);
+
+    $spec = generateSpec();
+
+    $ref = $spec['paths']['/oa-fixture/raw-data']['post']['requestBody']['content']['application/json']['schema']['$ref'];
+    $component = rawSchemaComponentFor($spec, $ref);
+
+    expect($component['type'])->toBe('object')
+        ->and($component['required'])->toBe(['kind'])
+        ->and($component['properties'])->toHaveKey('kind')
+        // `secret` would be inferred from the constructor without #[RawSchema].
+        ->and($component['properties'])->not->toHaveKey('secret');
+});
+
+it('replaces an API Resource body with the literal #[RawSchema] (oneOf composition)', function (): void {
+    Route::get('/oa-fixture/raw-resource', [RawSchemaController::class, 'resource']);
+
+    $spec = generateSpec();
+
+    $response = $spec['paths']['/oa-fixture/raw-resource']['get']['responses']['200'] ?? null;
+    expect($response)->not->toBeNull();
+
+    // Laravel wraps a single resource under `data`; the wrapped schema is the raw component.
+    $ref = $response['content']['application/json']['schema']['properties']['data']['$ref'];
+    $component = rawSchemaComponentFor($spec, $ref);
+
+    expect($component)->toHaveKey('oneOf')
+        ->and($component['oneOf'])->toHaveCount(2)
+        ->and($component)->not->toHaveKey('ignored');
+});
+
+it('replaces a FormRequest body with the literal #[RawSchema] and skips the rules() read', function (): void {
+    Route::post('/oa-fixture/raw-form-request', [RawSchemaController::class, 'formRequest']);
+
+    $spec = generateSpec();
+
+    $ref = $spec['paths']['/oa-fixture/raw-form-request']['post']['requestBody']['content']['application/json']['schema']['$ref'];
+    $component = rawSchemaComponentFor($spec, $ref);
+
+    expect($component['required'])->toBe(['token'])
+        ->and($component['properties'])->toHaveKey('token')
+        // `email` would be mapped from rules() without #[RawSchema].
+        ->and($component['properties'])->not->toHaveKey('email');
+});
+
+it('lets class-level #[RawSchema] win over property-level field attributes', function (): void {
+    Route::post('/oa-fixture/raw-precedence', [RawSchemaController::class, 'withFieldAttribute']);
+
+    $spec = generateSpec();
+
+    $ref = $spec['paths']['/oa-fixture/raw-precedence']['post']['requestBody']['content']['application/json']['schema']['$ref'];
+    $component = rawSchemaComponentFor($spec, $ref);
+
+    expect($component['properties'])->toHaveKey('only')
+        ->and($component['properties'])->not->toHaveKey('annotated');
+});
+
+it('produces a valid document even when #[RawSchema] carries an unsupported keyword', function (): void {
+    Route::post('/oa-fixture/raw-unsupported', [RawSchemaController::class, 'unsupported']);
+
+    $spec = generateSpec();
+
+    $ref = $spec['paths']['/oa-fixture/raw-unsupported']['post']['requestBody']['content']['application/json']['schema']['$ref'];
+    $component = rawSchemaComponentFor($spec, $ref);
+
+    // The `if` keyword is dropped at build time; the surviving body is intact.
+    expect($component)->not->toHaveKey('if')
+        ->and($component['properties'])->toHaveKey('kind');
+});

--- a/tests/Fixtures/RawSchema/RawSchemaController.php
+++ b/tests/Fixtures/RawSchema/RawSchemaController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Illuminate\Routing\Controller;
+
+class RawSchemaController extends Controller
+{
+    public function data(RawSchemaData $payload): array
+    {
+        return [];
+    }
+
+    public function resource(): RawSchemaResource
+    {
+        return new RawSchemaResource(null);
+    }
+
+    public function formRequest(RawSchemaFormRequest $request): array
+    {
+        return [];
+    }
+
+    public function withFieldAttribute(RawSchemaWithFieldAttributeData $payload): array
+    {
+        return [];
+    }
+
+    public function unsupported(RawSchemaUnsupportedKeywordData $payload): array
+    {
+        return [];
+    }
+
+    public function noPayload(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/RawSchema/RawSchemaData.php
+++ b/tests/Fixtures/RawSchema/RawSchemaData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use Spatie\LaravelData\Data;
+
+/**
+ * A Spatie Data class whose body is replaced by a literal `#[RawSchema]`. The `secret` property
+ * the convention would otherwise infer is absent from the literal body, proving inference is
+ * skipped.
+ */
+#[RawSchema([
+    'type' => 'object',
+    'required' => ['kind'],
+    'properties' => [
+        'kind' => ['type' => 'string', 'enum' => ['a', 'b']],
+    ],
+])]
+final class RawSchemaData extends Data
+{
+    public function __construct(
+        public string $kind,
+        public string $secret,
+    ) {}
+}

--- a/tests/Fixtures/RawSchema/RawSchemaFormRequest.php
+++ b/tests/Fixtures/RawSchema/RawSchemaFormRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Radiergummi\OpenApi\Attributes\RawSchema;
+
+/**
+ * A FormRequest whose body is replaced by a literal `#[RawSchema]`. The `email` rule the
+ * convention would otherwise map is absent from the literal body, proving the rules() read is
+ * skipped.
+ */
+#[RawSchema([
+    'type' => 'object',
+    'required' => ['token'],
+    'properties' => [
+        'token' => ['type' => 'string'],
+    ],
+])]
+class RawSchemaFormRequest extends FormRequest
+{
+    /** @return array<string, array<int, string>> */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/Fixtures/RawSchema/RawSchemaResource.php
+++ b/tests/Fixtures/RawSchema/RawSchemaResource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Radiergummi\OpenApi\Attributes\RawSchema;
+
+/**
+ * An API Resource whose body is replaced by a literal `#[RawSchema]` carrying a composition
+ * keyword (`oneOf`) the convention could never infer.
+ */
+#[RawSchema([
+    'oneOf' => [
+        ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+        ['type' => 'string'],
+    ],
+])]
+class RawSchemaResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray($request): array
+    {
+        return ['ignored' => 'this would be inferred without #[RawSchema]'];
+    }
+}

--- a/tests/Fixtures/RawSchema/RawSchemaUnsupportedKeywordData.php
+++ b/tests/Fixtures/RawSchema/RawSchemaUnsupportedKeywordData.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use Spatie\LaravelData\Data;
+
+/**
+ * Carries an `if` keyword swagger-php cannot serialise. The keyword is dropped at build time
+ * (degrade-and-log) and flagged by the `schema.raw-keyword-unsupported` lint rule.
+ */
+#[RawSchema([
+    'type' => 'object',
+    'properties' => [
+        'kind' => ['type' => 'string'],
+    ],
+    'if' => ['properties' => ['kind' => ['const' => 'a']]],
+])]
+final class RawSchemaUnsupportedKeywordData extends Data
+{
+    public function __construct(
+        public string $kind,
+    ) {}
+}

--- a/tests/Fixtures/RawSchema/RawSchemaWithFieldAttributeData.php
+++ b/tests/Fixtures/RawSchema/RawSchemaWithFieldAttributeData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use Radiergummi\OpenApi\Attributes\RequestField;
+use Spatie\LaravelData\Data;
+
+/**
+ * Both `#[RawSchema]` (class-level) and `#[RequestField]` (property-level) are present. The
+ * class-level attribute wins via the early return, so the field attribute has no effect.
+ */
+#[RawSchema([
+    'type' => 'object',
+    'properties' => [
+        'only' => ['type' => 'string'],
+    ],
+])]
+final class RawSchemaWithFieldAttributeData extends Data
+{
+    public function __construct(
+        #[RequestField(description: 'This description must not appear in the output.')]
+        public string $annotated,
+    ) {}
+}

--- a/tests/Support/SchemaFromResourceFactory.php
+++ b/tests/Support/SchemaFromResourceFactory.php
@@ -11,6 +11,7 @@ use Radiergummi\OpenApi\Plugins\ApiResources\Support\SchemaFromResource;
 use Radiergummi\OpenApi\Plugins\ApiResources\Support\WrappedModelLocator;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
 use Radiergummi\OpenApi\Support\MethodBody\SingleReturnArrayLiteralFinder;
@@ -37,6 +38,7 @@ final class SchemaFromResourceFactory
             wrappedModelLocator: self::wrappedModelLocator(),
             modelToSchema: self::modelToSchema($registry),
             logger: new NullLogger(),
+            explicitSchema: new ExplicitClassSchema(new NullLogger()),
         );
     }
 

--- a/tests/Unit/Core/Extractors/FormRequestRequestSchemaResolverTest.php
+++ b/tests/Unit/Core/Extractors/FormRequestRequestSchemaResolverTest.php
@@ -13,6 +13,7 @@ use Radiergummi\OpenApi\Support\Extraction\FakerExampleSynthesiser;
 use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
 use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use Radiergummi\OpenApi\Support\Registry\ResolvedSchema;
 use Radiergummi\OpenApi\Tests\Fixtures\Action;
 use Radiergummi\OpenApi\Tests\Fixtures\FileUploadFixtureController;
@@ -34,6 +35,7 @@ function makeFormRequestResolver(): FormRequestRequestSchemaResolver
         logger: new NullLogger(),
         synthesiser: new FakerExampleSynthesiser(enabled: false),
         findings: new ArrayFindingsCollector(),
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
 
     return new FormRequestRequestSchemaResolver(
@@ -100,6 +102,7 @@ it('registers the FormRequest schema in the component registry', function (): vo
         logger: new NullLogger(),
         synthesiser: new FakerExampleSynthesiser(enabled: false),
         findings: new ArrayFindingsCollector(),
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
     $resolver = new FormRequestRequestSchemaResolver(
         schemaBuilder: $builder,

--- a/tests/Unit/Core/Extractors/SchemaFromFormRequestTest.php
+++ b/tests/Unit/Core/Extractors/SchemaFromFormRequestTest.php
@@ -11,6 +11,7 @@ use Radiergummi\OpenApi\Plugins\Core\Support\SchemaFromFormRequest;
 use Radiergummi\OpenApi\Support\Extraction\FakerExampleSynthesiser;
 use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use Radiergummi\OpenApi\Tests\Fixtures\DeeplyChainedFormRequest;
 use Radiergummi\OpenApi\Tests\Fixtures\FileUploadFormRequest;
 use Radiergummi\OpenApi\Tests\Fixtures\RouteBoundFormRequest;
@@ -28,6 +29,7 @@ beforeEach(function (): void {
         logger: new NullLogger(),
         synthesiser: new FakerExampleSynthesiser(enabled: false),
         findings: $this->findings,
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
 });
 
@@ -166,6 +168,7 @@ it('registers a placeholder schema, logs a warning, and emits a finding when rul
         logger: $logger,
         synthesiser: new FakerExampleSynthesiser(enabled: false),
         findings: $findings,
+        explicitSchema: new ExplicitClassSchema(new NullLogger()),
     );
 
     $brokenClass = new class () extends FormRequest {

--- a/tests/Unit/Lint/Rules/SchemaRawKeywordUnsupportedTest.php
+++ b/tests/Unit/Lint/Rules/SchemaRawKeywordUnsupportedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Rules\SchemaRawKeywordUnsupported;
+use Radiergummi\OpenApi\Support\Extraction\PayloadParameterScanner;
+use Radiergummi\OpenApi\Tests\Fixtures\RawSchema\RawSchemaController;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
+use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
+
+uses()->group('openapi', 'lint');
+
+function rawKeywordRule(): SchemaRawKeywordUnsupported
+{
+    return new SchemaRawKeywordUnsupported(new PayloadParameterScanner(indirectionClasses: []));
+}
+
+function rawKeywordFindings(string $method): array
+{
+    $descriptor = ActionDescriptorFactory::forControllerMethod(RawSchemaController::class, $method, '/fixture');
+    $operation = OperationNodeFactory::forDescriptor($descriptor, pathUri: '/api/v0/test');
+    $context = OperationNodeFactory::emptyContext();
+
+    return iterator_to_array(rawKeywordRule()->checkOperation($operation, $context));
+}
+
+it('reports its id and level 1', function (): void {
+    $rule = rawKeywordRule();
+
+    expect($rule->id())->toBe('schema.raw-keyword-unsupported')
+        ->and($rule->level())->toBe(1);
+});
+
+it('flags a #[RawSchema] carrying an unsupported keyword', function (): void {
+    $findings = rawKeywordFindings('unsupported');
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->ruleId)->toBe('schema.raw-keyword-unsupported')
+        ->and($findings[0]->level)->toBe(1)
+        ->and($findings[0]->message)->toContain('if');
+});
+
+it('stays silent for a #[RawSchema] with only supported keywords', function (): void {
+    expect(rawKeywordFindings('data'))->toBe([]);
+});
+
+it('stays silent when the payload has no #[RawSchema]', function (): void {
+    $descriptor = ActionDescriptorFactory::forControllerMethod(RawSchemaController::class, 'noPayload', '/fixture');
+    $operation = OperationNodeFactory::forDescriptor($descriptor, pathUri: '/api/v0/test');
+
+    expect(iterator_to_array(rawKeywordRule()->checkOperation($operation, OperationNodeFactory::emptyContext())))
+        ->toBe([]);
+});
+
+it('emits no findings without a descriptor', function (): void {
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/api/v0/test');
+
+    expect(iterator_to_array(rawKeywordRule()->checkOperation($operation, OperationNodeFactory::emptyContext())))
+        ->toBe([]);
+});

--- a/tests/Unit/Support/Generator/ExplicitClassSchemaTest.php
+++ b/tests/Unit/Support/Generator/ExplicitClassSchemaTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Log\NullLogger;
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
+use Radiergummi\OpenApi\Tests\Fixtures\AddressFixtureData;
+use Radiergummi\OpenApi\Tests\Fixtures\RawSchema\RawSchemaData;
+use Radiergummi\OpenApi\Tests\Fixtures\RawSchema\RawSchemaResource;
+use Radiergummi\OpenApi\Tests\Fixtures\RawSchema\RawSchemaUnsupportedKeywordData;
+
+uses()->group('openapi');
+
+function explicitClassSchema(): ExplicitClassSchema
+{
+    return new ExplicitClassSchema(new NullLogger());
+}
+
+it('reads the #[RawSchema] attribute when present', function (): void {
+    $attribute = explicitClassSchema()->read(new ReflectionClass(RawSchemaData::class));
+
+    expect($attribute)->toBeInstanceOf(RawSchema::class)
+        ->and($attribute->schema['properties'])->toHaveKey('kind');
+});
+
+it('returns null when the class has no #[RawSchema]', function (): void {
+    expect(explicitClassSchema()->read(new ReflectionClass(AddressFixtureData::class)))->toBeNull();
+});
+
+it('builds a valid object schema from the literal definition', function (): void {
+    $attribute = new RawSchema([
+        'type' => 'object',
+        'required' => ['a'],
+        'properties' => [
+            'a' => ['type' => 'string'],
+        ],
+    ]);
+
+    $schema = explicitClassSchema()->toSchema($attribute, new ReflectionClass(RawSchemaData::class));
+
+    expect($schema->type)->toBe('object')
+        ->and($schema->required)->toBe(['a'])
+        ->and($schema->properties[0]->property)->toBe('a')
+        ->and($schema->validate())->toBeTrue();
+});
+
+it('preserves composition (oneOf) and const keywords and validates', function (): void {
+    $attribute = new RawSchema([
+        'oneOf' => [
+            ['const' => 'a'],
+            ['const' => 'b'],
+        ],
+    ]);
+
+    $schema = explicitClassSchema()->toSchema($attribute, new ReflectionClass(RawSchemaResource::class));
+
+    expect($schema->oneOf)->toHaveCount(2)
+        ->and($schema->validate())->toBeTrue();
+});
+
+it('drops an unsupported keyword and still validates', function (): void {
+    $attribute = (new ReflectionClass(RawSchemaUnsupportedKeywordData::class))
+        ->getAttributes(RawSchema::class)[0]
+        ->newInstance();
+
+    $schema = explicitClassSchema()->toSchema($attribute, new ReflectionClass(RawSchemaUnsupportedKeywordData::class));
+
+    // The `if` keyword is gone, and the surviving body validates on both swagger-php majors.
+    expect($schema->validate())->toBeTrue();
+});
+
+it('reports unsupported keywords without touching the supported set', function (): void {
+    $unsupported = ExplicitClassSchema::unsupportedKeywords([
+        'type' => 'object',
+        'oneOf' => [],
+        'x-vendor' => true,
+        'if' => [],
+        'dependentRequired' => [],
+        'dependencies' => [],
+    ]);
+
+    expect($unsupported)->toBe(['if', 'dependentRequired', 'dependencies']);
+});

--- a/tests/Unit/Support/Generator/SchemaFromArrayDefinitionTest.php
+++ b/tests/Unit/Support/Generator/SchemaFromArrayDefinitionTest.php
@@ -46,3 +46,28 @@ it('leaves non-array nodes without items', function (): void {
 
     expect(Generator::isDefault($schema->items))->toBeTrue();
 });
+
+it('converts oneOf/anyOf/allOf members into OA\Schema graphs that validate', function (): void {
+    $schema = SchemaFromArrayDefinition::build([
+        'oneOf' => [
+            ['type' => 'object', 'properties' => ['a' => ['type' => 'string']]],
+            ['type' => 'string'],
+        ],
+    ]);
+
+    expect($schema->oneOf)->toHaveCount(2)
+        ->and($schema->oneOf[0])->toBeInstanceOf(OA\Schema::class)
+        ->and($schema->oneOf[0]->properties[0])->toBeInstanceOf(OA\Property::class)
+        ->and($schema->oneOf[1])->toBeInstanceOf(OA\Schema::class)
+        ->and($schema->validate())->toBeTrue();
+});
+
+it('converts not into a nested OA\Schema that validates', function (): void {
+    $schema = SchemaFromArrayDefinition::build([
+        'not' => ['type' => 'string'],
+    ]);
+
+    expect($schema->not)->toBeInstanceOf(OA\Schema::class)
+        ->and($schema->not->type)->toBe('string')
+        ->and($schema->validate())->toBeTrue();
+});


### PR DESCRIPTION
Closes #344

## Scope: ship the full body-replacement mechanism; defer only the *secondary* conflict-lint

B genuinely bundles six things: (1) the `#[Schema]` attribute, (2) a shared literal-schema
builder + keyword validation, (3) inference-skip wiring in **three** plugin `buildSchema()` loci,
(4) the `schema.raw-keyword-unsupported` lint guardrail, (5) the class-`#[Schema]`-vs-field-attribute
**precedence**, (6) a *second* lint rule warning about ignored field attributes
(`schema.class-attribute-conflicts-with-field-attributes`).

The **minimal honest first slice = (1)–(5)**. That is the complete, usable feature: the attribute
replaces the inferred body, keywords are validated honestly, and the precedence is *implemented*
(class `#[Schema]` wins — the early return skips all field-attribute reads, so there is no silent
half-merge). The only deferred piece is **(6)**, the *cosmetic* lint that warns "you put
`#[ResponseField]` on a class that also has `#[Schema]`; the field attributes are ignored." That's a
nicety, not correctness — the behaviour is already correct and documented without it. Deferring it
keeps this PR to one reviewable mechanism + one lint rule. **(6) → follow-up issue** (file it after).

Rationale for not slicing thinner: the three inference-skips can't be split (a `#[Schema]` that only
works on Spatie Data but silently keeps inferring for resources/form-requests would be the dishonest
capability the parent issue warns against). And the keyword guardrail (4) must ship *with* the
attribute — emitting `#[Schema(['if' => …])]` that silently drops `if` is exactly the trap #336
Guardrail 2 exists to prevent. So (1)–(5) are one coherent, indivisible mechanism.

## Tier & boundary

Tier-2 → attribute. `#[Schema]` supplies a literal body the inference genuinely cannot derive — a
healthy attribute. Boundary vs. `openapi.overrides` (per #336 Guardrail 1): `#[Schema]` is
**co-located with the class, replaces its component body, travels with refactors**; `overrides` is
**document-level, operation-targeted** (it can't even address a component schema body). Different
locus, no overlap. Boundary vs. SwaggerPhp harvester (#17): the harvester ingests hand-authored
`#[OA\Schema]` annotations wholesale; `#[Schema]` is a *first-party* terse knob scoped to the
validated keyword set — complementary, not a replacement (note in docs).

## Seam placement (the cross-cutting concern the lead flagged)

The inference-skip must be **consistent across the three plugins without leaking plugin-specifics
into `Support/`**. Solution: one plugin-agnostic helper in `Support/` that does only reflection +
array→`OA\Schema` + keyword validation — no plugin types touched.

- **New:** `src/Support/Generator/ExplicitClassSchema.php` (or similar) — `@internal`. Static/simple
  methods: `read(ReflectionClass): ?Schema` (returns the parsed `#[Schema]` attribute instance or
  null) and `toSchema(Schema $attr): OA\Schema` (builds the literal `OA\Schema`, applying the
  validated keyword set). This is pure infra (reflection + swagger-php), so `Support/` is correct
  per the seam rules — it does **not** depend on any plugin.
- Each plugin's `private buildSchema()` gains an **early-return branch at the very top**, mirroring
  the existing `#[Discriminator]` early-return precedent already in
  `SchemaFromDataClass::buildSchema()` (`:121-140`):
  ```
  if (($explicit = ExplicitClassSchema::read($reflection)) !== null) {
      return ExplicitClassSchema::toSchema($explicit);
  }
  ```
  Loci (all confirmed same shape — reflect class, then build; all wrapped by
  `registry->buildOnce()`):
  - `src/Plugins/SpatieData/Support/SchemaFromDataClass.php::buildSchema()` (`:115`)
  - `src/Plugins/ApiResources/Support/SchemaFromResource.php::buildSchema()` (`:163`)
  - `src/Plugins/Core/Support/SchemaFromFormRequest.php::buildSchema()` (`:88`)
  Each plugin keeps its own reflection/registry glue; the shared helper carries the
  plugin-agnostic literal-schema logic. No plugin-specifics in `Support/`.

The `#[Schema]` attribute itself lives in `src/Attributes/Schema.php` (the general package — it's
not plugin-specific; all three plugins honor it).

## The keyword boundary (verified against swagger-php)

`OA\Schema` (via `Schema.php` + `JsonSchemaTrait.php`) **models** (safe to accept): `type`, `enum`,
`const`, `not`, `allOf`/`anyOf`/`oneOf`, `properties`, `required`, `additionalProperties`,
`patternProperties`, `propertyNames`, `contains`, `minimum`/`maximum`/`exclusiveMinimum`/
`exclusiveMaximum`, `multipleOf`, `minLength`/`maxLength`, `pattern`, `minItems`/`maxItems`,
`uniqueItems`, `default`, `title`, `description`, `format`, `dependencies`, plus `x-*` (via `$x`).
It does **NOT model** (the #140 wall — must reject, not drop): `if`, `then`, `else`,
`dependentRequired`, `dependentSchemas`. Maintain the accepted set as a `const` allowlist on the
helper (single source of truth, also consumed by the lint rule).

## The `schema.raw-keyword-unsupported` lint rule

- **id:** `schema.raw-keyword-unsupported`; **severity:** level 1 (error) — emitting a `#[Schema]`
  with a keyword the serializer drops produces a silently-wrong spec, the dishonest-capability case
  the guardrail targets. (Confirm 1 vs 3 in review; I lean 1 because it's silent data loss.)
- **What it flags:** a `#[Schema]` whose keyword array contains any key outside the helper's
  accepted allowlist. **fixHint:** "swagger-php cannot serialize `<keyword>`; remove it or express
  the shape with a supported keyword (see docs). Arbitrary keywords await the IR (#189)."
- **Shape:** mirror `OverridesUnknownField` (a `Rule` reading the parsed attribute; pick the visitor
  that reaches component schemas / class attributes — likely a class/operation visitor that can
  resolve the payload class, same traversal `MultipartFileWithoutMultipart` uses). Registered in
  `BaselineRegistration` (it's plugin-agnostic config-level infra — the rule keys off the attribute,
  not a plugin) **or** per the existing lint-registration convention; confirm during impl which
  registration path keeps it plugin-agnostic.
- **docs/linting.md** — add the catalog row between the `lint-rule-catalog` markers (hand-maintained
  per CLAUDE.md; `--list` is the live source).
- **Degrade-at-build:** independently of the lint rule, `ExplicitClassSchema::toSchema()` should
  **drop unsupported keys and log** (matching the library's "degrade gracefully + log" philosophy,
  e.g. the `EloquentModelToSchema`/`RequestBodyExtractor` precedent) so a non-linted run still
  produces a valid document rather than a swagger-php hard-fail. Lint surfaces it; the builder
  survives it.

## Conflict precedence (design question — RESOLVED)

**Class-level `#[Schema]` wins; field attributes on that class are ignored.** This falls out of the
early-return: `buildSchema()` returns the literal schema before any property/field-attribute pass
runs, so there is no merge and no ambiguity. Documented as the contract. The **warning** that field
attributes were ignored (`schema.class-attribute-conflicts-with-field-attributes`) is the deferred
secondary lint (follow-up issue) — the *behaviour* is defined and correct now; only the advisory
nudge is deferred.

## Plan (TDD — failing tests first)

### 1. Tests first

- **Unit (`tests/Unit/Support/Generator/ExplicitClassSchemaTest.php`):** `read()` returns the
  attribute when present, null otherwise; `toSchema(['type'=>'object','required'=>['a'],
  'properties'=>[...]])` → correct `OA\Schema`; an `oneOf`/`const`/`not` keyword survives; an
  unsupported `if` key is dropped + logged (assert it's absent from output).
- **Feature, per plugin (the indivisible three):** a Spatie Data class, a JsonResource, and a
  FormRequest each carrying `#[Schema([...])]` → the component schema is the literal body, and
  **inference is skipped** (e.g. a property the class would otherwise infer is absent because the
  literal body omits it). One feature test per locus to prove all three honor it.
- **Precedence:** a class with both `#[Schema([...])]` and `#[ResponseField]`/`#[ResourceField]` on
  members → the literal `#[Schema]` wins, field attributes have no effect.
- **Composition keywords:** `#[Schema(['oneOf' => [...]])]` round-trips (guards the #336 "don't
  silently drop oneOf/anyOf/allOf" honesty).
- **Lint rule:** `#[Schema(['if' => [...]])]` → `schema.raw-keyword-unsupported` finding with the
  offending keyword; a fully-supported `#[Schema]` → no finding.
- **Negative:** no `#[Schema]` → inference proceeds exactly as today (regression guard for all three
  plugins).

### 2–4. Implement

- `src/Attributes/Schema.php` — `#[Attribute(Attribute::TARGET_CLASS)]`, `final readonly`,
  constructor `(array $schema)` (PHPDoc the accepted shape; reference the allowlist). Docblock states
  "replaces the inferred component body; keywords bounded to what swagger-php serializes."
- `src/Support/Generator/ExplicitClassSchema.php` — the helper + accepted-keyword `const` allowlist
  + degrade-and-log.
- The three early-return branches (above).
- The lint rule + `BaselineRegistration`/lint registration + `docs/linting.md` row.

### 5. Bookkeeping

- `docs/attributes.md` (+ `docs/README.md` index if a section is added) — document `#[Schema]`, the
  accepted-keyword boundary, precedence over field attributes, and the boundary vs. `overrides` /
  the SwaggerPhp harvester.
- `CHANGELOG.md [Unreleased]` — **Added:** class-level `#[Schema]` body replacement + the
  `schema.raw-keyword-unsupported` lint rule.

### Files

- *New:* `src/Attributes/Schema.php`, `src/Support/Generator/ExplicitClassSchema.php`,
  the lint rule under `src/Lint/Rules/`, tests + fixtures.
- *Modified:* the three plugin `buildSchema()` loci, `BaselineRegistration` (or the lint registry),
  `docs/attributes.md`, `docs/linting.md`, `docs/README.md` (maybe), `CHANGELOG.md`.

No `src/Contracts/**` change, no config key, no stage-order change, no host-app runtime mutation.

## Deferred follow-up (file after this PR)

`schema.class-attribute-conflicts-with-field-attributes` — a level-3 advisory that field attributes
on a `#[Schema]`-bearing class are dead. Behaviour is already correct (they're ignored); this is the
nudge that tells the author. Own small issue.

## Controversial / escalation flags (escalation-bound: new public attribute, area:core + area:plugins)

1. **New public authoring symbol** `#[Schema]` + a new lint rule → human gate. Lands
   ready-but-escalated for Moritz. Expected — the lead pre-flagged it.
2. **Cross-cutting three-plugin change** — touches all three extraction backends. Mitigated by the
   shared `Support/` helper (one logic locus; plugins only add an early return) and the per-plugin
   feature tests. Still, it's the broadest blast radius of the batch → call out for careful review.
3. **Accepted-keyword allowlist + lint severity (1 vs 3)** — one judgement call; recommend level 1
   (silent data loss). Confirm in review.
4. **Naming:** `#[Schema]` is a common word and collides conceptually with swagger-php's
   `OA\Schema`. Confirm the maintainer wants this exact name (the issue specifies it) vs. e.g.
   `#[RawSchema]`/`#[SchemaBody]` to avoid import confusion. Flag, don't decide.

All are surface/design questions for the human gate, not implementation risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)