### PR TITLE
chore(#354): route `ApiResources` paginate detection through `PaginatorKind` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project are documented here.
 - The query-builder chain reader sees value-object constructors wrapped in fluent modifiers, so `AllowedFilter::exact('healthy')->nullable()` is read as `filter[healthy]` instead of dropped. (#257)
 - A `findOrFail()` / `firstOrFail()` lookup in the controller body infers a 404 response, deduped against the route-model-binding 404. (#168)
 - Infer error responses from non-2xx `response()->json([...], <4xx/5xx>)` literals in the controller body (Tier-1), carrying the literal body schema inlined per operation; falls back to the configured error envelope when only the status is statically readable. (#238)
+- Internal: the API Resource return-expression reader's paginate-method whitelist now routes through the shared `PaginatorKind::fromPaginatingMethod()` enum instead of a duplicated local constant. (#354)
 
 ## [0.1.0] - 2026-05-18
 

--- a/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
+++ b/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Return_;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Radiergummi\OpenApi\Enums\PaginatorKind;
 use Radiergummi\OpenApi\Routing\ResourceTarget;
 use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
@@ -91,13 +92,6 @@ final class ReturnExpressionResourceReader
      * chain link may transform the response, so it refuses the scan.
      */
     private const array RESOURCE_PRESERVING_CHAIN_METHODS = ['additional'];
-
-    /**
-     * Method names (lowercased) whose call marks a collection source as paginated. All three
-     * envelope variants document as the dominant `{data, links, meta}` length-aware shape; its
-     * envelope properties are optional, so the simple/cursor variants' narrower meta stays valid.
-     */
-    private const array PAGINATING_METHODS = ['paginate', 'simplepaginate', 'cursorpaginate'];
 
     /**
      * Chained methods (lowercased) on a paginator that return `$this` without changing the
@@ -614,7 +608,7 @@ final class ReturnExpressionResourceReader
         };
 
         return $name instanceof Identifier
-            && in_array($name->toLowerString(), self::PAGINATING_METHODS, true);
+            && PaginatorKind::fromPaginatingMethod($name->toString()) !== null;
     }
 
     /**


### PR DESCRIPTION
## Implementation plan — #354

### What & why

Remove the duplicated paginate-method whitelist in ApiResources' `ReturnExpressionResourceReader` by routing its detected call-name through the canonical `PaginatorKind::fromPaginatingMethod()` helper. After this, the call-name → kind authority lives in exactly one place even though each reader still detects its own call shape (a shared reader is **out of scope** — PR #350's plan-review already accepted the surgical per-plugin readers; CLAUDE.md forbids `src/Support/` holding plugin convention knowledge, and Core must not import ApiResources).

### Tier

No tier change. This is a **pure refactor** of an existing Tier-1 bounded-scan reader. No behaviour change, no new inference.

### No cross-plugin-import concern

`PaginatorKind::fromPaginatingMethod(string $method): ?self` lives at `src/Enums/PaginatorKind.php` in the **shared** `Radiergummi\OpenApi\Enums` namespace — **not** in `Plugins\Core`. ApiResources importing it is fine; it does not violate the no-cross-plugin-import rule. (`ReturnExpressionResourceReader` already lives under `Plugins\ApiResources\Support\`.)

The enum helper lowercases internally (`strtolower($method)`), which matches the reader's current `toLowerString()` comparison — so the behaviour is byte-identical.

### Files to modify

`src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php`:

1. Add `use Radiergummi\OpenApi\Enums\PaginatorKind;` to the imports.
2. Delete the `PAGINATING_METHODS` const (line ~100, with its docblock).
3. In `endsInPaginatingCall()` (line ~596), change the final return from:
   ```php
   return $name instanceof Identifier
       && in_array($name->toLowerString(), self::PAGINATING_METHODS, true);
   ```
   to:
   ```php
   return $name instanceof Identifier
       && PaginatorKind::fromPaginatingMethod($name->toString()) !== null;
   ```
   (Pass `toString()`, not `toLowerString()` — the enum helper lowercases itself; keeping the reader's own lowercasing would be redundant. Either works; `toString()` reads cleaner since the normalization now belongs to the enum.)

**Do NOT drop the `in_array` import** — it is still used at lines 258, 513, 566, and 601 (`PAGINATOR_PRESERVING_CHAIN_METHODS` chain-walk and other whitelists). Only the `PAGINATING_METHODS` *usage* of `in_array` goes away. The `PAGINATOR_PRESERVING_CHAIN_METHODS` const stays — it is unrelated chain-walking the enum does not model.

### Tests — regression surface (no new tests needed; this is a behaviour-preserving refactor)

The existing suite already pins the detection paths the refactor touches. The coder must keep these green (they ARE the verification):

`tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php`:
- `staticModelPaginate` → `paginate()` marks paginated (`paginated === true`).
- `simplePaginated` → `simplePaginate()` marks paginated.
- `paginatedWithQueryString` → `paginate()->withQueryString()` (chain-walk + paginate detection).
- `paginatedWithNonWhitelistedTrailingCall` → `paginate()->through(...)` NOT paginated (the non-whitelisted trailing call hides the evidence → `paginated === false`).
- `docblockToResourceCollectionPaginated` → `paginate()->toResourceCollection(...)` paginated.

`tests/Feature/Plugins/ApiResources/ReturnExpressionResolutionTest.php`:
- paginated vs. unpaginated collection envelope (`{data, links, meta}` vs `{data}`).

These cover all three paginate-family verbs plus the chain-walk and the negative (non-paginated) path. The `cursorPaginate` verb is exercised by the enum's own unit coverage and the Core reader; ApiResources detection of `cursorpaginate` flows through the same `endsInPaginatingCall` branch, so the three explicit cases above are sufficient regression for this reader.

### Verification

```
vendor/bin/pest tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php \
                tests/Feature/Plugins/ApiResources/ReturnExpressionResolutionTest.php
composer test        # full suite
vendor/bin/pint --test
composer lint        # PHPStan level 8
```

### Docs / CHANGELOG

No observable behaviour change → **no `docs/` page update**. Add a `CHANGELOG.md [Unreleased]` entry under a "Changed" (internal/refactor) note, e.g.:
> Internal: ApiResources' `ReturnExpressionResourceReader` now derives paginate-call detection > from the shared `PaginatorKind::fromPaginatingMethod()` helper instead of a private whitelist.

(Optional — it is an internal-only change; include it for traceability since CLAUDE.md asks for an `[Unreleased]` entry on behaviour changes. The coder may judge it too trivial; if so, skip and note that in the PR.)

### Survey gate

This is **generation-affecting** (area:core/plugins, pagination detection), so the survey gate WILL run. The change is behaviour-preserving, so the survey baseline must be **unchanged** — any delta is a regression.

### Controversy

None. No `src/Contracts/**` touch, no stage-order change, no config key, no public-signature change. Pure internal dedup. Auto-merge candidate once CI is green.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)