### PR TITLE
feat(#36): model factory definition() seeds model-schema examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to this project are documented here.
 - A `findOrFail()` / `firstOrFail()` lookup in the controller body infers a 404 response, deduped against the route-model-binding 404. (#168)
 - Infer error responses from non-2xx `response()->json([...], <4xx/5xx>)` literals in the controller body (Tier-1), carrying the literal body schema inlined per operation; falls back to the configured error envelope when only the status is statically readable. (#238)
 - Internal: the API Resource return-expression reader's paginate-method whitelist now routes through the shared `PaginatorKind::fromPaginatingMethod()` enum instead of a duplicated local constant. (#354)
+- Eloquent model schemas seed their per-property examples from the model's Laravel factory `definition()` (scalar values only), reseeded deterministically per model from `openapi.examples.faker_seed`; disabled when example synthesis is off or the seed is null. (#36)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -219,6 +219,22 @@ Article:
 
 `password` is absent because it is in `$hidden`.
 
+### Examples from model factories
+
+When a model exposes a Laravel factory (the `HasFactory` trait), the generator
+invokes the factory's `definition()` and uses its **scalar** values as the
+per-property `example` in the model's schema. A factory definition is a
+hand-curated, app-maintained realistic payload, so reusing it raises example
+quality at no extra authoring cost. Only scalar (and `null`) values are taken;
+nested arrays, relationship closures, and factory references are skipped.
+
+Factory `definition()` typically calls `fake()`, so the values are reseeded
+deterministically from `openapi.examples.faker_seed` (mixed with the model
+class) before each read — reads are order-independent and stable across runs.
+This path follows the same switches as the rest of example synthesis: it is
+disabled when `openapi.examples.synthesise` is `false` or `faker_seed` is `null`
+(see [Configuration](config.md)).
+
 ### Documenting computed fields
 
 A field in `$appends` without a typed legacy accessor falls back to an

--- a/docs/config.md
+++ b/docs/config.md
@@ -26,7 +26,7 @@ this page is the at-a-glance summary.
 | `security_middleware_map` | Map of custom guard-middleware name → a scheme declared in `security_schemes`. A route carrying a mapped middleware emits that scheme's per-operation requirement (taking precedence over the auto-derived `auth:*`/`scope:*` resolution for that route), so project-specific guards don't make a protected endpoint look public. |
 | `plugins` | Ordered list of `Plugin` class-strings. Ships with `SpatieDataPlugin` and `ApiResourcesPlugin` enabled; `QueryBuilderPlugin` and `FractalPlugin` shipped commented out. |
 | `request_payload_indirection` | Base classes whose constructors are also scanned for Data-class parameters. See [Request bodies → Indirect request payloads](request-bodies.md#indirect-request-payloads). |
-| `examples` | Example synthesis: `synthesise` (default `true`) toggles Faker-generated examples for fields with no authored example; `faker_seed` makes them deterministic. |
+| `examples` | Example synthesis: `synthesise` (default `true`) toggles Faker-generated examples for fields with no authored example and model-factory `definition()` examples for Eloquent model schemas; `faker_seed` makes them deterministic (a `null` seed disables both). |
 | `visibility` | `default` accepts `'public'` (every route documented unless `#[Hide]`) or `'hidden'` (every route excluded unless `#[Expose]`). See [Recipes → Switch between public-default and hidden-default visibility](recipes.md#switch-between-public-default-and-hidden-default-visibility). |
 | `overrides` | Spec-only per-route operation field overrides, keyed by route name or URI glob. See [Operation overrides](#operation-overrides) below. |
 | `routes` | Spec/playground route registration. See below. |

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -410,6 +410,20 @@ class OpenApiServiceProvider extends ServiceProvider
         );
 
         $this->app->scoped(
+            Support\Extraction\ModelFactoryExampleReader::class,
+            static fn(Container $app): Support\Extraction\ModelFactoryExampleReader
+                => new Support\Extraction\ModelFactoryExampleReader(
+                    // Disabled (null seed) when auto-examples are switched off or no fixed seed is
+                    // configured — factory fake() values would otherwise be non-deterministic.
+                    seed: (bool) (config('openapi.examples.synthesise') ?? true)
+                        && config('openapi.examples.faker_seed') !== null
+                        ? (int) config('openapi.examples.faker_seed')
+                        : null,
+                    logger: $app->make(LoggerInterface::class),
+                ),
+        );
+
+        $this->app->scoped(
             Plugins\Core\Resolvers\DiscriminatedRequestSchemaResolver::class,
             static function (Container $app): Plugins\Core\Resolvers\DiscriminatedRequestSchemaResolver {
                 $registry = $app->make(OpenApiRegistry::class);

--- a/src/Support/Extraction/EloquentModelToSchema.php
+++ b/src/Support/Extraction/EloquentModelToSchema.php
@@ -84,6 +84,7 @@ final class EloquentModelToSchema
         private readonly TypeNodeResolver $typeNodeResolver,
         private readonly DocBlockParser $docBlockParser,
         private readonly LoggerInterface $logger,
+        private readonly ModelFactoryExampleReader $factoryExampleReader,
     ) {}
 
     /**
@@ -589,6 +590,7 @@ final class EloquentModelToSchema
         }
 
         $names = array_values(array_diff($allNames, $hidden));
+        $examples = $this->factoryExampleReader->examplesFor($modelClass);
         $properties = [];
 
         foreach ($names as $name) {
@@ -653,6 +655,16 @@ final class EloquentModelToSchema
             }
 
             $properties[] = new OA\Property(['property' => $name]);
+        }
+
+        // Seed examples from the model's factory definition() (when one exists and is deterministic);
+        // leaves untouched any property the factory does not produce.
+        if ($examples !== []) {
+            foreach ($properties as $property) {
+                if (array_key_exists($property->property, $examples)) {
+                    $property->example = $examples[$property->property];
+                }
+            }
         }
 
         // A property is required when it has a @property/@property-read annotation whose type is

--- a/src/Support/Extraction/ModelFactoryExampleReader.php
+++ b/src/Support/Extraction/ModelFactoryExampleReader.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Extraction;
+
+use Faker\Generator as Faker;
+use Illuminate\Container\Attributes\Scoped;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+use function array_key_exists;
+use function crc32;
+use function is_scalar;
+use function method_exists;
+
+/**
+ * Reads a model's Laravel factory `definition()` as a source of per-property example values.
+ *
+ * A factory `definition()` is a hand-curated, app-maintained realistic payload — exactly the kind
+ * of data the generated document should show consumers. `Model::factory()` comes from the
+ * `HasFactory` trait (the base `Model` has no `factory()` method), so a model exposes a factory
+ * when `method_exists($modelClass, 'factory')`. The factory is instantiated and its `definition()`
+ * invoked so runtime `fake()` calls resolve to concrete values (Tier 0-ish: reflection + runtime
+ * invocation of app-owned metadata, not dataflow).
+ *
+ * Only scalar (and null) definition values become examples — a value that is itself a factory, a
+ * relationship closure, or an array/object is skipped, as it cannot stand in as a simple property
+ * example.
+ *
+ * Determinism — a factory's `definition()` draws from the container-bound `Faker\Generator`, whose
+ * seed this reader controls. Before **every** `definition()` invocation it reseeds that generator
+ * from `(faker_seed ^ crc32($modelClass))` so reads are order-independent (Faker delegates `seed()`
+ * to the global `mt_srand()`, so any RNG consumer between reads would otherwise drift the state) and
+ * distinct models draw distinct values. When `faker_seed` is null (the config opt-out), factory
+ * examples are disabled — they would be non-deterministic and churn the byte-exact snapshot output.
+ *
+ * Degrades gracefully — factory discovery, constructor side effects, or a `definition()` that
+ * touches the database can throw; on any `Throwable` the reader logs one warning and returns `[]`.
+ *
+ * @internal
+ */
+#[Scoped]
+final class ModelFactoryExampleReader
+{
+    /**
+     * Per-model memo of column → scalar example value.
+     *
+     * @var array<class-string<Model>, array<string, null|scalar>>
+     */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly ?int $seed,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * The scalar example values from the model's factory `definition()`, keyed by column. Returns
+     * an empty map when the model has no factory, the seed is null (determinism opt-out), or any
+     * error occurs during resolution.
+     *
+     * @param class-string<Model> $modelClass
+     *
+     * @return array<string, null|scalar>
+     */
+    public function examplesFor(string $modelClass): array
+    {
+        if (array_key_exists($modelClass, $this->cache)) {
+            return $this->cache[$modelClass];
+        }
+
+        if ($this->seed === null || !method_exists($modelClass, 'factory')) {
+            return $this->cache[$modelClass] = [];
+        }
+
+        try {
+            // Reseed the bound generator immediately before invoking definition(), mixing the model
+            // class into the seed so reads stay order-independent and distinct models differ.
+            Container::getInstance()->make(Faker::class)->seed($this->seed ^ crc32($modelClass));
+
+            /** @var array<string, mixed> $definition */
+            $definition = $modelClass::factory()->definition();
+        } catch (Throwable $throwable) {
+            $this->logger->warning('ModelFactoryExampleReader: factory definition() failed, no examples', [
+                'model' => $modelClass,
+                'exception' => $throwable->getMessage(),
+            ]);
+
+            return $this->cache[$modelClass] = [];
+        }
+
+        $examples = [];
+
+        foreach ($definition as $column => $value) {
+            // Only scalars stand in as a simple property example; closures, factory refs, and
+            // nested arrays/objects are skipped.
+            if (is_scalar($value) || $value === null) {
+                $examples[$column] = $value;
+            }
+        }
+
+        return $this->cache[$modelClass] = $examples;
+    }
+}

--- a/tests/Fixtures/Factories/FactoryArticleFactory.php
+++ b/tests/Fixtures/Factories/FactoryArticleFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\FactoryArticle;
+
+/**
+ * @extends Factory<FactoryArticle>
+ */
+class FactoryArticleFactory extends Factory
+{
+    protected $model = FactoryArticle::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            // Runtime fake() calls — exercise the determinism/reseed path.
+            'title' => $this->faker->sentence(),
+            'views' => $this->faker->numberBetween(1, 1000),
+            'published' => $this->faker->boolean(),
+            // Non-scalar value — must be skipped by the scalar filter.
+            'tags' => $this->faker->words(3),
+        ];
+    }
+}

--- a/tests/Fixtures/Factories/SecondFactoryArticleFactory.php
+++ b/tests/Fixtures/Factories/SecondFactoryArticleFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\SecondFactoryArticle;
+
+/**
+ * A factory with the same definition shape as {@see FactoryArticleFactory}, on a different model.
+ * Used to prove the per-model seed mixing draws distinct values for distinct model classes.
+ *
+ * @extends Factory<SecondFactoryArticle>
+ */
+class SecondFactoryArticleFactory extends Factory
+{
+    protected $model = SecondFactoryArticle::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(),
+            'views' => $this->faker->numberBetween(1, 1000),
+        ];
+    }
+}

--- a/tests/Fixtures/Factories/ThrowingArticleFactory.php
+++ b/tests/Fixtures/Factories/ThrowingArticleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\ThrowingFactoryArticle;
+use RuntimeException;
+
+/**
+ * @extends Factory<ThrowingFactoryArticle>
+ */
+class ThrowingArticleFactory extends Factory
+{
+    protected $model = ThrowingFactoryArticle::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        throw new RuntimeException('definition() touched the database');
+    }
+}

--- a/tests/Fixtures/Models/FactoryArticle.php
+++ b/tests/Fixtures/Models/FactoryArticle.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Radiergummi\OpenApi\Tests\Fixtures\Factories\FactoryArticleFactory;
+
+/**
+ * @property bool         $published
+ * @property list<string> $tags
+ * @property string       $title
+ * @property int          $views
+ *
+ * @use HasFactory<FactoryArticleFactory>
+ */
+class FactoryArticle extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'views' => 'integer',
+        'published' => 'boolean',
+        'tags' => 'array',
+    ];
+
+    protected static function newFactory(): Factory
+    {
+        return FactoryArticleFactory::new();
+    }
+}

