### PR TITLE
ci: coverage reuses the test cell's marker to win the skip race

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,12 +239,18 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - name: Probe result marker
+      # Coverage is a pure function of the same hashed inputs as the test matrix, so it reuses the
+      # php8.4/L12 cell's marker rather than its own. That marker is written sooner (the test cells
+      # finish well before this slower instrumented run), so a PR opened right after a `main` merge
+      # no longer loses the race against coverage's own — formerly last-written — marker and re-runs
+      # the full suite for no reason. On a real code change the hash is new and unmarked → coverage
+      # runs and uploads as before. Coverage owns no marker of its own (the test job writes this one).
+      - name: Probe test result marker (identical inputs ⇒ identical coverage)
         id: marker
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: .ci-marker
-          key: coverage-${{ runner.os }}-${{ hashFiles('src/**', 'tests/**', 'config/**', 'examples/**', 'composer.json', 'composer.lock', 'phpstan.neon', 'pint.json', 'phpunit.xml', '.github/workflows/**') }}
+          key: tests-${{ runner.os }}-php8.4-l12-${{ hashFiles('src/**', 'tests/**', 'config/**', 'examples/**', 'composer.json', 'composer.lock', 'phpstan.neon', 'pint.json', 'phpunit.xml', '.github/workflows/**') }}
           lookup-only: true
       - name: Setup PHP
         if: steps.marker.outputs.cache-hit != 'true'
@@ -303,17 +309,8 @@ jobs:
         with:
           files: .cache/junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Record result marker
-        if: ${{ success() && steps.marker.outputs.cache-hit != 'true' }}
-        shell: bash
-        # language=bash
-        run: echo "${GITHUB_SHA}" > .ci-marker
-      - name: Persist result marker
-        if: ${{ success() && steps.marker.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: .ci-marker
-          key: ${{ steps.marker.outputs.cache-primary-key }}
+      # No marker save here: coverage reuses the test cell's marker (probed above) and never writes
+      # its own, so the test job remains the single writer of that key.
 
   snapshot:
     name: Snapshot (locked toolchain)


### PR DESCRIPTION
## Problem

The `Coverage` job re-runs the full instrumented suite (~106s) on PRs where coverage **cannot change** — e.g. the tooling-only #357. It's not "always on"; it **loses a timing race**.

Every job in `tests.yml` keys a result-marker cache on the same content hash of the real inputs (`src/**`, `tests/**`, `config/**`, `examples/**`, lockfile, `phpstan.neon`, `pint.json`, `phpunit.xml`, `.github/workflows/**`) and skips its heavy steps on a hit. But each job probes its **own** prefix, and coverage's marker is the **last one written** in a run (instrumented serial run ≈ 106s vs ≈ 10–60s for the matrix cells). A PR whose CI starts shortly after a `main` merge finds `main`'s fast-job markers already saved for that hash but `main`'s `coverage-<hash>` marker not yet written → coverage misses, runs the full suite, and re-saves (visible as duplicate `coverage-<hash>` cache entries).

`main` has no required status checks, so this is pure wasted minutes, not a gate.

## Fix

Coverage is a pure function of the **same** hashed inputs as the test matrix, so it now probes the **php8.4/L12 cell's `tests-…-<hash>` marker** instead of its own:

- That marker is written sooner than coverage's was, so an unchanged-input PR now skips coverage just like the other jobs — the race is gone for the no-op case.
- On a real code change the hash is new and unmarked → coverage still runs **and uploads** to Codecov as before.
- Coverage no longer writes a marker of its own, so the test job stays the single writer of that key (no cross-job key contention).

When coverage skips, no fresh Codecov upload happens for that commit — which is correct: on a no-op PR Codecov already reports `not affected` via carryforward.

## Scope

One job in `.github/workflows/tests.yml` (probe key + drop its marker-save steps). YAML validated. No change to what coverage measures or to any other job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)