### PR TITLE
feat(#31): pagination query params from ->paginate() body scan (Tier-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project are documented here.
 - `#[CookieParam]` authoring attribute documenting an `in: cookie` parameter read off the request at runtime. (#335)
 - `x:` vendor-extension passthrough on the field attributes (`#[ResponseField]`, `#[RequestField]`, `#[QueryParam]`, `#[PathParam]`, `#[CookieParam]`): attach `x-*` specification extensions to a field's schema, co-located with the field (the field-level analogue of `openapi.overrides`). (#336)
 - `additionalProperties:` override on the field attributes (`#[ResponseField]`, `#[RequestField]`, `#[QueryParam]`, `#[PathParam]`): set a field's map behaviour to a bool or a typed value schema; applied last, it wins over inferred `array<string, T>` map values. (#345)
+- Pagination query parameters from a `->paginate()`/`->simplePaginate()`/`->cursorPaginate()` body call (Tier-1): offset paginators emit `page`/`per_page`, cursor paginators emit `cursor`; an explicit `#[QueryParam]` wins for its name. (#31)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -421,9 +421,9 @@ public function feed(): CursorPaginator          // → cursor
   `?per_page=` idiom rather than a framework default; it is documented for the
   offset case.
 - `cursorPaginate()` emits an optional `string` `cursor` parameter.
-- The call is matched only on the dominant (unconditional) return path, looking
-  through chains like `->paginate()->withQueryString()`. A paginate call hidden
-  behind an `if`/ternary is not treated as the operation's shape.
+- The first unconditional `paginate()`-family call is matched, looking through
+  chains like `->paginate()->withQueryString()`. A call behind an `if`/ternary
+  is not treated as the operation's shape.
 - These compose with the accessor/validation parameters above, and an explicit
   `#[QueryParam('page')]` wins entirely for its name — annotate it when the page
   knob needs a description or different constraints.

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -399,6 +399,35 @@ Boundaries, by design (no dataflow analysis):
 - An explicit `#[QueryParam]` wins **entirely** for its name (no merging);
   parameters from different sources with different names compose.
 
+### Pagination parameters
+
+The same bounded scan recognises a `paginate()`-family call in the first 10
+top-level statements and documents the pagination knob it implies:
+
+```php
+public function index(): LengthAwarePaginator    // → page, per_page
+{
+    return Article::query()->paginate();
+}
+
+public function feed(): CursorPaginator          // → cursor
+{
+    return Article::query()->cursorPaginate();
+}
+```
+
+- `paginate()` and `simplePaginate()` (offset pagination) emit `page` and
+  `per_page` — both optional `integer`, `minimum: 1`. `per_page` is the common
+  `?per_page=` idiom rather than a framework default; it is documented for the
+  offset case.
+- `cursorPaginate()` emits an optional `string` `cursor` parameter.
+- The call is matched only on the dominant (unconditional) return path, looking
+  through chains like `->paginate()->withQueryString()`. A paginate call hidden
+  behind an `if`/ternary is not treated as the operation's shape.
+- These compose with the accessor/validation parameters above, and an explicit
+  `#[QueryParam('page')]` wins entirely for its name — annotate it when the page
+  knob needs a description or different constraints.
+
 ## Controller middleware
 
 Everywhere the generator reads a route's middleware — security requirements,

--- a/examples/api-resources/openapi.yaml
+++ b/examples/api-resources/openapi.yaml
@@ -15,7 +15,21 @@ paths:
       summary: 'List flights.'
       description: "Returns a paginated collection of all known flights wrapped in the\nstandard JsonResource `{data, links, meta}` envelope."
       operationId: get_api_flights
-      parameters: []
+      parameters:
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
           description: OK
@@ -60,7 +74,21 @@ paths:
       summary: 'List bookings.'
       description: "The signature only says `AnonymousResourceCollection` — the generator reads\nthe `BookingResource::collection(...)` return expression to resolve the item\nresource, and the `paginate()` call to pick the `{data, links, meta}`\nenvelope. No `#[ResponseResource]` needed."
       operationId: get_api_bookings
-      parameters: []
+      parameters:
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
           description: OK

--- a/examples/combined/openapi.yaml
+++ b/examples/combined/openapi.yaml
@@ -17,6 +17,20 @@ paths:
       operationId: get_api_flights
       parameters:
         -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
           name: 'filter[number]'
           in: query
           required: false

--- a/examples/form-requests/openapi.yaml
+++ b/examples/form-requests/openapi.yaml
@@ -17,6 +17,20 @@ paths:
       operationId: get_api_flights
       parameters:
         -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
           name: X-Request-Id
           in: header
           description: 'Optional client-supplied correlation id echoed back on every response.'

--- a/examples/fractal/openapi.yaml
+++ b/examples/fractal/openapi.yaml
@@ -15,7 +15,21 @@ paths:
       summary: 'List flights.'
       description: "Returns a paginated collection wrapped in Fractal's `{data, meta.pagination}`\nenvelope."
       operationId: get_api_flights
-      parameters: []
+      parameters:
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
           description: OK

--- a/examples/query-builder/openapi.yaml
+++ b/examples/query-builder/openapi.yaml
@@ -17,6 +17,20 @@ paths:
       operationId: get_api_flights
       parameters:
         -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
           name: 'filter[number]'
           in: query
           required: false

--- a/examples/spatie-data/openapi.yaml
+++ b/examples/spatie-data/openapi.yaml
@@ -18,7 +18,21 @@ paths:
         description: 'Public API reference'
         url: 'https://example.com/docs/flights'
       operationId: get_api_flights
-      parameters: []
+      parameters:
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
           description: OK

--- a/src/Enums/PaginatorKind.php
+++ b/src/Enums/PaginatorKind.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 
 use function is_a;
+use function strtolower;
 
 /**
  * The three Laravel paginator shapes, distinguished by the metadata each serializes via its
@@ -45,6 +46,21 @@ enum PaginatorKind
             is_a($class, LengthAwarePaginator::class, allow_string: true),
             is_a($class, self::SPATIE_PAGINATED_DATA_COLLECTION, allow_string: true) => self::LengthAware,
             is_a($class, Paginator::class, allow_string: true) => self::Simple,
+            default => null,
+        };
+    }
+
+    /**
+     * Maps a paginating builder method to its paginator kind, or null when the (lowercased) name
+     * is not a paginate-family call: `paginate` → length-aware, `simplePaginate` → simple,
+     * `cursorPaginate` → cursor. The canonical method-name mapping, sibling to {@see fromClass}.
+     */
+    public static function fromPaginatingMethod(string $method): ?self
+    {
+        return match (strtolower($method)) {
+            'paginate' => self::LengthAware,
+            'simplepaginate' => self::Simple,
+            'cursorpaginate' => self::Cursor,
             default => null,
         };
     }

--- a/src/Plugins/Core/CorePlugin.php
+++ b/src/Plugins/Core/CorePlugin.php
@@ -24,6 +24,7 @@ use Radiergummi\OpenApi\Plugins\Core\Resolvers\EloquentModelResponseResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\FormRequestRequestSchemaResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\InlineJsonResponseResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\InlineValidationRequestSchemaResolver;
+use Radiergummi\OpenApi\Plugins\Core\Resolvers\PaginationQueryParameterResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\PaginatorResponseResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\RequestFieldRequestSchemaResolver;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\ResourceConventionResolver;
@@ -61,6 +62,10 @@ final class CorePlugin implements Plugin
         // Tier-0 miss — actions whose signature carries no typed payload parameter.
         $registry->addRequestSchemaResolver(InlineValidationRequestSchemaResolver::class);
         $registry->addQueryParameterResolver(CoreQueryParameterResolver::class);
+
+        // Runs after the core resolver so an explicit #[QueryParam('page')] keeps its emission via
+        // OperationBuilder's (name, in) dedup; otherwise page/per_page/cursor simply compose.
+        $registry->addQueryParameterResolver(PaginationQueryParameterResolver::class);
         $registry->addPrimaryResponseResolver(PaginatorResponseResolver::class);
         $registry->addPrimaryResponseResolver(EloquentModelResponseResolver::class);
 

--- a/src/Plugins/Core/Resolvers/PaginationQueryParameterResolver.php
+++ b/src/Plugins/Core/Resolvers/PaginationQueryParameterResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Core\Resolvers;
+
+use OpenApi\Annotations as OA;
+use Override;
+use Radiergummi\OpenApi\Contracts\Registry\QueryParameterResolver;
+use Radiergummi\OpenApi\Enums\PaginatorKind;
+use Radiergummi\OpenApi\Plugins\Core\Support\PaginatorCallReader;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+
+/**
+ * Emits the conventional pagination query parameters for an action that calls a `paginate()`-family
+ * method (Tier-1 body scan via {@see PaginatorCallReader}, issue #31).
+ *
+ * Offset paginators (`paginate()`, `simplePaginate()`) advertise `page` and `per_page`; a cursor
+ * paginator (`cursorPaginate()`) advertises `cursor`. `per_page` is the common `?per_page=` idiom
+ * rather than a framework default, documented for the offset case. All three are optional.
+ *
+ * Registered after {@see CoreQueryParameterResolver}; `OperationBuilder` dedups by `(name, in)` and
+ * keeps an explicit `#[QueryParam]` over resolver output, so a hand-declared `page` wins.
+ */
+final readonly class PaginationQueryParameterResolver implements QueryParameterResolver
+{
+    public function __construct(private PaginatorCallReader $reader) {}
+
+    /**
+     * @return list<OA\Parameter>
+     */
+    #[Override]
+    public function resolveQueryParameters(ActionDescriptor $descriptor): array
+    {
+        $method = $descriptor->method;
+
+        if ($method === null) {
+            return [];
+        }
+
+        $kind = $this->reader->detect($method);
+
+        if ($kind === null) {
+            return [];
+        }
+
+        return match ($kind) {
+            PaginatorKind::Cursor => [$this->cursorParameter()],
+            PaginatorKind::LengthAware, PaginatorKind::Simple => $this->offsetParameters(),
+        };
+    }
+
+    /**
+     * @return list<OA\Parameter>
+     */
+    private function offsetParameters(): array
+    {
+        return [
+            $this->integerParameter('page'),
+            $this->integerParameter('per_page'),
+        ];
+    }
+
+    private function integerParameter(string $name): OA\Parameter
+    {
+        return new OA\Parameter([
+            'name' => $name,
+            'in' => 'query',
+            'required' => false,
+            'schema' => new OA\Schema(['type' => 'integer', 'minimum' => 1]),
+        ]);
+    }
+
+    private function cursorParameter(): OA\Parameter
+    {
+        return new OA\Parameter([
+            'name' => 'cursor',
+            'in' => 'query',
+            'required' => false,
+            'schema' => new OA\Schema(['type' => 'string']),
+        ]);
+    }
+}

--- a/src/Plugins/Core/Support/PaginatorCallReader.php
+++ b/src/Plugins/Core/Support/PaginatorCallReader.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Core\Support;
+
+use Illuminate\Container\Attributes\Scoped;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use Radiergummi\OpenApi\Enums\PaginatorKind;
+use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
+use ReflectionMethod;
+
+/**
+ * Detects a `paginate()`-family call in a controller action body — the Tier-1 bounded scan behind
+ * pagination query parameters (issue #31).
+ *
+ * Scans the first {@see self::STATEMENT_LIMIT} top-level statements under
+ * {@see ConditionalContextPolicy::SkipConditionalContexts}: a paginate call is the dominant return
+ * path of a listing action, not a guarded branch, so a call hidden behind an `if`/ternary is not
+ * treated as the operation's shape. The first method or static call whose lowercased name maps via
+ * {@see PaginatorKind::fromPaginatingMethod()} decides the kind; anything else (no paginate call,
+ * an unreadable or closure body) returns null and the operation advertises no pagination knob.
+ *
+ * @internal
+ */
+#[Scoped]
+final readonly class PaginatorCallReader
+{
+    private const int STATEMENT_LIMIT = 10;
+
+    private StatementNodeFinder $statementNodeFinder;
+
+    public function __construct(private MethodBodyScanner $scanner)
+    {
+        $this->statementNodeFinder = new StatementNodeFinder();
+    }
+
+    public function detect(ReflectionMethod $method): ?PaginatorKind
+    {
+        $statements = $this->scanner->firstStatements($method, self::STATEMENT_LIMIT);
+
+        $call = $this->statementNodeFinder->findFirst(
+            $statements,
+            ConditionalContextPolicy::SkipConditionalContexts,
+            static function (Node $node): bool {
+                $name = match (true) {
+                    $node instanceof MethodCall,
+                    $node instanceof StaticCall => $node->name,
+                    default => null,
+                };
+
+                return $name instanceof Identifier
+                    && PaginatorKind::fromPaginatingMethod($name->toString()) !== null;
+            },
+        );
+
+        if (!$call instanceof MethodCall && !$call instanceof StaticCall) {
+            return null;
+        }
+
+        // The predicate only matches an Identifier name, but its narrowing is invisible here.
+        return $call->name instanceof Identifier
+            ? PaginatorKind::fromPaginatingMethod($call->name->toString())
+            : null;
+    }
+}

--- a/src/Plugins/Core/Support/PaginatorCallReader.php
+++ b/src/Plugins/Core/Support/PaginatorCallReader.php
@@ -20,11 +20,12 @@ use ReflectionMethod;
  * pagination query parameters (issue #31).
  *
  * Scans the first {@see self::STATEMENT_LIMIT} top-level statements under
- * {@see ConditionalContextPolicy::SkipConditionalContexts}: a paginate call is the dominant return
- * path of a listing action, not a guarded branch, so a call hidden behind an `if`/ternary is not
- * treated as the operation's shape. The first method or static call whose lowercased name maps via
- * {@see PaginatorKind::fromPaginatingMethod()} decides the kind; anything else (no paginate call,
- * an unreadable or closure body) returns null and the operation advertises no pagination knob.
+ * {@see ConditionalContextPolicy::SkipConditionalContexts}: the first method or static call whose
+ * lowercased name maps via {@see PaginatorKind::fromPaginatingMethod()} decides the kind. Detection
+ * is presence-based (any unconditional statement, not only the returned expression), since in a
+ * listing action the paginate call is the operation's shape rather than a guarded branch — so a
+ * call hidden behind an `if`/ternary is not matched. Anything else (no paginate call, an unreadable
+ * or closure body) returns null and the operation advertises no pagination knob.
  *
  * @internal
  */

--- a/tests/Feature/PaginatorResponseTest.php
+++ b/tests/Feature/PaginatorResponseTest.php
@@ -10,7 +10,9 @@ use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Attributes\QueryParam;
 use Radiergummi\OpenApi\Attributes\ResponseResource;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
 
 uses()->group('openapi');
 
@@ -26,7 +28,7 @@ class PaginatorDocblockController extends Controller
     /**
      * List widgets.
      *
-     * @return LengthAwarePaginatorContract<PaginatedWidget>
+     * @return LengthAwarePaginatorContract<Author>
      */
     public function index(): LengthAwarePaginatorContract
     {
@@ -58,11 +60,34 @@ class CursorPaginatorController extends Controller
     /**
      * Stream widgets.
      *
-     * @return CursorPaginatorContract<PaginatedWidget>
+     * @return CursorPaginatorContract<Author>
      */
     public function index(): CursorPaginatorContract
     {
         return new CursorPaginator([], 15);
+    }
+}
+
+/**
+ * Body-scan fixtures: the `->paginate()`-family call in the body drives the pagination query
+ * parameters. Actions are never invoked.
+ */
+class PaginateBodyController extends Controller
+{
+    public function offset(): LengthAwarePaginatorContract
+    {
+        return Author::query()->paginate(15);
+    }
+
+    public function cursor(): CursorPaginatorContract
+    {
+        return Author::query()->cursorPaginate(15);
+    }
+
+    #[QueryParam('page', description: 'Authored page knob.')]
+    public function authoredPage(): LengthAwarePaginatorContract
+    {
+        return Author::query()->paginate(15);
     }
 }
 
@@ -110,4 +135,59 @@ it('documents a cursor paginator with cursor metadata', function (): void {
     expect($schema)->not->toBeNull()
         ->and($schema['properties'])->toHaveKeys(['data', 'next_cursor', 'prev_cursor'])
         ->and($schema['properties'])->not->toHaveKey('total');
+});
+
+/**
+ * @return array<string, array<string, mixed>>
+ */
+function paginationParametersByName(array $operation): array
+{
+    $byName = [];
+
+    foreach ($operation['parameters'] ?? [] as $parameter) {
+        if (($parameter['in'] ?? null) === 'query') {
+            $byName[$parameter['name']] = $parameter;
+        }
+    }
+
+    return $byName;
+}
+
+it('emits page and per_page for an offset-paginating body', function (): void {
+    Route::get('/paginate/offset', [PaginateBodyController::class, 'offset']);
+
+    $operation = generateSpec()['paths']['/paginate/offset']['get'];
+    $parameters = paginationParametersByName($operation);
+
+    expect($parameters)->toHaveKeys(['page', 'per_page'])
+        ->and($parameters)->not->toHaveKey('cursor')
+        ->and($parameters['page']['required'])->toBeFalse()
+        ->and($parameters['page']['schema']['type'])->toBe('integer')
+        ->and($parameters['page']['schema']['minimum'])->toBe(1)
+        ->and($parameters['per_page']['schema']['type'])->toBe('integer');
+});
+
+it('emits cursor for a cursor-paginating body and omits offset params', function (): void {
+    Route::get('/paginate/cursor', [PaginateBodyController::class, 'cursor']);
+
+    $operation = generateSpec()['paths']['/paginate/cursor']['get'];
+    $parameters = paginationParametersByName($operation);
+
+    expect($parameters)->toHaveKey('cursor')
+        ->and($parameters)->not->toHaveKeys(['page', 'per_page'])
+        ->and($parameters['cursor']['schema']['type'])->toBe('string');
+});
+
+it('lets an explicit #[QueryParam(page)] win over the inferred page', function (): void {
+    Route::get('/paginate/authored', [PaginateBodyController::class, 'authoredPage']);
+
+    $operation = generateSpec()['paths']['/paginate/authored']['get'];
+    $pageParameters = array_filter(
+        $operation['parameters'] ?? [],
+        static fn(array $parameter): bool
+            => ($parameter['name'] ?? null) === 'page' && ($parameter['in'] ?? null) === 'query',
+    );
+
+    expect($pageParameters)->toHaveCount(1)
+        ->and(reset($pageParameters)['schema']['description'] ?? null)->toBe('Authored page knob.');
 });

--- a/tests/Unit/Core/Pagination/PaginationQueryParameterResolverTest.php
+++ b/tests/Unit/Core/Pagination/PaginationQueryParameterResolverTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Core\Pagination;
+
+use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Plugins\Core\Resolvers\PaginationQueryParameterResolver;
+use Radiergummi\OpenApi\Plugins\Core\Support\PaginatorCallReader;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
+
+uses()->group('openapi');
+
+/**
+ * Parse-only fixture; actions are never invoked.
+ */
+class PaginationResolverFixtureController
+{
+    public function offset(): mixed
+    {
+        return Author::query()->paginate(15);
+    }
+
+    public function cursor(): mixed
+    {
+        return Author::query()->cursorPaginate(15);
+    }
+
+    public function plain(): mixed
+    {
+        return Author::query()->get();
+    }
+}
+
+/**
+ * @return list<OA\Parameter>
+ */
+function resolvePaginationParameters(string $method): array
+{
+    $resolver = new PaginationQueryParameterResolver(
+        new PaginatorCallReader(new MethodBodyScanner()),
+    );
+
+    return $resolver->resolveQueryParameters(
+        ActionDescriptorFactory::forControllerMethod(
+            PaginationResolverFixtureController::class,
+            $method,
+        ),
+    );
+}
+
+it('emits page and per_page for an offset paginator', function (): void {
+    $parameters = resolvePaginationParameters('offset');
+
+    expect($parameters)->toHaveCount(2);
+
+    $byName = [];
+
+    foreach ($parameters as $parameter) {
+        $byName[$parameter->name] = $parameter;
+    }
+
+    expect($byName)->toHaveKeys(['page', 'per_page'])
+        ->and($byName['page']->in)->toBe('query')
+        ->and($byName['page']->required)->toBeFalse()
+        ->and($byName['page']->schema->type)->toBe('integer')
+        ->and($byName['page']->schema->minimum)->toBe(1)
+        ->and($byName['per_page']->schema->type)->toBe('integer')
+        ->and($byName['per_page']->schema->minimum)->toBe(1)
+        ->and($byName['per_page']->required)->toBeFalse();
+});
+
+it('emits a single cursor parameter for a cursor paginator', function (): void {
+    $parameters = resolvePaginationParameters('cursor');
+
+    expect($parameters)->toHaveCount(1)
+        ->and($parameters[0]->name)->toBe('cursor')
+        ->and($parameters[0]->in)->toBe('query')
+        ->and($parameters[0]->required)->toBeFalse()
+        ->and($parameters[0]->schema->type)->toBe('string');
+});
+
+it('emits nothing for a non-paginating action', function (): void {
+    expect(resolvePaginationParameters('plain'))->toBe([]);
+});

--- a/tests/Unit/Core/Pagination/PaginatorCallReaderTest.php
+++ b/tests/Unit/Core/Pagination/PaginatorCallReaderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Core\Pagination;
+
+use Radiergummi\OpenApi\Enums\PaginatorKind;
+use Radiergummi\OpenApi\Plugins\Core\Support\PaginatorCallReader;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
+use ReflectionMethod;
+
+uses()->group('openapi');
+
+/**
+ * Parse-only fixture; actions are never invoked. The bodies exercise the call-shape whitelist of
+ * {@see PaginatorCallReader} — only their source matters.
+ */
+class PaginatorCallReaderFixtureController
+{
+    public function lengthAware(): mixed
+    {
+        return Author::query()->paginate(15);
+    }
+
+    public function simple(): mixed
+    {
+        return Author::query()->simplePaginate(15);
+    }
+
+    public function cursor(): mixed
+    {
+        return Author::query()->cursorPaginate(15);
+    }
+
+    public function chained(): mixed
+    {
+        return Author::query()->paginate(25)->withQueryString();
+    }
+
+    public function staticCall(): mixed
+    {
+        return Author::paginate();
+    }
+
+    public function noPaginate(): mixed
+    {
+        return Author::query()->get();
+    }
+
+    public function conditional(bool $flag): mixed
+    {
+        if ($flag) {
+            return Author::query()->paginate();
+        }
+
+        return Author::query()->get();
+    }
+}
+
+function readPaginatorCall(string $method): ?PaginatorKind
+{
+    $reader = new PaginatorCallReader(new MethodBodyScanner());
+
+    return $reader->detect(
+        new ReflectionMethod(PaginatorCallReaderFixtureController::class, $method),
+    );
+}
+
+it('detects paginate() as length-aware', function (): void {
+    expect(readPaginatorCall('lengthAware'))->toBe(PaginatorKind::LengthAware);
+});
+
+it('detects simplePaginate() as simple', function (): void {
+    expect(readPaginatorCall('simple'))->toBe(PaginatorKind::Simple);
+});
+
+it('detects cursorPaginate() as cursor', function (): void {
+    expect(readPaginatorCall('cursor'))->toBe(PaginatorKind::Cursor);
+});
+
+it('detects a chained paginate()->withQueryString() call', function (): void {
+    expect(readPaginatorCall('chained'))->toBe(PaginatorKind::LengthAware);
+});
+
+it('detects a static paginate() call', function (): void {
+    expect(readPaginatorCall('staticCall'))->toBe(PaginatorKind::LengthAware);
+});
+
+it('returns null when no paginate call is present', function (): void {
+    expect(readPaginatorCall('noPaginate'))->toBeNull();
+});
+
+it('ignores a paginate call guarded by a conditional', function (): void {
+    expect(readPaginatorCall('conditional'))->toBeNull();
+});


### PR DESCRIPTION
Closes #31

## Implementation plan — pagination query params from `->paginate()` (#31)

### Tier

**Tier 1** — a bounded AST whitelist match on a `->paginate()` / `->simplePaginate()` /
`->cursorPaginate()` call in the first N statements of the action body. No variable tracking, no
dataflow. Degrades to "no extra params" when the body isn't readable.

### Why this is needed (the gap)

`PaginatorResponseResolver` (`src/Plugins/Core/Resolvers/PaginatorResponseResolver.php:47-65`) keys
**purely off the return type** (`PaginatorKind::fromClass($returnType->getName())`). Two cases miss:

1. **Vito case (the issue's headline).** `public function index(): ResourceCollection` returning
   `Resource::collection($q->simplePaginate(25))`. The return type is the generic
   `ResourceCollection`, not a paginator, so `PaginatorResponseResolver` never fires. The
   **response envelope** here is already produced by the ApiResources plugin's
   `ReturnExpressionResourceReader` (it already detects the paginate call and sets `paginated:
   true`). What is missing is **only the query parameters** — the proof hand-added
   `#[QueryParam('page')]` to ~24 ops.
2. **Bare-paginator case.** `public function index(): LengthAwarePaginator` — the envelope *is*
   resolved today, but the operation still advertises **no `page`/`cursor` knob**.

So the load-bearing, cleanly-scoped deliverable is a **new query-parameter resolver** that emits the
pagination params from a body scan, fixing both cases at once. (See "Response-kind fallback" below
for the secondary, more invasive half of the issue.)

### Component 1 — shared paginate-call reader (Core)

**Create** `src/Plugins/Core/Support/PaginatorCallReader.php` — `#[Scoped] final readonly`, ctor
`(MethodBodyScanner $scanner)`. One public method:

```php
public function detect(ReflectionMethod $method): ?PaginatorKind
```

Scans the first `STATEMENT_LIMIT = 10` top-level statements (`MethodBodyScanner::firstStatements`)
under `ConditionalContextPolicy::SkipConditionalContexts` (a paginate call is the dominant return
path, not a guarded branch — mirror `ReturnExpressionResourceReader`, **not** `AbortErrorContributor`).
Uses `StatementNodeFinder::findFirst` for a `MethodCall`/`StaticCall` whose lowercased name is in
`['paginate', 'simplepaginate', 'cursorpaginate']`, and maps it to a `PaginatorKind`:
`paginate` → `LengthAware`, `simplePaginate` → `Simple`, `cursorPaginate` → `Cursor`.
Returns `null` when no paginate call is found or the body isn't readable.

This consolidates the call-name whitelist that currently lives **private** inside
`ReturnExpressionResourceReader` (`PAGINATING_METHODS`, `endsInPaginatingCall()`,
`src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php:100,596`). Placing the reader in
**`src/Plugins/Core/Support/`** (not `src/Support/`) respects the CLAUDE.md rule that `src/Support`
holds no plugin convention knowledge while keeping it reusable by Core. **Do not** refactor
ApiResources to consume it in this PR (surgical scope; ApiResources keeps its richer chain-walking
logic which also handles `Resource::collection($source)` wrapping). Note the duplication in the PR
body so a later issue can dedupe if desired.

Add `PaginatorKind::fromPaginatingMethod(string $method): ?self` to `src/Enums/PaginatorKind.php`
(sibling to the existing `fromClass`) so the method-name → kind mapping lives next to the class-name
mapping. Mapping: `paginate`→LengthAware, `simplepaginate`→Simple, `cursorpaginate`→Cursor.

### Component 2 — pagination query parameters (the primary deliverable)

**Create** `src/Plugins/Core/Resolvers/PaginationQueryParameterResolver.php` implementing
`Contracts\Registry\QueryParameterResolver`. `#[Scoped] final readonly`, ctor
`(PaginatorCallReader $reader)`. `resolveQueryParameters(ActionDescriptor $descriptor): array`:

- `$method = $descriptor->method`; return `[]` if null.
- `$kind = $reader->detect($method)`; return `[]` if null.
- Offset kinds (`LengthAware`, `Simple`) → emit:
  - `page` — `new OA\Parameter(['name' => 'page', 'in' => 'query', 'required' => false, 'schema' => new OA\Schema(['type' => 'integer', 'minimum' => 1])])`
  - `per_page` — `integer`, `minimum: 1`, `required: false`.
- Cursor kind → emit `cursor` — `string`, `required: false`.

**Registration** (`src/Plugins/Core/CorePlugin.php`, near line 62): add
`$registry->addQueryParameterResolver(PaginationQueryParameterResolver::class);` **after**
`CoreQueryParameterResolver`. Merge semantics are handled in `OperationBuilder` (lines 138-163):
dedup by `(name, in)`, and an explicit `#[QueryParam('page')]` already wins over resolver output
(the `$explicitQueryParameterNames` guard). So if a user hand-declares `page`, ours yields — correct.
A second pagination resolver after Core means `page`/`per_page`/`cursor` simply compose with Core's
accessor/validation-derived params; collisions on the same name are last-writer (acceptable — both
describe the same integer `page`). **Confirm** during impl that no Core source already emits a
conflicting `page` schema for these routes.

`per_page` is conventional, not framework-read by default — the issue explicitly asks for it; we
emit it for the offset case as documentation of the common `?per_page=` idiom. Keep it `required:
false`.

### Component 3 — response-kind fallback (the secondary half; flag for review)

The issue also asks the body-scan signal to "select the correct `PaginatorKind` when the `@return`
annotation alone is ambiguous." Scope this **narrowly**:

- Extend `PaginatorResponseResolver` so that **when the return type is *not* itself a paginator**
  (current early-return at `:63`) it consults `PaginatorCallReader::detect()` as a fallback kind.
  It only proceeds to build an envelope if an **item class is still derivable** (the existing
  `resolveItemClass` path: `#[ResponseResource]` or `@return Foo<Bar>` generic). With no item type
  it logs and returns null exactly as today — no behavior change for undeclared items.
- **Do not** let this override the ApiResources `{data, links, meta}` resource envelope. Ordering:
  `PaginatorResponseResolver` is registered before the ApiResources resolver? **Verify the
  primary-response resolver order** (`CorePlugin` registers Paginator at `:63`; ApiResources
  registers its own later). If Core's paginator resolver runs first and now fires on a
  `ResourceCollection` return that ApiResources would have shaped richly, that is a **regression**.
  Mitigation: gate the fallback so it only fires when the return type is a *bare paginator-less*
  type that no other resolver claims — simplest safe rule: **only fall back when there is an
  explicit `@return Foo<Bar>` generic or `#[ResponseResource]` AND the return type is not a
  ResourceCollection/Data type**. If this ordering can't be made safe surgically, **drop Component 3
  from this PR** and ship Components 1+2 (query params) alone — that already resolves the Vito case
  end-to-end, since ApiResources supplies the envelope there. Record the decision as a PR comment.

**Reviewer flag:** Component 3 touches response-resolver precedence and is the only part at risk of
regressing existing paginator/resource output. The coder should land 1+2 first (green), then attempt
3 behind its own test, and back it out if it can't be made non-regressing.

### Tests (TDD — failing test first)

**Create** `tests/Unit/Core/Pagination/PaginatorCallReaderTest.php` (`group('openapi')`): via fixture
controllers + reflection — `paginate()`→LengthAware, `simplePaginate()`→Simple,
`cursorPaginate()`→Cursor, chained `->paginate(25)->withQueryString()` still detected (outermost
non-chain call), no paginate call → null, unreadable/closure body → null.

**Create** `tests/Unit/Core/Pagination/PaginationQueryParameterResolverTest.php` (`group('openapi')`),
building descriptors via `tests/Support/ActionDescriptorFactory.php`: offset → `page`+`per_page`
(integer, minimum 1, not required); cursor → `cursor` (string, not required); non-paginating action
→ `[]`.

**Extend** `tests/Feature/PaginatorResponseTest.php` (`group('openapi')`) with end-to-end
`generateSpec()` cases:
- An offset-paginating action (bare `LengthAwarePaginator<X>` return) → operation `parameters`
  include `page` and `per_page`; envelope unchanged.
- A cursor-paginating action → `cursor` param present; offset params absent.
- The Vito shape: `@return ResourceCollection` returning `Resource::collection($q->simplePaginate())`
  (with ApiResources enabled) → `page`/`per_page` present. (If ApiResources isn't enabled in the
  default test config, assert the bare-paginator equivalent instead and note the ApiResources
  interaction is covered by the resolver unit test.)
- A `#[QueryParam('page', ...)]` hand-declared on a paginating action → the authored param wins (no
  duplicate `page`), proving the merge/dedup precedence.

If Component 3 lands: add a `tests/Feature/ExamplesTest.php` flavor or a `PaginatorResponseTest`
case for the ambiguous-`@return` → body-selected-kind path (snapshot byte-match + 3.1 validation +
lint-clean per the issue's Verify command).

### Observable changes → docs + changelog

- `CHANGELOG.md` `[Unreleased]`: "Emit `page`/`per_page` (offset) or `cursor` (cursor) query
  parameters for actions that call `->paginate()`/`->simplePaginate()`/`->cursorPaginate()`
  (Tier-1)."
- `docs/` — the query-parameter page and/or the pagination/response page (locate via
  `docs/README.md`). Document the three params and that `#[QueryParam]` overrides them.

### Controversy assessment

- **Components 1+2 (query params): non-controversial.** New Core reader + new Core resolver + one
  registration line + one enum helper. No `Contracts/**` change, no config key, no stage-order
  change, no public-signature change. Merge semantics reuse `OperationBuilder`'s existing dedup.
  Survey applies (generation-affecting).
- **Component 3 (response-kind fallback): needs human review** — it alters primary-response
  resolution and could regress ApiResources/paginator output. Flagged above; coder backs it out if
  it can't be made non-regressing. The lead should expect a human gate **iff** Component 3 is
  included; otherwise auto-merge candidate.

Verify: `vendor/bin/pest tests/Feature/PaginatorResponseTest.php tests/Feature/ExamplesTest.php tests/Unit/Core/Pagination`

🤖 Generated with [Claude Code](https://claude.com/claude-code)