--- a/tests/Fixtures/Models/SecondFactoryArticle.php
+++ b/tests/Fixtures/Models/SecondFactoryArticle.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Radiergummi\OpenApi\Tests\Fixtures\Factories\SecondFactoryArticleFactory;
+
+/**
+ * @property string $title
+ * @property int    $views
+ *
+ * @use HasFactory<SecondFactoryArticleFactory>
+ */
+class SecondFactoryArticle extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'views' => 'integer',
+    ];
+
+    protected static function newFactory(): Factory
+    {
+        return SecondFactoryArticleFactory::new();
+    }
+}

--- a/tests/Fixtures/Models/ThrowingFactoryArticle.php
+++ b/tests/Fixtures/Models/ThrowingFactoryArticle.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Radiergummi\OpenApi\Tests\Fixtures\Factories\ThrowingArticleFactory;
+
+/**
+ * @property string $title
+ *
+ * @use HasFactory<ThrowingArticleFactory>
+ */
+class ThrowingFactoryArticle extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected static function newFactory(): Factory
+    {
+        return ThrowingArticleFactory::new();
+    }
+}

--- a/tests/Support/SchemaFromResourceFactory.php
+++ b/tests/Support/SchemaFromResourceFactory.php
@@ -10,6 +10,7 @@ use Radiergummi\OpenApi\Plugins\ApiResources\Support\ResourceToArrayReader;
 use Radiergummi\OpenApi\Plugins\ApiResources\Support\SchemaFromResource;
 use Radiergummi\OpenApi\Plugins\ApiResources\Support\WrappedModelLocator;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\ExplicitClassSchema;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
