### PR TITLE
feat(#263): Fractal binding from fractal() helper / facade / injected-Manager call shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project are documented here.
 - `#[RawSchema]` class-level attribute replaces a payload class's inferred component body with a literal JSON Schema (Spatie Data, API Resource, FormRequest); keywords are bounded to what swagger-php serialises, with unsupported keywords dropped-and-logged and flagged by the new `schema.raw-keyword-unsupported` lint rule. (#344)
 - Pagination query parameters from a `->paginate()`/`->simplePaginate()`/`->cursorPaginate()` body call (Tier-1): offset paginators emit `page`/`per_page`, cursor paginators emit `cursor`; an explicit `#[QueryParam]` wins for its name. (#31)
 - Success-response model schema inferred from a directly-returned `Model::find()`/`findOrFail()`/`firstOrFail()` call in the controller body (Tier-1), feeding the existing Eloquent model→schema reader; composes with the `findOrFail()` 404. (#97)
+- Fractal responses inferred from the `fractal()` helper, the `Spatie\Fractalistic\Fractal` facade, and injected-`Manager` `new Item`/`new Collection` resource construction (Tier-1 body scan), with `item`/`collection` envelopes and `serializeWith(...)` serializer detection; the bare two-argument `fractal($data, new T())` form, a variable transformer, and an unrecognised serializer all degrade with a note, and `#[FractalResponse]` remains authoritative. (#263)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -458,6 +458,56 @@ documented; annotate such actions with `#[FractalResponse]`. The two
 method names are a fixed whitelist — there is no configurable convention
 knob.
 
+### `fractal()` helper / facade / Manager call shapes
+
+The two dominant Fractal invocation styles — the `fractal()` helper and the
+`Spatie\Fractalistic\Fractal` facade — are documented without any
+`#[FractalResponse]`, as is the injected-`Manager` resource-construction style:
+
+```php
+public function show(): JsonResponse
+{
+    return fractal()->item(new Booking(), new BookingTransformer())->respond();   // {data: $ref}
+}
+
+public function index(): JsonResponse
+{
+    return Fractal::create()
+        ->collection(Booking::all(), new BookingTransformer())
+        ->respond();                                                              // {data: [$ref]}
+}
+
+public function managed(Manager $fractal): JsonResponse
+{
+    $resource = new Item(new Booking(), new BookingTransformer());
+
+    return new JsonResponse($fractal->createData($resource)->toArray());          // {data: $ref}
+}
+```
+
+The binding reads the first `return` expression (and, for the `Manager` style, a
+`new Item(…)` / `new Collection(…)` resource) within the first 10 statements,
+and requires:
+
+- an `->item(…)` / `->collection(…)` chain link whose root is literally the
+  `fractal()` helper or the `Fractal` facade (so the same method names on an
+  unrelated service or query builder never match), or a single `new Item(…)` /
+  `new Collection(…)` resource — `item` / `Item` binds the single envelope,
+  `collection` / `Collection` the collection envelope;
+- a transformer named by a literal `new T()` or `T::class` argument that extends
+  `TransformerAbstract` and yields documentable fields.
+
+A trailing `->serializeWith(new ArraySerializer())` / `JsonApiSerializer` maps
+onto the matching serializer envelope. All Fractal classes are matched by name,
+so neither package need be installed for the scan to run.
+
+The **bare two-argument helper** `fractal($data, new T())` is **refused**: item
+vs collection is not statically knowable from the first argument, so the
+generator emits a generation-log note rather than guessing an envelope — annotate
+those actions with `#[FractalResponse]`. A variable/dynamic transformer, an
+unrecognised serializer, or a transformer with no documentable fields likewise
+degrade with a note; `#[FractalResponse]` always wins where declared.
+
 Lint rules:
 
 | Rule | Level |
@@ -472,10 +522,12 @@ Lint rules:
 literal is readable and yields fields — the schema is not empty then.
 
 > [!NOTE]
-> `fractal.response-unbound` is opt-in. The `fractal()` helper and
-> `Spatie\Fractalistic\Fractal` facade are invoked inside method bodies in
-> shapes the generator does not read (only the `$entity_transformer`
-> convention above is matched).
+> `fractal.response-unbound` is opt-in and keys off an **injected `Manager`
+> parameter** only. The `fractal()` helper and `Fractal` facade shapes never
+> inject a `Manager`, so they never trigger this rule — even now that the
+> generator reads them (see the call-shape binding above). The rule remains a
+> conservative backstop for the one Fractal style whose response the generator
+> cannot bind without an attribute when it carries no literal transformer.
 
 ## SwaggerPhp
 

--- a/src/Plugins/Fractal/FractalPlugin.php
+++ b/src/Plugins/Fractal/FractalPlugin.php
@@ -12,6 +12,7 @@ use Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules\FractalIncludeTransformerMiss
 use Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules\FractalResponseUnbound;
 use Radiergummi\OpenApi\Plugins\Fractal\Lint\Rules\FractalTransformerClassMissing;
 use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\EntityTransformerResponseResolver;
+use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\FractalHelperResponseResolver;
 use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\FractalResponseResolver;
 use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\TransformerRefSchemaResolver;
 use Radiergummi\OpenApi\Registry\OpenApiRegistry;
@@ -27,6 +28,7 @@ final class FractalPlugin implements Plugin
         $registry->addRefSchemaResolver(TransformerRefSchemaResolver::class);
         $registry->addPrimaryResponseResolver(FractalResponseResolver::class);
         $registry->addPrimaryResponseResolver(EntityTransformerResponseResolver::class);
+        $registry->addPrimaryResponseResolver(FractalHelperResponseResolver::class);
         $registry->addRule(FractalResponseUnbound::class);
         $registry->addRule(FractalFieldsUndeclared::class);
         $registry->addRule(FractalIncludeTransformerMissing::class);

--- a/src/Plugins/Fractal/Resolvers/FractalCallShape.php
+++ b/src/Plugins/Fractal/Resolvers/FractalCallShape.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fractal\Resolvers;
+
+use Radiergummi\OpenApi\Plugins\Fractal\Support\Serializer;
+
+/**
+ * A matched Fractal call shape: the transformer to document, whether the envelope is a collection,
+ * and the serializer it runs (null when an unrecognised serializer was named, which refuses).
+ *
+ * @internal
+ */
+final readonly class FractalCallShape
+{
+    /**
+     * @param class-string $transformerClass
+     */
+    public function __construct(
+        public string $transformerClass,
+        public bool $collection,
+        public ?Serializer $serializer,
+    ) {}
+}

--- a/src/Plugins/Fractal/Resolvers/FractalHelperResponseResolver.php
+++ b/src/Plugins/Fractal/Resolvers/FractalHelperResponseResolver.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fractal\Resolvers;
+
+use Illuminate\Container\Attributes\Scoped;
+use OpenApi\Annotations as OA;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeFinder;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Contracts\Attributes\PrimaryResponseAuthoringAttribute;
+use Radiergummi\OpenApi\Contracts\Registry\PrimaryResponseResolver;
+use Radiergummi\OpenApi\Enums\MediaType;
+use Radiergummi\OpenApi\Plugins\Fractal\Attributes\TransformerField;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\FractalEnvelopeFactory;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\SchemaFromTransformer;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\Serializer;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\TransformerTransformReader;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+
+use function class_exists;
+use function count;
+use function in_array;
+use function is_a;
+use function sprintf;
+
+/**
+ * Infers the primary response from the dominant Fractal invocation styles — a Tier-1 bounded scan
+ * (epic #5, issue #263), the deferred binding half of #13.
+ *
+ * Three call shapes are recognised within the first {@see self::STATEMENT_LIMIT} top-level
+ * statements:
+ *
+ * - the `fractal()` helper chained into `->item(…)` / `->collection(…)`,
+ * - the `Spatie\Fractalistic\Fractal` facade chained the same way (`Fractal::create()->item(…)`),
+ * - an injected `League\Fractal\Manager` fed a `new Item(…)` / `new Collection(…)` resource.
+ *
+ * The transformer comes from the resource/chain-link argument when it is a literal `new T()` or
+ * `T::class` naming a concrete `TransformerAbstract` subclass; `item` / `Item` binds the single
+ * envelope, `collection` / `Collection` the collection envelope. A trailing `->serializeWith(new
+ * …Serializer())` maps onto the modelled {@see Serializer} cases. All Fractal classes are matched
+ * by FQCN string, so the plugin never depends on the packages being installed.
+ *
+ * Degradation contract (mirrors {@see EntityTransformerResponseResolver}): the bare two-argument
+ * helper `fractal($data, new T())` is refused — item vs collection is not statically knowable from
+ * the first argument. A variable/dynamic transformer, an unrecognised serializer, or a transformer
+ * with no documentable fields all refuse with a generation-log note. An action carrying a
+ * {@see PrimaryResponseAuthoringAttribute} (`#[FractalResponse]`) is never scanned, and the
+ * return-type guard keeps the scan away from signatures the Tier-0 resolvers already own.
+ */
+#[Scoped]
+final readonly class FractalHelperResponseResolver implements PrimaryResponseResolver
+{
+    public const int STATEMENT_LIMIT = 10;
+
+    private const string HELPER_FUNCTION = 'fractal';
+
+    /**
+     * The static entrypoint classes recognised for `Fractal::create()`: the Fractalistic base
+     * class, the laravel-fractal subclass, and laravel-fractal's facade alias. Matched by FQCN
+     * string so neither package need be installed.
+     */
+    private const array FACADE_CLASSES = [
+        'Spatie\\Fractalistic\\Fractal',
+        'Spatie\\Fractal\\Fractal',
+        'Spatie\\Fractal\\Facades\\Fractal',
+    ];
+
+    private const string FACADE_FACTORY_METHOD = 'create';
+
+    private const string ITEM_METHOD = 'item';
+
+    private const string COLLECTION_METHOD = 'collection';
+
+    private const string RESOURCE_ITEM_CLASS = 'League\\Fractal\\Resource\\Item';
+
+    private const string RESOURCE_COLLECTION_CLASS = 'League\\Fractal\\Resource\\Collection';
+
+    private const string SERIALIZE_WITH_METHOD = 'serializeWith';
+
+    /**
+     * `new` serializer FQCN → modelled enum case. An unrecognised serializer refuses.
+     */
+    private const array SERIALIZER_CLASSES = [
+        'League\\Fractal\\Serializer\\DataArraySerializer' => Serializer::DataArray,
+        'League\\Fractal\\Serializer\\ArraySerializer' => Serializer::ArraySerializer,
+        'Spatie\\Fractalistic\\ArraySerializer' => Serializer::ArraySerializer,
+        'League\\Fractal\\Serializer\\JsonApiSerializer' => Serializer::JsonApi,
+    ];
+
+    public function __construct(
+        private MethodBodyScanner $scanner,
+        private TransformerTransformReader $transformReader,
+        private SchemaFromTransformer $schemaFromTransformer,
+        private FractalEnvelopeFactory $envelopeFactory,
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @throws ReflectionException
+     */
+    #[Override]
+    public function resolvePrimaryResponse(ActionDescriptor $descriptor): ?OA\Response
+    {
+        $method = $descriptor->method;
+
+        if ($method === null || !$this->returnTypeAllowsBodyScan($method)) {
+            return null;
+        }
+
+        // An explicit authoring attribute always wins; #[FractalResponse] is consumed by
+        // FractalResponseResolver earlier in the chain.
+        if ($descriptor->declaresAttributeImplementing(PrimaryResponseAuthoringAttribute::class)) {
+            return null;
+        }
+
+        $statements = $this->scanner->firstStatements($method, self::STATEMENT_LIMIT);
+
+        if ($statements === []) {
+            return null;
+        }
+
+        $match = $this->matchCallShape($statements);
+
+        if ($match === null) {
+            return null;
+        }
+
+        if (!$this->transformReader->isTransformerSubclass($match->transformerClass)) {
+            return null;
+        }
+
+        if (!$this->hasDocumentableFields($match->transformerClass)) {
+            $this->note(
+                $method,
+                sprintf(
+                    'but transformer %s declares no #[TransformerField] and yields no documentable fields',
+                    $match->transformerClass,
+                ),
+            );
+
+            return null;
+        }
+
+        $serializer = $match->serializer;
+
+        if ($serializer === null) {
+            $this->note($method, 'but the serializer it is configured with is not one of the modelled cases');
+
+            return null;
+        }
+
+        $ref = $this->schemaFromTransformer->buildRef($match->transformerClass);
+        $envelope = $match->collection
+            ? $this->envelopeFactory->collection($ref, $serializer)
+            : $this->envelopeFactory->single($ref, $serializer);
+        $mediaType = $serializer === Serializer::JsonApi ? MediaType::JsonApi : MediaType::Json;
+
+        return new OA\Response([
+            'response' => '200',
+            'description' => 'OK',
+            'content' => [$mediaType->schema($envelope)],
+        ]);
+    }
+
+    // region Call-shape matching
+
+    /**
+     * The first recognised Fractal call shape within the scanned statements, or null. The helper
+     * and facade shapes resolve from the first top-level `return` expression; the injected-Manager
+     * shape resolves from a `new Item(…)` / `new Collection(…)` resource anywhere in the
+     * statements (a single one, or it is ambiguous and refused).
+     *
+     * @param list<Node\Stmt> $statements
+     */
+    private function matchCallShape(array $statements): ?FractalCallShape
+    {
+        $returnExpression = $this->firstReturnExpression($statements);
+
+        if ($returnExpression !== null) {
+            $chained = $this->matchChainedShape($returnExpression);
+
+            if ($chained !== null) {
+                return $chained;
+            }
+        }
+
+        return $this->matchManagerResourceShape($statements);
+    }
+
+    /**
+     * The expression of the first top-level `return` statement.
+     *
+     * @param list<Node\Stmt> $statements
+     */
+    private function firstReturnExpression(array $statements): ?Expr
+    {
+        foreach ($statements as $statement) {
+            if ($statement instanceof Return_) {
+                return $statement->expr;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Walks a method-call chain from its outer terminal links inward, collecting the serializer
+     * named by `->serializeWith(…)`, until it reaches an `->item(…)` / `->collection(…)` link
+     * whose chain root is the `fractal()` helper or the Fractalistic facade. Any other root — an
+     * unrelated service or query builder exposing the same method names — does not match.
+     */
+    private function matchChainedShape(Expr $expression): ?FractalCallShape
+    {
+        $serializer = Serializer::DataArray;
+
+        $node = $expression;
+
+        while ($node instanceof MethodCall && $node->name instanceof Node\Identifier) {
+            $methodName = $node->name->toString();
+
+            if ($methodName === self::SERIALIZE_WITH_METHOD) {
+                $serializer = $this->serializerFrom($node->args);
+            }
+
+            if ($methodName === self::ITEM_METHOD || $methodName === self::COLLECTION_METHOD) {
+                if (!$this->isFractalEntrypoint($node->var)) {
+                    return null;
+                }
+
+                $transformerClass = $this->transformerArgument($node->args, 1);
+
+                if ($transformerClass === null) {
+                    return null;
+                }
+
+                return new FractalCallShape(
+                    $transformerClass,
+                    collection: $methodName === self::COLLECTION_METHOD,
+                    serializer: $serializer,
+                );
+            }
+
+            $node = $node->var;
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the receiver of an `->item(…)` / `->collection(…)` link is a Fractal entrypoint:
+     * the `fractal()` helper call or the `Fractal::create()` / facade static call. Asserting the
+     * concrete root is what keeps the same method names on unrelated receivers from matching.
+     */
+    private function isFractalEntrypoint(Expr $receiver): bool
+    {
+        if ($receiver instanceof FuncCall) {
+            return $receiver->name instanceof Name
+                && $receiver->name->toString() === self::HELPER_FUNCTION;
+        }
+
+        if ($receiver instanceof StaticCall) {
+            return $receiver->class instanceof Name
+                && $this->isFacadeClass($receiver->class->toString())
+                && $receiver->name instanceof Node\Identifier
+                && $receiver->name->toString() === self::FACADE_FACTORY_METHOD;
+        }
+
+        return false;
+    }
+
+    private function isFacadeClass(string $class): bool
+    {
+        return in_array($class, self::FACADE_CLASSES, true);
+    }
+
+    /**
+     * The single `new Item(…)` / `new Collection(…)` resource construction across the scanned
+     * statements (the injected-Manager shape). Two or more resource constructions are ambiguous
+     * and refused.
+     *
+     * @param list<Node\Stmt> $statements
+     */
+    private function matchManagerResourceShape(array $statements): ?FractalCallShape
+    {
+        $resources = new NodeFinder()->find(
+            $statements,
+            fn(Node $node): bool => $node instanceof New_ && $this->isResourceClass($node->class),
+        );
+
+        if (count($resources) !== 1) {
+            return null;
+        }
+
+        /** @var New_ $resource */
+        $resource = $resources[0];
+
+        /** @var Name $resourceClass */
+        $resourceClass = $resource->class;
+        $transformerClass = $this->transformerArgument($resource->args, 1);
+
+        if ($transformerClass === null) {
+            return null;
+        }
+
+        return new FractalCallShape(
+            $transformerClass,
+            collection: $resourceClass->toString() === self::RESOURCE_COLLECTION_CLASS,
+            serializer: Serializer::DataArray,
+        );
+    }
+
+    private function isResourceClass(Node $class): bool
+    {
+        return $class instanceof Name
+            && ($class->toString() === self::RESOURCE_ITEM_CLASS
+                || $class->toString() === self::RESOURCE_COLLECTION_CLASS);
+    }
+
+    /**
+     * The class named by the argument at the given index, when it is a literal `new T(…)` or
+     * `T::class`. Anything else (a variable, a method call, a property) is not statically knowable.
+     *
+     * @param array<int, Arg|Node\VariadicPlaceholder> $args
+     *
+     * @return null|class-string
+     */
+    private function transformerArgument(array $args, int $index): ?string
+    {
+        $argument = $args[$index] ?? null;
+
+        if (!$argument instanceof Arg) {
+            return null;
+        }
+
+        $value = $argument->value;
+
+        $name = match (true) {
+            $value instanceof New_ && $value->class instanceof Name => $value->class->toString(),
+            $value instanceof ClassConstFetch
+                && $value->class instanceof Name
+                && $value->name instanceof Node\Identifier
+                && $value->name->toString() === 'class' => $value->class->toString(),
+            default => null,
+        };
+
+        return $name !== null && class_exists($name) ? $name : null;
+    }
+
+    /**
+     * The modelled serializer named by a `->serializeWith(new …Serializer())` argument, or null
+     * when the argument names a serializer outside the three modelled cases — which refuses
+     * rather than documenting the wrong envelope.
+     *
+     * @param array<int, Arg|Node\VariadicPlaceholder> $args
+     */
+    private function serializerFrom(array $args): ?Serializer
+    {
+        $argument = $args[0] ?? null;
+
+        if (!$argument instanceof Arg || !$argument->value instanceof New_) {
+            return null;
+        }
+
+        $class = $argument->value->class;
+
+        if (!$class instanceof Name) {
+            return null;
+        }
+
+        return self::SERIALIZER_CLASSES[$class->toString()] ?? null;
+    }
+
+    // endregion
+
+    // region Guards & logging
+
+    /**
+     * Whether the declared return type leaves room for a body scan: untyped, a builtin, or an
+     * HTTP response class. Any other named type is Tier-0 territory the signature resolvers own;
+     * union and intersection types are refused rather than arbitrated.
+     */
+    private function returnTypeAllowsBodyScan(ReflectionMethod $method): bool
+    {
+        $returnType = $method->getReturnType();
+
+        if ($returnType === null) {
+            return true;
+        }
+
+        if (!$returnType instanceof ReflectionNamedType) {
+            return false;
+        }
+
+        return $returnType->isBuiltin()
+            || is_a($returnType->getName(), HttpFoundationResponse::class, true);
+    }
+
+    /**
+     * Whether the transformer yields any documentable fields — declared `#[TransformerField]`
+     * attributes or a readable `transform()` literal. Binding an envelope around a genuinely empty
+     * item schema would document nothing while claiming authority over the response.
+     *
+     * @param class-string $transformerClass
+     *
+     * @throws ReflectionException
+     */
+    private function hasDocumentableFields(string $transformerClass): bool
+    {
+        if (new ReflectionClass($transformerClass)->getAttributes(TransformerField::class) !== []) {
+            return true;
+        }
+
+        $inferred = $this->transformReader->read($transformerClass);
+
+        return $inferred !== null && $inferred !== [];
+    }
+
+    private function note(ReflectionMethod $method, string $reason): void
+    {
+        $this->logger->notice(
+            sprintf(
+                'fractal() helper / facade / Manager response in %s::%s %s; no response inferred. '
+                . 'Annotate the action with #[FractalResponse] to document it.',
+                $method->getDeclaringClass()->getName(),
+                $method->getName(),
+                $reason,
+            ),
+        );
+    }
+
+    // endregion
+}

--- a/tests/Feature/Plugins/Fractal/FractalCallShapeResponseTest.php
+++ b/tests/Feature/Plugins/Fractal/FractalCallShapeResponseTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature\Plugins\Fractal;
+
+use Illuminate\Support\Facades\Route;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Plugins\ApiResources\ApiResourcesPlugin;
+use Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin;
+use Radiergummi\OpenApi\Plugins\SpatieData\SpatieDataPlugin;
+use Radiergummi\OpenApi\Tests\Fixtures\Fractal\FacadeFractalController;
+use Radiergummi\OpenApi\Tests\Fixtures\Fractal\HelperFractalController;
+use Radiergummi\OpenApi\Tests\Fixtures\Fractal\ManagerFractalController;
+use Radiergummi\OpenApi\Tests\Fixtures\Fractal\NonFractalReceiverController;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\EmptyTransformer;
+
+use function array_any;
+use function str_contains;
+
+uses()->group('openapi', 'plugin:fractal');
+
+beforeEach(function (): void {
+    config(['openapi.plugins' => [
+        SpatieDataPlugin::class,
+        ApiResourcesPlugin::class,
+        FractalPlugin::class,
+    ]]);
+});
+
+/**
+ * @param array<string, mixed> $spec
+ *
+ * @return null|array<string, mixed>
+ */
+function callShapeSchema(array $spec, string $path, string $mediaType = 'application/json'): ?array
+{
+    return $spec['paths'][$path]['get']['responses']['200']['content'][$mediaType]['schema'] ?? null;
+}
+
+it('binds fractal()->item() to the single envelope', function (): void {
+    Route::get('/helper/item', [HelperFractalController::class, 'item']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/item');
+
+    expect($schema['properties']['data']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('binds fractal()->collection() to the collection envelope', function (): void {
+    Route::get('/helper/collection', [HelperFractalController::class, 'collection']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/collection');
+
+    expect($schema['properties']['data']['type'] ?? null)->toBe('array')
+        ->and($schema['properties']['data']['items']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('reads the transformer from a ::class argument', function (): void {
+    Route::get('/helper/class-const', [HelperFractalController::class, 'classConstTransformer']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/class-const');
+
+    expect($schema['properties']['data']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('binds the Fractalistic facade item() to the single envelope', function (): void {
+    Route::get('/facade/item', [FacadeFractalController::class, 'item']);
+
+    $schema = callShapeSchema(generateSpec(), '/facade/item');
+
+    expect($schema['properties']['data']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('binds the Fractalistic facade collection() to the collection envelope', function (): void {
+    Route::get('/facade/collection', [FacadeFractalController::class, 'collection']);
+
+    $schema = callShapeSchema(generateSpec(), '/facade/collection');
+
+    expect($schema['properties']['data']['type'] ?? null)->toBe('array')
+        ->and($schema['properties']['data']['items']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('binds an injected Manager + new Item() to the single envelope', function (): void {
+    Route::get('/manager/item', [ManagerFractalController::class, 'item']);
+
+    $schema = callShapeSchema(generateSpec(), '/manager/item');
+
+    expect($schema['properties']['data']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('binds an injected Manager + new Collection() to the collection envelope', function (): void {
+    Route::get('/manager/collection', [ManagerFractalController::class, 'collection']);
+
+    $schema = callShapeSchema(generateSpec(), '/manager/collection');
+
+    expect($schema['properties']['data']['type'] ?? null)->toBe('array')
+        ->and($schema['properties']['data']['items']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('applies the ArraySerializer envelope when serializeWith names it', function (): void {
+    Route::get('/helper/array-serializer', [HelperFractalController::class, 'arraySerializer']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/array-serializer');
+
+    // ArraySerializer collections are a top-level array, not a {data: [...]} wrapper.
+    expect($schema['type'] ?? null)->toBe('array')
+        ->and($schema['items']['$ref'] ?? null)->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('applies the JsonApi envelope and media type when serializeWith names it', function (): void {
+    Route::get('/helper/jsonapi', [HelperFractalController::class, 'jsonApiSerializer']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/jsonapi', 'application/vnd.api+json');
+
+    expect($schema['properties']['data']['properties']['attributes']['$ref'] ?? null)
+        ->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('refuses the bare two-argument helper form — item vs collection is not knowable', function (): void {
+    Route::get('/helper/bare', [HelperFractalController::class, 'bareTwoArgument']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/bare');
+
+    expect($schema['properties']['data'] ?? null)->toBeNull();
+});
+
+it('refuses a variable transformer argument', function (): void {
+    Route::get('/helper/variable', [HelperFractalController::class, 'variableTransformer']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/variable');
+
+    expect($schema['properties']['data'] ?? null)->toBeNull();
+});
+
+it('refuses a transformer with no documentable fields, noting it', function (): void {
+    Route::get('/helper/empty', [HelperFractalController::class, 'emptyTransformer']);
+
+    $logger = recordingLogger();
+    app()->instance(LoggerInterface::class, $logger);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/empty');
+
+    expect($schema['properties']['data'] ?? null)->toBeNull();
+
+    $noted = array_any(
+        $logger->records,
+        static fn(array $record): bool => str_contains($record['message'], EmptyTransformer::class)
+            && str_contains($record['message'], 'yields no documentable fields'),
+    );
+
+    expect($noted)->toBeTrue();
+});
+
+it('refuses an unrecognised serializer rather than guessing the envelope', function (): void {
+    Route::get('/helper/unknown-serializer', [HelperFractalController::class, 'unknownSerializer']);
+
+    $schema = callShapeSchema(generateSpec(), '/helper/unknown-serializer');
+
+    expect($schema['properties']['data'] ?? null)->toBeNull();
+});
+
+it('does not fire on item()/collection() calls on a non-Fractal receiver', function (): void {
+    Route::get('/non-fractal/service', [NonFractalReceiverController::class, 'viaService']);
+    Route::get('/non-fractal/query', [NonFractalReceiverController::class, 'viaQuery']);
+
+    $spec = generateSpec();
+
+    expect(callShapeSchema($spec, '/non-fractal/service')['properties']['data'] ?? null)->toBeNull()
+        ->and(callShapeSchema($spec, '/non-fractal/query')['properties']['data'] ?? null)->toBeNull()
+        ->and($spec['components']['schemas'] ?? [])->not->toHaveKey('InferredArticleTransformer');
+});

--- a/tests/Fixtures/Fractal/ArticleService.php
+++ b/tests/Fixtures/Fractal/ArticleService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Fractal;
+
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\InferredArticleTransformer;
+
+/**
+ * An unrelated service that happens to expose `item()` / `collection()` methods — used to prove
+ * the binding does not fire on non-Fractal receivers.
+ */
+final class ArticleService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function item(Article $article, InferredArticleTransformer $transformer): array
+    {
+        return $transformer->transform($article);
+    }
+
+    /**
+     * @param list<string> $rows
+     *
+     * @return list<string>
+     */
+    public function collection(array $rows, InferredArticleTransformer $transformer): array
+    {
+        return $rows;
+    }
+}

--- a/tests/Fixtures/Fractal/CustomSerializer.php
+++ b/tests/Fixtures/Fractal/CustomSerializer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Fractal;
+
+use League\Fractal\Serializer\ArraySerializer;
+
+/**
+ * A serializer outside the three modelled FQCNs — used to pin the unknown-serializer refusal.
+ * Matching is by exact class name, so subclassing a modelled serializer does not make it match.
+ */
+final class CustomSerializer extends ArraySerializer {}

--- a/tests/Fixtures/Fractal/FacadeFractalController.php
+++ b/tests/Fixtures/Fractal/FacadeFractalController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Fractal;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\InferredArticleTransformer;
+use Spatie\Fractal\Fractal;
+
+/**
+ * Controllers using the `Spatie\Fractal\Fractal::create()` facade-style entrypoint, chained into
+ * `item()` / `collection()`.
+ */
+final class FacadeFractalController extends Controller
+{
+    public function item(): JsonResponse
+    {
+        return Fractal::create()->item(new Article(), new InferredArticleTransformer())->respond();
+    }
+
+    public function collection(): JsonResponse
+    {
+        return Fractal::create()
+            ->collection(Article::query()->get(), new InferredArticleTransformer())
+            ->respond();
+    }
+}

--- a/tests/Fixtures/Fractal/HelperFractalController.php
+++ b/tests/Fixtures/Fractal/HelperFractalController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Fractal;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use League\Fractal\Serializer\ArraySerializer;
+use League\Fractal\Serializer\JsonApiSerializer;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\EmptyTransformer;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\InferredArticleTransformer;
+
+use function fractal;
+
+/**
+ * Controllers using the `fractal()` helper and its chained `item()` / `collection()` shapes,
+ * terminated with `respond()` — the dominant in-the-wild Fractal invocation style.
+ */
+final class HelperFractalController extends Controller
+{
+    public function item(): JsonResponse
+    {
+        return fractal()->item(new Article(), new InferredArticleTransformer())->respond();
+    }
+
+    public function collection(): JsonResponse
+    {
+        return fractal()->collection(Article::query()->get(), new InferredArticleTransformer())->respond();
+    }
+
+    public function classConstTransformer(): JsonResponse
+    {
+        return fractal()->item(new Article(), InferredArticleTransformer::class)->respond();
+    }
+
+    public function arraySerializer(): JsonResponse
+    {
+        return fractal()
+            ->collection(Article::query()->get(), new InferredArticleTransformer())
+            ->serializeWith(new ArraySerializer())
+            ->respond();
+    }
+
+    public function jsonApiSerializer(): JsonResponse
+    {
+        return fractal()
+            ->item(new Article(), new InferredArticleTransformer())
+            ->serializeWith(new JsonApiSerializer())
+            ->respond();
+    }
+
+    /** Bare two-arg helper: item vs collection is not statically knowable — refused. */
+    public function bareTwoArgument(): JsonResponse
+    {
+        return fractal(new Article(), new InferredArticleTransformer())->respond();
+    }
+
+    /** The transformer is a variable, not a literal — refused. */
+    public function variableTransformer(): JsonResponse
+    {
+        $transformer = new InferredArticleTransformer();
+
+        return fractal()->item(new Article(), $transformer)->respond();
+    }
+
+    /** The transformer yields no documentable fields — refused with a note. */
+    public function emptyTransformer(): JsonResponse
+    {
+        return fractal()->item(new Article(), new EmptyTransformer())->respond();
+    }
+
+    /** An unrecognised serializer — refused rather than guessing the envelope. */
+    public function unknownSerializer(): JsonResponse
+    {
+        return fractal()
+            ->item(new Article(), new InferredArticleTransformer())
+            ->serializeWith(new CustomSerializer())
+            ->respond();
+    }
+}

--- a/tests/Fixtures/Fractal/ManagerFractalController.php
+++ b/tests/Fixtures/Fractal/ManagerFractalController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Fractal;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\InferredArticleTransformer;
+
+/**
+ * Controllers constructing `League\Fractal\Resource\Item` / `Collection` directly and serialising
+ * them through an injected `Manager` — the third recognised invocation style.
+ */
+final class ManagerFractalController extends Controller
+{
+    public function __construct(private readonly Manager $fractal) {}
+
+    public function item(): JsonResponse
+    {
+        $resource = new Item(new Article(), new InferredArticleTransformer());
+
+        return new JsonResponse($this->fractal->createData($resource)->toArray());
+    }
+
+    public function collection(): JsonResponse
+    {
+        $resource = new Collection(Article::query()->get(), new InferredArticleTransformer());
+
+        return new JsonResponse($this->fractal->createData($resource)->toArray());
+    }
+}

--- a/tests/Fixtures/Fractal/NonFractalReceiverController.php
+++ b/tests/Fixtures/Fractal/NonFractalReceiverController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Fractal;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\InferredArticleTransformer;
+
+/**
+ * `item()` / `collection()` calls whose receiver is NOT the `fractal()` helper or the Fractalistic
+ * facade — an unrelated service or query builder. These must never be mistaken for a Fractal
+ * binding, even though the method names and a literal transformer-like argument coincide.
+ */
+final class NonFractalReceiverController extends Controller
+{
+    public function __construct(private readonly ArticleService $service) {}
+
+    public function viaService(): JsonResponse
+    {
+        return new JsonResponse($this->service->item(new Article(), new InferredArticleTransformer()));
+    }
+
+    public function viaQuery(): JsonResponse
+    {
+        return new JsonResponse($this->service->collection(['a'], new InferredArticleTransformer()));
+    }
+}

--- a/tests/Unit/Plugins/Fractal/FractalHelperResponseResolverTest.php
+++ b/tests/Unit/Plugins/Fractal/FractalHelperResponseResolverTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Plugins\Fractal;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Route;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use League\Fractal\Serializer\ArraySerializer;
+use League\Fractal\Serializer\JsonApiSerializer;
+use OpenApi\Annotations as OA;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Radiergummi\OpenApi\Plugins\Fractal\Attributes\FractalResponse;
+use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\FractalHelperResponseResolver;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\FractalEnvelopeFactory;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\SchemaFromTransformer;
+use Radiergummi\OpenApi\Plugins\Fractal\Support\TransformerTransformReader;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\Extraction\EloquentModelToSchema;
+use Radiergummi\OpenApi\Support\Extraction\ModelFactoryExampleReader;
+use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Generator\JsonSchemaFromType;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Support\MethodBody\SingleReturnArrayLiteralFinder;
+use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
+use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
+use Radiergummi\OpenApi\Support\Types\TypeNodeToSchema;
+use Radiergummi\OpenApi\Tests\Fixtures\Fractal\CustomSerializer;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Article;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\EmptyTransformer;
+use Radiergummi\OpenApi\Tests\Fixtures\Transformers\InferredArticleTransformer;
+use ReflectionClass;
+use ReflectionMethod;
+use Stringable;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+
+use function array_any;
+use function fractal;
+use function is_array;
+use function str_contains;
+
+uses()->group('openapi', 'plugin:fractal');
+
+// region Fixtures
+
+/**
+ * An unrelated service exposing `item()` / `collection()` — proves the binding keys off the
+ * `fractal()` / facade chain root, not the method names.
+ */
+class HelperResolverFakeService
+{
+    public function item(mixed $data, mixed $transformer): mixed
+    {
+        return $data;
+    }
+
+    public function collection(mixed $data, mixed $transformer): mixed
+    {
+        return $data;
+    }
+}
+
+/**
+ * Parse-only fixture; actions are never invoked. Each body exercises one call shape.
+ */
+class HelperResolverFixtureController
+{
+    public function __construct(
+        private readonly Manager $manager = new Manager(),
+        private readonly HelperResolverFakeService $service = new HelperResolverFakeService(),
+    ) {}
+
+    public function helperItem(): JsonResponse
+    {
+        return fractal()->item(new Article(), new InferredArticleTransformer())->respond();
+    }
+
+    public function helperCollection(): JsonResponse
+    {
+        return fractal()->collection([], new InferredArticleTransformer())->respond();
+    }
+
+    public function classConstTransformer(): JsonResponse
+    {
+        return fractal()->item(new Article(), InferredArticleTransformer::class)->respond();
+    }
+
+    public function arraySerializer(): JsonResponse
+    {
+        return fractal()
+            ->collection([], new InferredArticleTransformer())
+            ->serializeWith(new ArraySerializer())
+            ->respond();
+    }
+
+    public function jsonApiSerializer(): JsonResponse
+    {
+        return fractal()
+            ->item(new Article(), new InferredArticleTransformer())
+            ->serializeWith(new JsonApiSerializer())
+            ->respond();
+    }
+
+    public function managerItem(): JsonResponse
+    {
+        $resource = new Item(new Article(), new InferredArticleTransformer());
+
+        return new JsonResponse($this->manager->createData($resource)->toArray());
+    }
+
+    public function managerCollection(): JsonResponse
+    {
+        $resource = new Collection([], new InferredArticleTransformer());
+
+        return new JsonResponse($this->manager->createData($resource)->toArray());
+    }
+
+    /** Bare two-arg helper: item vs collection is not knowable. */
+    public function bareTwoArgument(): JsonResponse
+    {
+        return fractal(new Article(), new InferredArticleTransformer())->respond();
+    }
+
+    public function variableTransformer(): JsonResponse
+    {
+        $transformer = new InferredArticleTransformer();
+
+        return fractal()->item(new Article(), $transformer)->respond();
+    }
+
+    public function emptyTransformer(): JsonResponse
+    {
+        return fractal()->item(new Article(), new EmptyTransformer())->respond();
+    }
+
+    public function unknownSerializer(): JsonResponse
+    {
+        return fractal()
+            ->item(new Article(), new InferredArticleTransformer())
+            ->serializeWith(new CustomSerializer())
+            ->respond();
+    }
+
+    #[FractalResponse(transformer: InferredArticleTransformer::class)]
+    public function attributed(): JsonResponse
+    {
+        return fractal()->item(new Article(), new InferredArticleTransformer())->respond();
+    }
+
+    public function typedModelReturn(): Article
+    {
+        return new Article();
+    }
+
+    public function serviceItem(): mixed
+    {
+        return $this->service->item(new Article(), new InferredArticleTransformer());
+    }
+
+    public function serviceCollection(): mixed
+    {
+        return $this->service->collection([], new InferredArticleTransformer());
+    }
+
+    public function plain(): mixed
+    {
+        return ['ok' => true];
+    }
+}
+
+// endregion
+
+// region Helpers
+
+function helperResolver(?LoggerInterface $logger = null): FractalHelperResponseResolver
+{
+    $logger ??= new NullLogger();
+    $registry = new ComponentSchemaRegistry();
+
+    $transformReader = new TransformerTransformReader(
+        returnLiteralFinder: new SingleReturnArrayLiteralFinder(new MethodBodyScanner()),
+        modelToSchema: new EloquentModelToSchema(
+            registry: $registry,
+            jsonSchemaFromType: new JsonSchemaFromType($logger, $registry),
+            typeNodeToSchema: new TypeNodeToSchema(),
+            typeResolver: TypeResolver::create(),
+            typeNodeResolver: TypeNodeResolver::create(),
+            docBlockParser: DocBlockParser::create(),
+            factoryExampleReader: new ModelFactoryExampleReader(seed: 1234, logger: $logger),
+            logger: $logger,
+        ),
+    );
+
+    $schemaFromTransformer = new SchemaFromTransformer(
+        registry: $registry,
+        refSchemaResolvers: static fn(): array => [],
+        transformReader: $transformReader,
+        logger: $logger,
+    );
+
+    return new FractalHelperResponseResolver(
+        new MethodBodyScanner(),
+        $transformReader,
+        $schemaFromTransformer,
+        new FractalEnvelopeFactory(),
+        $logger,
+    );
+}
+
+function helperDescriptor(string $method): ActionDescriptor
+{
+    /** @var class-string $controller */
+    $controller = HelperResolverFixtureController::class;
+
+    return new ActionDescriptor(
+        route: new Route(['GET'], '/test', static fn() => null),
+        controller: new ReflectionClass($controller),
+        method: new ReflectionMethod($controller, $method),
+        summary: null,
+        description: null,
+    );
+}
+
+/**
+ * @return AbstractLogger&object{records: list<array{message: string}>}
+ */
+function helperRecordingLogger(): AbstractLogger
+{
+    return new class () extends AbstractLogger {
+        /** @var list<array{message: string}> */
+        public array $records = [];
+
+        public function log(mixed $level, string|Stringable $message, array $context = []): void
+        {
+            $this->records[] = ['message' => (string) $message];
+        }
+    };
+}
+
+/**
+ * The `OA\Schema` carried for the given media type by an `OA\Response`, or null when the response
+ * is null or carries no content for that media type.
+ */
+function helperContentSchema(?OA\Response $response, string $mediaType = 'application/json'): mixed
+{
+    $content = $response?->content;
+
+    if (!is_array($content)) {
+        return null;
+    }
+
+    foreach ($content as $entry) {
+        if ($entry instanceof OA\MediaType && $entry->mediaType === $mediaType) {
+            return $entry->schema;
+        }
+    }
+
+    return null;
+}
+
+// endregion
+
+it('binds fractal()->item() to the single envelope', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('helperItem'));
+
+    $schema = helperContentSchema($response);
+
+    expect($schema)->not->toBeNull()
+        ->and($schema->properties[0]->property)->toBe('data');
+});
+
+it('binds fractal()->collection() to the collection envelope', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('helperCollection'));
+
+    $schema = helperContentSchema($response);
+
+    expect($schema->properties[0]->property)->toBe('data')
+        ->and($schema->properties[0]->type)->toBe('array');
+});
+
+it('reads the transformer from a ::class argument', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('classConstTransformer'));
+
+    expect(helperContentSchema($response))->not->toBeNull();
+});
+
+it('binds an injected Manager + new Item() to the single envelope', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('managerItem'));
+
+    $schema = helperContentSchema($response);
+
+    expect($schema->properties[0]->property)->toBe('data')
+        ->and($schema->properties[0]->ref)->toBe('#/components/schemas/InferredArticleTransformer');
+});
+
+it('binds an injected Manager + new Collection() to the collection envelope', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('managerCollection'));
+
+    $schema = helperContentSchema($response);
+
+    expect($schema->properties[0]->property)->toBe('data')
+        ->and($schema->properties[0]->type)->toBe('array');
+});
+
+it('maps serializeWith(ArraySerializer) onto the ArraySerializer envelope', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('arraySerializer'));
+
+    $schema = helperContentSchema($response);
+
+    // ArraySerializer collections are a top-level array, not a {data: [...]} wrapper.
+    expect($schema->type)->toBe('array');
+});
+
+it('maps serializeWith(JsonApiSerializer) onto the JsonApi envelope and media type', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('jsonApiSerializer'));
+
+    expect(helperContentSchema($response, 'application/vnd.api+json'))->not->toBeNull()
+        ->and(helperContentSchema($response))->toBeNull();
+});
+
+it('refuses the bare two-argument helper form', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('bareTwoArgument'));
+
+    expect($response)->toBeNull();
+});
+
+it('refuses a variable transformer argument', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('variableTransformer'));
+
+    expect($response)->toBeNull();
+});
+
+it('refuses a transformer with no documentable fields, noting it', function (): void {
+    $logger = helperRecordingLogger();
+    $response = helperResolver($logger)->resolvePrimaryResponse(helperDescriptor('emptyTransformer'));
+
+    expect($response)->toBeNull();
+
+    $noted = array_any(
+        $logger->records,
+        static fn(array $record): bool => str_contains($record['message'], EmptyTransformer::class)
+            && str_contains($record['message'], 'yields no documentable fields'),
+    );
+
+    expect($noted)->toBeTrue();
+});
+
+it('refuses an unrecognised serializer, noting it', function (): void {
+    $logger = helperRecordingLogger();
+    $response = helperResolver($logger)->resolvePrimaryResponse(helperDescriptor('unknownSerializer'));
+
+    expect($response)->toBeNull();
+
+    $noted = array_any(
+        $logger->records,
+        static fn(array $record): bool => str_contains($record['message'], 'not one of the modelled cases'),
+    );
+
+    expect($noted)->toBeTrue();
+});
+
+it('never scans an action carrying #[FractalResponse]', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('attributed'));
+
+    expect($response)->toBeNull();
+});
+
+it('refuses a named non-HTTP return type', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('typedModelReturn'));
+
+    expect($response)->toBeNull();
+});
+
+it('does not fire on item() called on a non-Fractal receiver', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('serviceItem'));
+
+    expect($response)->toBeNull();
+});
+
+it('does not fire on collection() called on a non-Fractal receiver', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('serviceCollection'));
+
+    expect($response)->toBeNull();
+});
+
+it('stays silent for a method without any whitelisted call shape', function (): void {
+    $response = helperResolver()->resolvePrimaryResponse(helperDescriptor('plain'));
+
+    expect($response)->toBeNull();
+});


### PR DESCRIPTION
Closes #263

## Implementation plan — #263 Fractal binding from `fractal()` helper / facade / injected-`Manager`

### What & why

Bind a Fractal transformer to an endpoint by reading the `fractal()` helper, the
`Spatie\Fractalistic\Fractal` facade, and injected-`Manager` resource-construction call shapes from
the controller method body — the binding half of #13 that PR #261 explicitly deferred (confirmed via
PR #261 scope-decision comment §2). These are the two dominant invocation styles in the wild
(`return fractal($invoice, new InvoiceTransformer())->respond();` and `Fractal::create(...)`), and
they're exactly what the `fractal.response-unbound` lint rule cannot see (it keys off an injected
`Manager` parameter only).

### Tier

**Tier 1** — bounded AST whitelist over the scanned return expression, matching the first N top-level
statements, no cross-call variable tracking. Reuses the #13 machinery wholesale:
`TransformerTransformReader`, `SchemaFromTransformer`, `FractalEnvelopeFactory`, `MethodBodyScanner`,
`StatementNodeFinder`. No new tier; no dataflow.

### The seam (verified)

The precedent to mirror is `EntityTransformerResponseResolver`
(`src/Plugins/Fractal/Resolvers/EntityTransformerResponseResolver.php`) — a `#[Scoped]`
`PrimaryResponseResolver` that scans the body, resolves a transformer class, and wraps its
`SchemaFromTransformer` ref in a `FractalEnvelopeFactory` envelope. The new resolver is a sibling
with a different call-shape whitelist.

Available, already-built pieces:
- `FractalEnvelopeFactory::single($ref, $serializer)`, `::collection(...)`, `::paginated(...)` — all
  take an optional `Serializer` (cases: `DataArray` default, `ArraySerializer`, `JsonApi`).
- `SchemaFromTransformer::buildRef(class-string): string`.
- `TransformerTransformReader::isTransformerSubclass(string): bool`, `read(): ?array`,
  `declaresTransform(): bool`.
- `MethodBodyScanner::firstStatements($method, $limit)`, `StatementNodeFinder` for conditional-aware
  node search.

### New file

`src/Plugins/Fractal/Resolvers/FractalHelperResponseResolver.php` (name TBD — pick something that
reads as "helper/facade/manager call-shape binding"; `FractalCallShapeResponseResolver` is an
alternative). `#[Scoped] final readonly class … implements PrimaryResponseResolver`. Constructor
mirrors `EntityTransformerResponseResolver` (scanner, transformReader, schemaFromTransformer,
envelopeFactory, logger) — all deps are themselves `#[Scoped]`/auto-resolvable, so **no explicit
service-provider binding is needed** (confirmed: `EntityTransformerResponseResolver` has none).

### Call-shape whitelist (the heart of the change)

Resolve from the **first top-level `return` expression** within `STATEMENT_LIMIT` statements. Walk
through the trailing terminal chain links (`->respond()`, `->toArray()`, `->toJson()`,
`->respondWithArray()` — the response terminals) to reach the Fractal call, the same way
`ReturnExpressionResourceReader` walks paginator-preserving links. Match:

1. **Helper, chained shape — `fractal()->item($x, T)` / `fractal()->collection($x, T)`:**
   envelope = item→single / collection→collection; transformer `T` from the 2nd arg when it is
   `new XTransformer(...)` or `XTransformer::class`.
2. **Helper, bare two-arg shape — `fractal($data, new XTransformer())` / `fractal($data, XTransformer::class)`:**
   transformer is knowable, but **item vs collection is NOT statically knowable** from arg 1.
   Per the issue: **refuse the bare two-arg form** (note + degrade) unless a defensible default
   emerges — it does not, so refuse. State this explicitly; do not guess the envelope.
3. **Facade — `Fractal::create()->item($x, new XTransformer())` / `->collection($x, new XTransformer())`:**
   transformer + envelope from the chain link. Match the facade by class-const/name
   `Spatie\Fractalistic\Fractal` (FQCN string, package-not-installed-safe, like the lint rule does
   for `League\Fractal\Manager`).
4. **Injected `Manager` — `new Item($x, new XTransformer())` / `new Collection($x, new XTransformer())`** passed to
   `$manager->createData(...)`: envelope from `Item`→single / `Collection`→collection
   (`League\Fractal\Resource\Item` / `…\Collection`, FQCN string match), transformer from the 2nd
   `new`/class-const arg.
5. **Serializer terminal — `->serializeWith(new ArraySerializer())` / `->parseIncludes(...)` etc.:**
   map a recognised `new <Serializer>` onto the modelled `Serializer` cases (`DataArraySerializer`→
   `DataArray`, `ArraySerializer`→`ArraySerializer`, `JsonApiSerializer`→`JsonApi`); an
   unrecognised serializer **refuses** (don't silently document the wrong envelope). Default when no
   `serializeWith`: `Serializer::DataArray` (Fractal's default).

**Transformer-argument extraction** (shared helper): from an `Arg` whose value is
`New_` (→ class name) or `ClassConstFetch ::class` (→ class name); resolve to a concrete
`TransformerAbstract` subclass via `transformReader->isTransformerSubclass()`. Anything else
(variable, method call, property) → not statically knowable → refuse.

### Ambiguity & degradation contract (per #13, mirrored from EntityTransformer resolver)

- `#[FractalResponse]` / any `PrimaryResponseAuthoringAttribute` present → **never scan** (return
  null; the attribute wins). Same guard as the sibling resolver.
- Return-type guard: only scan when the return type allows it (untyped / builtin / HTTP response) —
  reuse the `returnTypeAllowsBodyScan()` logic verbatim so Tier-0 signature resolvers stay
  authoritative.
- A single unambiguous transformer+envelope per method, or **refuse with one generation-log
  `notice`** (matching `EntityTransformerResponseResolver::note()` wording: "...; no response
  inferred. Annotate the action with #[FractalResponse] to document it.").
- Transformer resolves but yields no documentable fields → note + refuse (reuse the
  `hasDocumentableFields()` check).
- Multiple distinct matched shapes / bare-helper-form / unknown serializer → refuse.

### Registration

`src/Plugins/Fractal/FractalPlugin.php` — add
`$registry->addPrimaryResponseResolver(FractalHelperResponseResolver::class);` after the existing
two. **Order matters**: place it alongside `EntityTransformerResponseResolver` (both Tier-1 body
scanners); `FractalResponseResolver` (the attribute) stays first. Confirm chain order keeps the
attribute and Tier-0 resolvers authoritative.

### Tests (TDD — failing first)

**Unit — `tests/Unit/Plugins/Fractal/FractalHelperResponseResolverTest.php`** (one case per shape):
- `fractal()->item($x, new T())` → single envelope, T fields.
- `fractal()->collection($x, new T())` → collection envelope.
- `fractal()->item($x, T::class)` → single (class-const arg form).
- `Fractal::create()->item($x, new T())` → single (facade).
- `Fractal::create()->collection($x, new T())` → collection.
- injected `Manager` + `new Item($x, new T())` → single; `new Collection(...)` → collection.
- `->serializeWith(new ArraySerializer())` → `ArraySerializer` envelope; `JsonApiSerializer` →
  `JsonApi`; unknown serializer → refuse (null + note).
- **degrade**: bare `fractal($data, new T())` (no item/collection chain) → refuse + note.
- **degrade**: transformer arg is a variable (`fractal()->item($x, $t)`) → refuse + note.
- **degrade**: transformer with no documentable fields → refuse + note.
- **guard**: method carrying `#[FractalResponse]` → null (not scanned).
- **guard**: a named non-HTTP return type → null.
- terminal walk: `->respond()` / `->toArray()` after the chain doesn't hide the shape.

**Feature — `tests/Feature/Plugins/Fractal/`** (new file, e.g. `FractalCallShapeResponseTest.php`):
end-to-end through generation — a controller using the `fractal()` helper and one using the facade
each yield the enveloped 200 response with `transform()`-literal fields in the document.

**Fixtures — `tests/Fixtures/Fractal/`**: controllers for each style (helper item/collection,
facade, injected-Manager) and a transformer with documentable fields. Reuse the existing transformer
fixtures where possible (check what `TransformerTransformInferenceTest` / `FractalResponseTest` use).

### Verification

```
vendor/bin/pest tests/Unit/Plugins/Fractal/FractalHelperResponseResolverTest.php
vendor/bin/pest tests/Feature/Plugins/Fractal/
composer test
vendor/bin/pint --test
composer lint
```

### Docs / CHANGELOG

- `docs/` — the Fractal plugin docs (grep `Fractal` under `docs/`; likely a plugins/integration
  page). Add the new recognised call shapes to the "what gets inferred" list, note the bare-helper
  refusal and the `#[FractalResponse]` escape hatch.
- `CHANGELOG.md [Unreleased]` "Added": Fractal responses are now inferred from the `fractal()`
  helper, the `Fractalistic` facade, and injected-`Manager` resource construction (Tier-1 body
  scan), with `item`/`collection` envelopes and serializer detection; ambiguous shapes degrade with
  a note and `#[FractalResponse]` remains authoritative.

### Survey gate

**Generation-affecting** (area:responses/plugins), AND the Fractal plugin is **commented out by
default** in `config/openapi.plugins` (requires opting into `league/fractal`). The dogfood corpus
runs default plugins, so unless the survey harness enables Fractal, expect ~0 delta; if it does
enable it for Fractal-using apps (Pelican etc. named in the issue), the delta is *new* enveloped
responses where today there are none — expected and intended. Lead handles the gate; flag that the
delta should be additive (new response schemas), never a regression of existing ones.

### Controversy

Moderate — it's the largest of the three and adds a real inference path. But: no `src/Contracts/**`
change, no stage-order change, no config key, no public-signature change, no service-provider
binding (auto-resolved). It's a new `PrimaryResponseResolver` modeled directly on the shipped
`EntityTransformerResponseResolver`, reusing all #13 machinery. The judgment calls are all in the
whitelist/refusal boundaries — every one is pinned by a degrade test. Reviewer should focus on: the
bare-helper refusal (no envelope guessing), the FQCN-string matching for facade/Manager/serializers
(package-not-installed-safe), and chain-order keeping the attribute authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)