### PR TITLE
chore: fix finish-pr branch-deletion ordering vs worktree

### DIFF
--- a/.claude/skills/autonomous-team/bin/finish-pr
+++ b/.claude/skills/autonomous-team/bin/finish-pr
@@ -13,13 +13,20 @@ comment="${*:-🤖 **[lead]** all gates green + non-controversial → squash-mer
 
 branch=$(gh pr view "$pr" --json headRefName --jq '.headRefName')
 
-gh pr merge "$pr" --squash --delete-branch
+# Merge first (squash). Defer branch deletion until after the worktree is gone:
+# `gh pr merge --delete-branch` cannot remove the local branch while its worktree
+# still references it, so we delete the branch explicitly below instead.
+gh pr merge "$pr" --squash
 
 root=$(git rev-parse --show-toplevel)
 slug=$(printf '%s' "$branch" | tr '/' '-')
 path="${root}/.claude/worktrees/${slug}"
 [ -d "$path" ] && git worktree remove "$path" --force
 git worktree prune
+
+# Branch is now unreferenced — delete it locally and on the remote.
+git branch -D "$branch" 2>/dev/null || true
+git push origin --delete "$branch" 2>/dev/null || true
 
 gh pr comment "$pr" --body "$comment" >/dev/null
 echo "merged + cleaned: PR #${pr} (${branch})"


### PR DESCRIPTION
## Problem

`.claude/skills/autonomous-team/bin/finish-pr` ran `gh pr merge --squash --delete-branch` **before** removing the PR branch's worktree. Git refuses to delete a local branch that a worktree still references, so every merge failed the branch-deletion step with:

```
failed to delete local branch <branch>: cannot delete branch '<branch>' used by worktree at '.claude/worktrees/<slug>'
```

This recurred on all three auto-merges of the last `/autonomous-team` run and required manual `git worktree remove` + `git branch -D` cleanup each time.

## Fix

Reorder the teardown so the branch is unreferenced before it's deleted:

1. `gh pr merge "$pr" --squash` (no `--delete-branch`).
2. Remove the worktree + `git worktree prune`.
3. Delete the branch locally (`git branch -D`) and on the remote (`git push origin --delete`), each guarded with `|| true` for idempotency.

Merging *before* any local teardown is deliberate: under `set -e`, a failed merge now aborts before the worktree is touched, leaving state intact for retry.

## Scope

Tooling-only change to one script in the autonomous-team skill. No library/`src` change. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)