@@ -71,6 +72,7 @@ final class SchemaFromResourceFactory
             typeNodeResolver: TypeNodeResolver::create(),
             docBlockParser: DocBlockParser::create(),
             logger: $logger,
+            factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
         );
     }
 }

--- a/tests/Unit/Core/Inference/FindReturnModelResponseResolverTest.php
+++ b/tests/Unit/Core/Inference/FindReturnModelResponseResolverTest.php
@@ -12,6 +12,7 @@ use Psr\Log\NullLogger;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\FindReturnModelResponseResolver;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
@@ -132,6 +133,7 @@ function findReturnResolver(?LoggerInterface $logger = null): FindReturnModelRes
         typeNodeResolver: TypeNodeResolver::create(),
         docBlockParser: DocBlockParser::create(),
         logger: $logger,
+        factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
     );
 
     return new FindReturnModelResponseResolver(

--- a/tests/Unit/Plugins/Fractal/Lint/FractalFieldsUndeclaredTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalFieldsUndeclaredTest.php
@@ -10,6 +10,7 @@ use Radiergummi\OpenApi\Plugins\Fractal\Attributes\TransformerField;
 use Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules\FractalFieldsUndeclared;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\TransformerTransformReader;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
@@ -58,6 +59,7 @@ function fractalFieldsUndeclaredRule(): FractalFieldsUndeclared
             typeNodeResolver: TypeNodeResolver::create(),
             docBlockParser: DocBlockParser::create(),
             logger: $logger,
+            factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
         ),
     ));
 }

