### PR TITLE
feat(#150): #[RequestField] class-string type:/items: resolve to $ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to this project are documented here.
 - Infer error responses from non-2xx `response()->json([...], <4xx/5xx>)` literals in the controller body (Tier-1), carrying the literal body schema inlined per operation; falls back to the configured error envelope when only the status is statically readable. (#238)
 - Internal: the API Resource return-expression reader's paginate-method whitelist now routes through the shared `PaginatorKind::fromPaginatingMethod()` enum instead of a duplicated local constant. (#354)
 - Eloquent model schemas seed their per-property examples from the model's Laravel factory `definition()` (scalar values only), reseeded deterministically per model from `openapi.examples.faker_seed`; disabled when example synthesis is off or the seed is null. (#36)
+- `#[RequestField]` ref support: a class-string `type:` resolves to a `$ref`, and a class-string `items:` on a `type: 'array'` field resolves to `items: { $ref }` — mirroring the response-side `#[ResourceField]`; an unresolvable class degrades to a permissive object. (#150)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/request-bodies.md
+++ b/docs/request-bodies.md
@@ -213,6 +213,21 @@ declaration wins over a type-hinted `FormRequest` on the same action. The same
 field attributes apply as everywhere else — `type`, `format`, `enum`, `minLength`,
 `pattern`, and so on (see [Validation rules → schema constraints](#validation-rules--schema-constraints)).
 
+For a field whose value is another schema-bearing class, pass its class-string as
+`type` — it resolves to a `$ref` through the ref-resolver chain (a Spatie Data
+class, an API Resource, anything a registered resolver builds). For a field that is
+a **collection** of such a class, keep `type: 'array'` and pass the item
+class-string as `items`; it resolves to `items: { $ref: … }`. Both mirror the
+response-side [`#[ResourceField]`](plugins.md#declared-fields-with-resourcefield);
+a class-string no resolver recognises degrades to a permissive `type: object`
+(or `items: { type: object }`).
+
+```php
+#[RequestField('owner', type: UserData::class)]
+#[RequestField('members', type: 'array', items: UserData::class)]
+public function store(Request $request): SiteResource { … }
+```
+
 ## Runtime state in `rules()`
 
 `rules()` bodies that read request state — `$this->route('foo')->bar`,

--- a/src/Attributes/RequestField.php
+++ b/src/Attributes/RequestField.php
@@ -38,7 +38,9 @@ final readonly class RequestField extends FieldAttribute
      *                                                                                                           otherwise
      * @param null|non-empty-string                                                        $title
      * @param null|non-empty-string                                                        $description
-     * @param null|OpenApiPrimitiveType                                                    $type
+     * @param null|class-string|OpenApiPrimitiveType                                       $type                 A JSON-Schema scalar
+     *                                                                                                           type, or a class-string
+     *                                                                                                           for a nested `$ref`.
      * @param null|non-empty-string                                                        $format
      * @param null|array<int, BackedEnum|int|string>|class-string<BackedEnum>|FieldDefault $enum
      * @param null|int<0, max>                                                             $minLength

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -409,6 +409,31 @@ class OpenApiServiceProvider extends ServiceProvider
             ),
         );
 
+        // The builder resolves class-string `#[RequestField]` types/items to a `$ref` through the
+        // full ref-resolver chain. It carries no exclusion: Core registers no RefSchemaResolver of
+        // its own, so there is no construction cycle to break.
+        $this->app->scoped(
+            Plugins\Core\Support\RequestFieldObjectBuilder::class,
+            static function (Container $app): Plugins\Core\Support\RequestFieldObjectBuilder {
+                $registry = $app->make(OpenApiRegistry::class);
+
+                return new Plugins\Core\Support\RequestFieldObjectBuilder(
+                    refSchemaResolvers: self::refSchemaResolverFactory($app, $registry),
+                );
+            },
+        );
+
+        // Explicit binding: the resolver now depends on the builder, which has a Closure ctor
+        // argument the container cannot auto-resolve.
+        $this->app->scoped(
+            Plugins\Core\Resolvers\RequestFieldRequestSchemaResolver::class,
+            static fn(Container $app): Plugins\Core\Resolvers\RequestFieldRequestSchemaResolver
+                => new Plugins\Core\Resolvers\RequestFieldRequestSchemaResolver(
+                    registry: $app->make(ComponentSchemaRegistry::class),
+                    objectBuilder: $app->make(Plugins\Core\Support\RequestFieldObjectBuilder::class),
+                ),
+        );
+
         $this->app->scoped(
             Support\Extraction\ModelFactoryExampleReader::class,
             static fn(Container $app): Support\Extraction\ModelFactoryExampleReader
@@ -432,6 +457,7 @@ class OpenApiServiceProvider extends ServiceProvider
                     registry: $app->make(ComponentSchemaRegistry::class),
                     refSchemaResolvers: self::refSchemaResolverFactory($app, $registry),
                     findings: $app->make(FindingsCollector::class),
+                    objectBuilder: $app->make(Plugins\Core\Support\RequestFieldObjectBuilder::class),
                 );
             },
         );

--- a/src/Plugins/Core/Resolvers/DiscriminatedRequestSchemaResolver.php
+++ b/src/Plugins/Core/Resolvers/DiscriminatedRequestSchemaResolver.php
@@ -44,6 +44,7 @@ final readonly class DiscriminatedRequestSchemaResolver implements RequestSchema
         private ComponentSchemaRegistry $registry,
         private Closure $refSchemaResolvers,
         private FindingsCollector $findings,
+        private RequestFieldObjectBuilder $objectBuilder,
     ) {}
 
     /** @throws InvalidArgumentException */
@@ -243,7 +244,7 @@ final readonly class DiscriminatedRequestSchemaResolver implements RequestSchema
             );
         }
 