--- a/tests/Unit/Plugins/Fractal/SchemaFromTransformerTest.php
+++ b/tests/Unit/Plugins/Fractal/SchemaFromTransformerTest.php
@@ -14,6 +14,7 @@ use Radiergummi\OpenApi\Plugins\Fractal\Attributes\TransformerInclude;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\SchemaFromTransformer;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\TransformerTransformReader;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
@@ -49,6 +50,7 @@ function makeSchemaFromTransformer(
                 typeNodeResolver: TypeNodeResolver::create(),
                 docBlockParser: DocBlockParser::create(),
                 logger: $logger,
+                factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
             ),
         ),
         logger: $logger,

--- a/tests/Unit/Plugins/Fractal/TransformerRefSchemaResolverTest.php
+++ b/tests/Unit/Plugins/Fractal/TransformerRefSchemaResolverTest.php
@@ -10,6 +10,7 @@ use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\TransformerRefSchemaResolver;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\SchemaFromTransformer;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\TransformerTransformReader;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
@@ -41,6 +42,7 @@ function makeTransformerRefResolver(): TransformerRefSchemaResolver
             typeNodeResolver: TypeNodeResolver::create(),
             docBlockParser: DocBlockParser::create(),
             logger: $logger,
+            factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
         ),
     );
 

--- a/tests/Unit/Plugins/Fractal/TransformerTransformReaderTest.php
+++ b/tests/Unit/Plugins/Fractal/TransformerTransformReaderTest.php
@@ -9,6 +9,7 @@ use Psr\Log\NullLogger;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\InferredTransformerField;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\TransformerTransformReader;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
@@ -42,6 +43,7 @@ function transformReader(): TransformerTransformReader
             typeNodeResolver: TypeNodeResolver::create(),
             docBlockParser: DocBlockParser::create(),
             logger: $logger,
+            factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
         ),
     );
 }

--- a/tests/Unit/Support/Extraction/EloquentModelPropertyLookupTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelPropertyLookupTest.php
@@ -7,6 +7,7 @@ namespace Radiergummi\OpenApi\Tests\Unit\Support\Extraction;
 use OpenApi\Annotations as OA;
 use Psr\Log\NullLogger;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
@@ -31,6 +32,7 @@ function modelPropertyReader(): EloquentModelToSchema
         typeNodeResolver: TypeNodeResolver::create(),
         docBlockParser: DocBlockParser::create(),
         logger: $logger,
+        factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
     );
 }
 

--- a/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
+++ b/tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Tests\Unit\Support\Extraction;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 use Psr\Log\NullLogger;
 use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
 use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
 use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
 use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
 use Radiergummi\OpenApi\Support\Types\TypeNodeToSchema;
 use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\FactoryArticle;
 use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 
 uses()->group('openapi');
@@ -38,6 +42,7 @@ function buildModelSchema(string $modelClass): OA\Schema
         typeNodeResolver: TypeNodeResolver::create(),
         docBlockParser: DocBlockParser::create(),
         logger: $logger,
+        factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
     );
 
     $key = $reader->build($modelClass);
@@ -124,6 +129,7 @@ it('maps an enum cast to a $ref into a shared reusable enum component', function
         typeNodeResolver: TypeNodeResolver::create(),
         docBlockParser: DocBlockParser::create(),
         logger: $logger,
+        factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
     );
 
     $reader->build(Article::class);
@@ -162,6 +168,7 @@ it('emits a $ref for a @property-read model relation and registers the nested co
         typeNodeResolver: TypeNodeResolver::create(),
         docBlockParser: DocBlockParser::create(),
         logger: $logger,
+        factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
     );
 
     $reader->build(Article::class);
@@ -388,4 +395,18 @@ it('respects @property list hints for encrypted:array and encrypted:collection c
     expect($properties['tags'])->toEqual(['type' => 'array', 'items' => ['type' => 'string']])
         ->and($properties['labels'])->toEqual(['type' => 'array', 'items' => ['type' => 'string']])
         ->and($properties['options'])->toEqual(['type' => 'object']);
+});
+
+it('seeds property examples from the model factory definition', function (): void {
+    $schema = buildModelSchema(FactoryArticle::class);
+
+    expect(modelProperty($schema, 'title')->example)->toBeString()
+        ->and(modelProperty($schema, 'views')->example)->toBeInt();
+});
+
+it('leaves properties without an example when the model has no factory', function (): void {
+    $schema = buildModelSchema(Author::class);
+
+    // Generator::UNDEFINED marks an unset swagger-php field.
+    expect(modelProperty($schema, 'name')->example)->toBe(Generator::UNDEFINED);
 });