-        [$properties, $required] = RequestFieldObjectBuilder::propertiesAndRequired($fields);
+        [$properties, $required] = $this->objectBuilder->propertiesAndRequired($fields);
 
         $schemaProps = ['type' => 'object', 'properties' => $properties];
 

--- a/src/Plugins/Core/Resolvers/RequestFieldRequestSchemaResolver.php
+++ b/src/Plugins/Core/Resolvers/RequestFieldRequestSchemaResolver.php
@@ -34,6 +34,7 @@ final readonly class RequestFieldRequestSchemaResolver implements RequestSchemaR
 {
     public function __construct(
         private ComponentSchemaRegistry $registry,
+        private RequestFieldObjectBuilder $objectBuilder,
     ) {}
 
     #[Override]
@@ -56,7 +57,7 @@ final readonly class RequestFieldRequestSchemaResolver implements RequestSchemaR
             $attributes,
         );
 
-        [$properties, $required] = RequestFieldObjectBuilder::propertiesAndRequired($fields);
+        [$properties, $required] = $this->objectBuilder->propertiesAndRequired($fields);
 
         if ($properties === []) {
             return null;

--- a/src/Plugins/Core/Support/RequestFieldObjectBuilder.php
+++ b/src/Plugins/Core/Support/RequestFieldObjectBuilder.php
@@ -4,24 +4,42 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Core\Support;
 
+use Closure;
+use Illuminate\Container\Attributes\Scoped;
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Attributes\RequestField;
+use Radiergummi\OpenApi\Contracts\Registry\RefSchemaResolver;
+use Radiergummi\OpenApi\Support\Extraction\FieldReferenceProperty;
+
+use function class_exists;
 
 /**
  * Turns a list of `#[RequestField]`s into the `properties` + `required` parts of an object schema.
  * Shared by {@see \Radiergummi\OpenApi\Plugins\Core\Resolvers\RequestFieldRequestSchemaResolver}
  * and {@see \Radiergummi\OpenApi\Plugins\Core\Resolvers\DiscriminatedRequestSchemaResolver}.
  *
+ * A class-string `type:` resolves to a `$ref` through the ref-resolver chain (mirroring the
+ * response-side `#[ResourceField]`); a class-string `items:` on a `type: 'array'` field resolves
+ * to `items: { $ref }`. Both degrade to a permissive object on a chain miss.
+ *
  * @internal
  */
+#[Scoped]
 final readonly class RequestFieldObjectBuilder
 {
+    /**
+     * @param Closure(): list<RefSchemaResolver> $refSchemaResolvers Lazy chain consulted for class-string fields.
+     */
+    public function __construct(
+        private Closure $refSchemaResolvers,
+    ) {}
+
     /**
      * @param iterable<RequestField> $fields
      *
      * @return array{0: list<OA\Property>, 1: list<string>} `[properties, required]`
      */
-    public static function propertiesAndRequired(iterable $fields): array
+    public function propertiesAndRequired(iterable $fields): array
     {
         /** @var list<OA\Property> $properties */
         $properties = [];
@@ -34,9 +52,7 @@ final readonly class RequestFieldObjectBuilder
                 continue;
             }
 
-            $property = new OA\Property(['property' => $field->name]);
-            $field->descriptor()->applyTo($property);
-            $properties[] = $property;
+            $properties[] = $this->buildProperty($field);
 
             if ($field->required === true) {
                 $required[] = $field->name;
@@ -44,5 +60,55 @@ final readonly class RequestFieldObjectBuilder
         }
 
         return [$properties, $required];
+    }
+
+    private function buildProperty(RequestField $field): OA\Property
+    {
+        $type = $field->type;
+
+        // A class-string `type:` resolves to a `$ref` (or a permissive object on a chain miss).
+        if ($type !== null && class_exists($type)) {
+            return FieldReferenceProperty::build(
+                $field->name ?? '',
+                $field->descriptor()->description,
+                $this->resolveClassRef($type),
+            );
+        }
+
+        $property = new OA\Property(['property' => $field->name]);
+        $field->descriptor()->applyTo($property);
+
+        // array-of-$ref: a class-string `items:` on an array field resolves to `items: { $ref }`
+        // via the same resolver chain as `type:`. The descriptor above already set `type: array`
+        // plus any min/max/unique constraints and a scalar `items` placeholder — only the items
+        // schema is overridden here. An unresolvable class degrades to a permissive object item,
+        // symmetric with the single-ref `type: object` fallback above.
+        if ($type === 'array' && $field->items !== null && class_exists($field->items)) {
+            $ref = $this->resolveClassRef($field->items);
+
+            $property->items = $ref !== null
+                ? new OA\Items(['ref' => $ref])
+                : new OA\Items(['type' => 'object']);
+        }
+
+        return $property;
+    }
+
+    /**
+     * Walks the ref-resolver chain and returns the first matching `$ref` string, or null.
+     *
+     * @param class-string $class
+     */
+    private function resolveClassRef(string $class): ?string
+    {
+        foreach (($this->refSchemaResolvers)() as $resolver) {
+            $ref = $resolver->resolveRef($class);
+
+            if ($ref !== null) {
+                return $ref;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Feature/DiscriminatedRequestBodyTest.php
+++ b/tests/Feature/DiscriminatedRequestBodyTest.php
@@ -110,6 +110,17 @@ it('resolves multiple class-string branches through the ref chain', function ():
         ->and($spec['components']['schemas'])->toHaveKeys(['CircleData', 'RectangleData']);
 })->group('plugin:spatie-data');
 
+it('resolves a class-string #[RequestField] type inside an inline branch to a $ref', function (): void {
+    Route::post('/oa-139/inline-field-ref', [DiscriminatedRequestFixtureController::class, 'inlineFieldRef']);
+    $spec = generateSpec();
+
+    $mapping = discriminatedBodySchema($spec, '/oa-139/inline-field-ref')['discriminator']['mapping'];
+    $branch = $spec['components']['schemas'][substr((string) $mapping['wrapped'], strlen('#/components/schemas/'))];
+
+    expect($branch['properties']['detail']['$ref'])->toBe('#/components/schemas/CircleData')
+        ->and($spec['components']['schemas'])->toHaveKey('CircleData');
+})->group('plugin:spatie-data');
+
 it('emits the expected discriminated request-body shape', function (): void {
     Route::post('/oa-139/inline', [DiscriminatedRequestFixtureController::class, 'inline']);
     $schema = discriminatedBodySchema(generateSpec(), '/oa-139/inline');

--- a/tests/Feature/RequestFieldMethodLevelTest.php
+++ b/tests/Feature/RequestFieldMethodLevelTest.php
@@ -32,3 +32,18 @@ it('builds a request body schema from method-level #[RequestField] attributes', 
         ->and($schema['properties']['aliases']['items']['type'])->toBe('string')
         ->and($schema['required'])->toBe(['domain']);
 });
+
+it('resolves a class-string #[RequestField] type/items to a $ref end-to-end', function (): void {
+    Route::post('/oa-fixture/request-field/store-with-ref', [RequestFieldMethodFixtureController::class, 'storeWithRef']);
+    $spec = generateSpec();
+
+    $op = $spec['paths']['/oa-fixture/request-field/store-with-ref']['post'] ?? [];
+    $ref = $op['requestBody']['content']['application/json']['schema']['$ref'] ?? null;
+    $key = substr((string) $ref, strlen('#/components/schemas/'));
+    $schema = $spec['components']['schemas'][$key] ?? [];
+
+    expect($schema['properties']['owner']['$ref'])->toBe('#/components/schemas/CircleData')
+        ->and($schema['properties']['shapes']['type'])->toBe('array')
+        ->and($schema['properties']['shapes']['items']['$ref'])->toBe('#/components/schemas/CircleData')
+        ->and($spec['components']['schemas'])->toHaveKey('CircleData');
+})->group('plugin:spatie-data');

--- a/tests/Fixtures/DiscriminatedRequestFixtureController.php
+++ b/tests/Fixtures/DiscriminatedRequestFixtureController.php
@@ -94,4 +94,13 @@ class DiscriminatedRequestFixtureController extends Controller
     {
         return [];
     }
+
+    // An inline branch whose field carries a class-string `type:` — exercises the field path
+    // through objectBuilder->buildProperty(), distinct from the whole-variant `schema:` branch.
+    #[RequestBody(discriminator: 'shape')]
+    #[RequestVariant('wrapped', fields: [new RequestField('detail', type: CircleData::class)])]
+    public function inlineFieldRef(Request $request): array
+    {
+        return [];
+    }
 }

--- a/tests/Fixtures/RequestFieldMethodFixtureController.php
+++ b/tests/Fixtures/RequestFieldMethodFixtureController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Radiergummi\OpenApi\Attributes\RequestBody;
 use Radiergummi\OpenApi\Attributes\RequestField;
+use Radiergummi\OpenApi\Tests\Fixtures\Discriminator\CircleData;
 
 /**
  * Test fixture — a controller that validates outside a FormRequest/Data class and documents its
@@ -22,6 +23,15 @@ class RequestFieldMethodFixtureController extends Controller
     #[RequestField('php_version', type: 'string', default: '8.4')]
     #[RequestField('aliases', type: 'array', items: 'string')]
     public function store(Request $request): array
+    {
+        return [];
+    }
+
+    /** A class-string `type:` resolves to a `$ref`; a class-string `items:` to `items: { $ref }`. */
+    #[RequestBody(description: 'Field-level refs.')]
+    #[RequestField('owner', type: CircleData::class)]
+    #[RequestField('shapes', type: 'array', items: CircleData::class)]
+    public function storeWithRef(Request $request): array
     {
         return [];
     }

--- a/tests/Unit/RequestFieldObjectBuilderTest.php
+++ b/tests/Unit/RequestFieldObjectBuilderTest.php
@@ -4,13 +4,46 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit;
 
+use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Attributes\RequestField;
+use Radiergummi\OpenApi\Contracts\Registry\RefSchemaResolver;
 use Radiergummi\OpenApi\Plugins\Core\Support\RequestFieldObjectBuilder;
 
 uses()->group('openapi');
 
+/** A non-resource class resolved via the ref-resolver chain. */
+class RequestFieldRefTarget {}
+
+/**
+ * @param list<RefSchemaResolver> $resolvers
+ */
+function makeRequestFieldObjectBuilder(array $resolvers = []): RequestFieldObjectBuilder
+{
+    return new RequestFieldObjectBuilder(static fn(): array => $resolvers);
+}
+
+function stubRefResolver(string $target, string $ref): RefSchemaResolver
+{
+    return new class ($target, $ref) implements RefSchemaResolver {
+        public function __construct(
+            private string $target,
+            private string $ref,
+        ) {}
+
+        public function canResolve(string $class): bool
+        {
+            return $class === $this->target;
+        }
+
+        public function resolveRef(string $class): ?string
+        {
+            return $this->canResolve($class) ? $this->ref : null;
+        }
+    };
+}
+
 it('builds properties and collects required names', function (): void {
-    [$properties, $required] = RequestFieldObjectBuilder::propertiesAndRequired([
+    [$properties, $required] = makeRequestFieldObjectBuilder()->propertiesAndRequired([
         new RequestField('domain', required: true, type: 'string'),
         new RequestField('php_version', type: 'string'),
     ]);
@@ -22,7 +55,7 @@ it('builds properties and collects required names', function (): void {
 });
 
 it('skips a field with no name', function (): void {
-    [$properties, $required] = RequestFieldObjectBuilder::propertiesAndRequired([
+    [$properties, $required] = makeRequestFieldObjectBuilder()->propertiesAndRequired([
         new RequestField(null, required: true),
         new RequestField('keep'),
     ]);
@@ -30,4 +63,58 @@ it('skips a field with no name', function (): void {
     expect($properties)->toHaveCount(1)
         ->and($properties[0]->property)->toBe('keep')
         ->and($required)->toBe([]);
+});
+
+it('leaves a scalar field untouched', function (): void {
+    [$properties] = makeRequestFieldObjectBuilder()->propertiesAndRequired([
+        new RequestField('domain', type: 'string', format: 'hostname'),
+    ]);
+
+    expect($properties[0]->property)->toBe('domain')
+        ->and($properties[0]->type)->toBe('string')
+        ->and($properties[0]->format)->toBe('hostname');
+});
+
+it('resolves a class-string `type` to a $ref', function (): void {
+    $resolver = stubRefResolver(RequestFieldRefTarget::class, '#/components/schemas/RequestFieldRefTarget');
+
+    [$properties] = makeRequestFieldObjectBuilder([$resolver])->propertiesAndRequired([
+        new RequestField('owner', type: RequestFieldRefTarget::class),
+    ]);
+
+    expect($properties[0]->property)->toBe('owner')
+        ->and($properties[0]->ref)->toBe('#/components/schemas/RequestFieldRefTarget');
+});
+
+it('degrades an unresolvable class-string `type` to a permissive object', function (): void {
+    [$properties] = makeRequestFieldObjectBuilder()->propertiesAndRequired([
+        new RequestField('owner', type: RequestFieldRefTarget::class),
+    ]);
+
+    expect($properties[0]->property)->toBe('owner')
+        ->and($properties[0]->type)->toBe('object');
+});
+
+it('resolves a class-string `items` on an array field to items: { $ref }', function (): void {
+    $resolver = stubRefResolver(RequestFieldRefTarget::class, '#/components/schemas/RequestFieldRefTarget');
+
+    [$properties] = makeRequestFieldObjectBuilder([$resolver])->propertiesAndRequired([
+        new RequestField('owners', type: 'array', items: RequestFieldRefTarget::class),
+    ]);
+
+    expect($properties[0]->property)->toBe('owners')
+        ->and($properties[0]->type)->toBe('array')
+        ->and($properties[0]->items)->toBeInstanceOf(OA\Items::class)
+        ->and($properties[0]->items->ref)->toBe('#/components/schemas/RequestFieldRefTarget');
+});
+
+it('degrades an unresolvable class-string `items` to a permissive object item', function (): void {
+    [$properties] = makeRequestFieldObjectBuilder()->propertiesAndRequired([
+        new RequestField('owners', type: 'array', items: RequestFieldRefTarget::class),
+    ]);
+
+    expect($properties[0]->property)->toBe('owners')
+        ->and($properties[0]->type)->toBe('array')
+        ->and($properties[0]->items)->toBeInstanceOf(OA\Items::class)
+        ->and($properties[0]->items->type)->toBe('object');
 });


### PR DESCRIPTION
Closes #150

## Implementation plan — #150 Request-side `#[RequestField]` ref support

### What & why

`#[RequestField]` has **no** ref resolution today. A class-string `type: Foo::class` or a
class-string `items: Foo::class` on an `array` field falls through to the scalar path and emits a
bogus schema. This is the request-side counterpart to #128 (`#[ResourceField]`, response side).
Both ref shapes are done together for consistency.

### Tier

**Tier 1** (the issue's label). Attribute-driven: the author wrote `type: Foo::class`; we resolve
`Foo` to a pooled `$ref` through the registered `RefSchemaResolver` chain. No body parsing. (The
"tier-1" label here reflects the area's whitelist semantics, not new AST work — this is reflection
+ resolver dispatch, mechanically the same as the already-shipped response side.)

### The seam (verified against the codebase)

- `RequestFieldObjectBuilder` (`src/Plugins/Core/Support/`) is today a **static** utility
  (`public static function propertiesAndRequired(iterable $fields)`) with no resolver access. It
  builds each field via `new OA\Property(...)` + `$field->descriptor()->applyTo($property)`.
- The response side's `SchemaFromResource::buildProperty()` is the exact pattern to mirror
  (`src/Plugins/ApiResources/Support/SchemaFromResource.php:277-329`): a class-string `type:` →
  `FieldReferenceProperty::build(name, description, resolveClassRef(type))`; an `array` field with
  class-string `items:` → `$property->items = $ref ? OA\Items(['ref'=>$ref]) : OA\Items(['type'=>'object'])`.
- `FieldReferenceProperty` already lives in **`src/Support/Extraction/`** and is documented as
  shared across plugins — Core may reuse it directly (no new shared class needed).
- Both call-site resolvers are registered as class-strings in `CorePlugin` (lines 59-60) and
  resolved through the container. `DiscriminatedRequestSchemaResolver` **already** holds the lazy
  `Closure(): list<RefSchemaResolver>` chain (ctor param `refSchemaResolvers`, bound in
  `OpenApiServiceProvider` line 412-423 via `self::refSchemaResolverFactory($app, $registry)`).
  `RequestFieldRequestSchemaResolver` currently has **no** explicit binding (auto-resolved; only
  needs `ComponentSchemaRegistry`).

### Files

**Modify `src/Plugins/Core/Support/RequestFieldObjectBuilder.php`:**
- Convert from static utility to a `#[Scoped]` DI'd instance (drop `static`, drop `readonly` only
  if needed — keep `final readonly class`, add a constructor). Constructor:
  `public function __construct(private readonly Closure $refSchemaResolvers) {}` with
  `@param Closure(): list<RefSchemaResolver> $refSchemaResolvers` — mirroring
  `DiscriminatedRequestSchemaResolver` / `SchemaFromResource`.
- `propertiesAndRequired()` becomes an instance method. In the field loop, replace the unconditional
  `new OA\Property + applyTo` with the same branch logic as `SchemaFromResource::buildProperty()`:
  1. `$type = $field->type;` if `$type !== null && class_exists($type)` →
     `FieldReferenceProperty::build($field->name, $field->descriptor()->description, $this->resolveClassRef($type))`.
  2. else build the property via `applyTo`, then if `$type === 'array' && $field->items !== null &&
     class_exists($field->items)` → override `$property->items` with the resolved ref (or permissive
     `OA\Items(['type'=>'object'])` on miss).
  3. else unchanged (scalar path).
- Add a private `resolveClassRef(string $class): ?string` that iterates `($this->refSchemaResolvers)()`
  and returns the first non-null `$resolver->resolveRef($class)`, else null. **No** plugin-specific
  special-case (the response side special-cases `JsonResource` because it lives in the ApiResources
  plugin; Core must NOT know about JsonResource — it relies purely on the resolver chain, which
  includes every plugin's `RefSchemaResolver`). State this asymmetry in the PR.
- `required` handling stays as-is.

Note `RequestField->type` is typed `?OpenApiPrimitiveType` in the subclass but `FieldAttribute`
already documents `type` as `null|class-string|OpenApiPrimitiveType` and the response-side
`ResourceField` accepts class-strings the same way — confirm `RequestField`'s `type` param accepts a
class-string at the attribute boundary (it is forwarded to `FieldAttribute` whose `@param` is
`class-string|OpenApiPrimitiveType`). If `RequestField`'s own `@param` narrows it to
`OpenApiPrimitiveType`, widen it to match `ResourceField` (PHPStan-only, no runtime effect). Verify
against `src/Attributes/ResourceField.php` for the exact docblock form to copy.

**Modify both call sites:**
- `src/Plugins/Core/Resolvers/RequestFieldRequestSchemaResolver.php` — inject
  `RequestFieldObjectBuilder` via ctor; call `$this->builder->propertiesAndRequired($fields)`.
- `src/Plugins/Core/Resolvers/DiscriminatedRequestSchemaResolver.php` — same: inject the builder,
  call the instance method (line ~246). It already has the chain; pass it through to the builder
  (or just inject the builder and drop nothing — the builder now owns the chain).

**Modify `src/OpenApiServiceProvider.php`:**
- Add a `scoped` binding for `RequestFieldObjectBuilder` constructed with
  `refSchemaResolvers: self::refSchemaResolverFactory($app, $registry)`.
- Add an explicit `scoped` binding for `RequestFieldRequestSchemaResolver` (it can no longer be
  auto-resolved) injecting the registry + the builder.
- `DiscriminatedRequestSchemaResolver`'s binding (line 412) gains the builder argument (or keeps its
  own chain and additionally receives the builder — pick the minimal diff: inject the builder, and
  if the builder now owns the chain, the discriminated resolver still needs its own chain for the
  class-string *branch* logic at line 197, so it keeps `refSchemaResolvers` AND gets the builder).

### Tests (TDD — failing first)

`tests/Unit/Core/Extractors/` (or wherever `RequestFieldRequestSchemaResolver` / discriminated
resolver tests live — locate the existing test file for these resolvers):

- **single class-string `type:`** on a method `#[RequestField]` → property emits `{ $ref: '#/.../Foo' }`,
  no scalar `type`.
- **array-of-ref**: `type: 'array', items: Foo::class` → `type: array`, `items: { $ref }`, plus any
  min/max/unique constraints preserved.
- **degrade — unresolvable class-string `type:`** (a class no resolver claims) → permissive
  `type: object` (via `FieldReferenceProperty`).
- **degrade — unresolvable class-string `items:`** → `items: { type: object }`.
- **scalar unchanged**: `type: 'string'` / `type: 'array', items: 'string'` still emit the scalar
  shape (regression that the ref branch doesn't capture non-class-strings — `class_exists` guards it).
- Cover both call paths: at least one assertion through `RequestFieldRequestSchemaResolver` and one
  through `DiscriminatedRequestSchemaResolver` (the discriminated branch fields go through the same
  builder).

Fixtures: a request DTO/resource class to point the `type:`/`items:` ref at — reuse an existing
fixture schema that a `RefSchemaResolver` resolves (e.g. a Spatie Data class or a model the Core
chain pools), to avoid inventing a resolver. Locate what the existing #128 response-side tests use
and mirror it.

### Verification

```
vendor/bin/pest --filter RequestField
vendor/bin/pest --filter Discriminated
composer test
vendor/bin/pint --test
composer lint
```

### Docs / CHANGELOG

- `docs/` — the `#[RequestField]` documentation (find it: likely in the attributes/request-body
  page; grep `RequestField` under `docs/`). Add that a class-string `type:`/`items:` now resolves to
  a `$ref`, mirroring `#[ResourceField]`. Keep it short and reference the response-side parity.
- `CHANGELOG.md [Unreleased]` "Added": request-side `#[RequestField]` now resolves a class-string
  `type:` to a `$ref` and a class-string `items:` on an array field to `items: { $ref }`, matching
  the response-side `#[ResourceField]`.

### Survey gate

This only changes output for apps that USE `#[RequestField]` with class-string types. The black-box
dogfood corpus uses none of our authoring attributes, so expect **~0 survey delta**. (Lead handles
the gate.)

### Controversy

Low-moderate. No `src/Contracts/**` change, no stage-order change, no config key, no public
extension-surface signature change. The one structural change is `RequestFieldObjectBuilder` going
from static to DI'd instance — internal (`@internal`), with only two in-tree call sites, both
updated. Matches the established `DiscriminatedRequestSchemaResolver`/`SchemaFromResource` pattern,
so it's idiomatic. Reviewer should confirm: (a) Core's `resolveClassRef` has no JsonResource
special-case, (b) both bindings construct cleanly (no eager-construction cycle — the chain is lazy),
(c) scalar path is byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)