--- a/tests/Unit/Support/Extraction/ModelFactoryExampleReaderTest.php
+++ b/tests/Unit/Support/Extraction/ModelFactoryExampleReaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Support\Extraction;
+
+use Psr\Log\NullLogger;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\FactoryArticle;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\SecondFactoryArticle;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\ThrowingFactoryArticle;
+
+uses()->group('openapi');
+
+function makeReader(?int $seed = 1234): ModelFactoryExampleReader
+{
+    return new ModelFactoryExampleReader(seed: $seed, logger: new NullLogger());
+}
+
+it('reads scalar definition values from a model factory', function (): void {
+    $examples = makeReader()->examplesFor(FactoryArticle::class);
+
+    expect($examples)->toHaveKeys(['title', 'views', 'published'])
+        ->and($examples['title'])->toBeString()
+        ->and($examples['views'])->toBeInt()
+        ->and($examples['published'])->toBeBool();
+});
+
+it('skips non-scalar definition values', function (): void {
+    $examples = makeReader()->examplesFor(FactoryArticle::class);
+
+    // `tags` is an array in the factory definition — not representable as a scalar example.
+    expect($examples)->not->toHaveKey('tags');
+});
+
+it('returns an empty map for a model without a factory', function (): void {
+    expect(makeReader()->examplesFor(Author::class))->toBe([]);
+});
+
+it('disables factory examples when the seed is null', function (): void {
+    expect(makeReader(seed: null)->examplesFor(FactoryArticle::class))->toBe([]);
+});
+
+it('degrades to an empty map and logs when definition() throws', function (): void {
+    $logger = recordingLogger();
+    $reader = new ModelFactoryExampleReader(seed: 1234, logger: $logger);
+
+    expect($reader->examplesFor(ThrowingFactoryArticle::class))->toBe([])
+        ->and($logger->records)->not->toBeEmpty();
+});
+
+it('produces identical values across repeated reads regardless of order', function (): void {
+    // Read A, then B, then A again — A's map must be byte-identical across both reads, proving the
+    // per-invocation reseed makes reads order-independent (B's draws between them must not drift
+    // A's RNG state). Fresh readers each time so memoisation isn't what makes them match.
+    $firstA = makeReader()->examplesFor(FactoryArticle::class);
+    makeReader()->examplesFor(SecondFactoryArticle::class);
+    $againA = makeReader()->examplesFor(FactoryArticle::class);
+
+    expect($againA)->toBe($firstA);
+});
+
+it('draws distinct values for distinct model classes from the same seed', function (): void {
+    // The two factories share an identical definition shape (title + views via fake()); mixing the
+    // model class into the seed must make their drawn values differ rather than coincide.
+    $first = makeReader()->examplesFor(FactoryArticle::class);
+    $second = makeReader()->examplesFor(SecondFactoryArticle::class);
+
+    expect($second['title'])->not->toBe($first['title']);
+});


### PR DESCRIPTION
Closes #36

## Implementation plan — #36 Model factories → response/request examples

### What & why

When an Eloquent model exposes a Laravel factory, source the model schema's per-property
**examples** from `factory()->definition()` — a hand-curated, app-maintained realistic payload —
instead of (or above) the generic Faker synthesis. Tier-0/1 polish: nice-to-have, not load-bearing.

### Key architectural finding (verify-and-rely)

The issue says "extend example sourcing in `FakerExampleSynthesiser`", but on inspection that class
is **per-field** and is wired only into request/Data-class schema builders
(`SchemaFromFormRequest`, `SchemaFromDataClass`, `InlineValidationRequestSchemaResolver`). **Model
schemas do not currently carry examples at all** — `EloquentModelToSchema::schemaFor()` builds
`OA\Property` objects with no `example` set, and never consults the synthesiser.

A factory `definition()` is a **whole-model associative array** (`['name' => fake()->name(), ...]`),
not a per-field synthesis. So the right seam is **not** inside `FakerExampleSynthesiser` (which would
distort its narrow per-field contract). Instead:

- Add a small, plugin-agnostic reader in `src/Support/Extraction/` —
  `ModelFactoryExampleReader` — that, given a `class-string<Model>`, resolves the model's factory,
  invokes `definition()`, and returns `array<string, mixed>` of column → concrete example value (or
  `[]` when the model has no factory / instantiation throws).
- `EloquentModelToSchema::schemaFor()` consults it once per model, then sets `$property->example`
  on each built property whose name has a factory value. This is the single, surgical wiring point.

This keeps `src/Support/` plugin-agnostic (models + factories are vanilla Laravel = Tier 0 metadata),
and leaves `FakerExampleSynthesiser` untouched. I will note this deviation from the issue's literal
"extend FakerExampleSynthesiser" wording as a PR comment (per CLAUDE.md: record plan deviations).

### Tier

**Tier 0-ish** (the issue's framing). `definition()` is an array literal but commonly calls
`fake()` at runtime, so a static AST read won't resolve values — instead we **instantiate the
factory and invoke `definition()`** so Faker calls resolve to concrete values. This is reflection +
runtime invocation of app-owned metadata, not dataflow analysis. No tier escalation.

### Factory resolution mechanism

`Model::factory()` is provided by the `HasFactory` trait, **not** `Model` itself — confirmed via
reflection (`Illuminate\Database\Eloquent\Model` has no `factory()` method; `HasFactory` provides
`newFactory()`/`factory()`). So detection is: the model class has a callable static `factory()`
(`method_exists($modelClass, 'factory')`). The reader calls `$modelClass::factory()->definition()`
inside a `try { } catch (Throwable)` — factory discovery, constructor side effects, or a
`definition()` that touches the DB/config can throw; on any failure return `[]` and **log one
warning** (matching the `EloquentModelToSchema` degrade-and-log convention).

Only **scalar** definition values (string/int/float/bool/null) become examples. A definition value
that is itself a factory, a relationship closure, a `Closure`, or an array/object is skipped — those
aren't representable as a simple scalar property example and would risk recursion. (Guard with an
`is_scalar() || is_null()` filter.)

### Determinism constraint (MUST cover)

`FakerExampleSynthesiser` reseeds Faker deterministically per call from
`(openapi.examples.faker_seed, fieldName)` so the byte-exact `snapshot` group in
`tests/Feature/ExamplesTest.php` stays green. A factory `definition()` calling `fake()` uses the
**global** Faker instance (Laravel's container-bound `Faker\Generator`), whose seed we do not
control per-call. **Two options, plan picks (a):**

(a) **Seed the global Faker before invoking `definition()`.** The reader, before calling
`definition()`, seeds the app's bound `Faker\Generator` via `mt_srand`/`$faker->seed()` from the
configured `openapi.examples.faker_seed` (passed into the reader, mirroring how the synthesiser gets
its seed in `OpenApiServiceProvider`). This makes factory-sourced `fake()` values reproducible across
runs. When `faker_seed` is `null` (config default opt-out), factory examples are **disabled** (would
be non-deterministic) — fall back to no example, same as today.

(b) rejected: post-hoc normalisation — too fragile.

The determinism test is the gating test: generate the same model's schema twice, assert identical
example values; and the existing `snapshot` group must stay byte-identical after a fixture is added.

### Files

**Create:**
- `src/Support/Extraction/ModelFactoryExampleReader.php` — `#[Scoped]`, `@internal`. Constructor
  takes `?int $seed` + `LoggerInterface`. One public method
  `examplesFor(class-string<Model> $modelClass): array<string,mixed>`, memoised per model. Returns
  `[]` when: no `factory()` method, `$seed === null`, or any `Throwable` during resolution.

**Modify:**
- `src/Support/Extraction/EloquentModelToSchema.php` — inject `ModelFactoryExampleReader`; in
  `schemaFor()`, fetch `$examples = $reader->examplesFor($modelClass)` once, and when building each
  property set `$property->example = $examples[$name]` if the key exists and value is scalar/null.
  (Also apply in `propertyFor()` for the Resource-key path? — **No**, keep scope to `schemaFor()`
  per the issue's "model's schema example"; note this in the PR. `propertyFor()` is the
  resource-driven single-property path and out of scope.)
- `src/OpenApiServiceProvider.php` — register `ModelFactoryExampleReader` with the same
  `openapi.examples.faker_seed`-derived seed used for `FakerExampleSynthesiser` (lines ~403-408).
- `config/openapi.php` — no new key needed; reuses `examples.faker_seed` and (optionally) gate on
  `examples.synthesise`. **Decision:** gate the factory path on `examples.synthesise` too, so the
  master switch turns off all auto-examples consistently. State in PR.

### Tests (TDD — failing first)

**`tests/Unit/Support/Extraction/` — new `ModelFactoryExampleReaderTest.php`:**
- factory present → `examplesFor()` returns the definition's scalar values.
- model without `factory()` → returns `[]`.
- `seed === null` → returns `[]` (determinism opt-out).
- `definition()` that throws → returns `[]` + warning logged (use a fixture factory whose
  `definition()` throws).
- non-scalar definition value (nested array / factory ref) → that key absent from the result.
- **determinism**: two calls on a `fake()`-using factory yield identical values.

**`tests/Unit/Support/Extraction/EloquentModelToSchemaTest.php`** (if exists; else add to the model
schema feature test): model with a factory → built property carries `example` from the factory;
model without a factory → no `example` (unchanged behaviour).

**Fixtures (new):**
- `tests/Fixtures/Models/<X>` model `use`ing `HasFactory` with a `newFactory()` (or a discoverable
  factory) whose `definition()` calls `fake()` (covers the determinism path) and includes one
  non-scalar value (covers the skip filter).
- a factory whose `definition()` throws (covers degrade).

**Snapshot guard:** `tests/Feature/ExamplesTest.php` `snapshot` group MUST stay green. Since adding a
factory to an *existing* snapshot fixture model would change the committed YAML, **prefer adding a
new fixture used only by the unit/feature tests, not by the snapshot flavors** — OR, if a snapshot
flavor model gains a factory, regenerate and commit the snapshot and call it out as an intentional
diff. Coder picks the lower-churn route; default to a dedicated fixture outside the snapshot set.

### Verification

```
vendor/bin/pest tests/Unit/Support/Extraction/ModelFactoryExampleReaderTest.php
vendor/bin/pest tests/Feature/ExamplesTest.php --group snapshot
composer test
vendor/bin/pint --test
composer lint
```

### Docs / CHANGELOG

- `docs/auto-derivation.md` → "Eloquent model response schemas" section (around the worked
  `Article` example, ~line 164): add a short subsection noting that when a model has a factory, its
  `definition()` seeds per-property examples (deterministic via `examples.faker_seed`; disabled when
  the seed is null).
- `CHANGELOG.md [Unreleased]` "Added": model schemas now source per-property examples from the
  model's factory `definition()` when one exists, deterministically seeded.

### Survey gate

**Generation-affecting** (area:core, examples in output) → survey gate WILL run. Adding examples to
model schemas is a real output delta on any dogfood app whose models have factories — the survey
baseline will move. That is **expected and intended**; reviewer should confirm the delta is only
added `example:` keys on model properties, deterministic, and nothing else regressed.

### Controversy

Mild. No `src/Contracts/**` change, no stage-order change, no new config key (reuses
`examples.faker_seed`/`examples.synthesise`), no public-signature change. The deviation from the
issue's literal "extend FakerExampleSynthesiser" wording (new reader instead) is the one judgment
call — documented as a PR comment. The global-Faker seeding for determinism is the subtle part; the
determinism test pins it. Reviewer should sanity-check the snapshot stays byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)