### PR TITLE
feat(#134): Fortify auth plugin — document headless core-auth endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to this project are documented here.
 - Eloquent model schemas seed their per-property examples from the model's Laravel factory `definition()` (scalar values only), reseeded deterministically per model from `openapi.examples.faker_seed`; disabled when example synthesis is off or the seed is null. (#36)
 - `#[RequestField]` ref support: a class-string `type:` resolves to a `$ref`, and a class-string `items:` on a `type: 'array'` field resolves to `items: { $ref }` — mirroring the response-side `#[ResourceField]`; an unresolvable class degrades to a permissive object. (#150)
 - A non-paginator action whose body unconditionally calls `paginate()`/`simplePaginate()`/`cursorPaginate()` now gets the matching paginated response envelope, with a declared item class (`#[ResponseResource(Model::class)]` or `@return Paginator<Item>`). Guarded so it never overrides a response API Resources or Spatie Data would shape — a resource/`Data` return type or a resource-naming `#[ResponseResource]` defers to those plugins. (#353)
+- **Fortify plugin** (opt-in): documents Laravel Fortify's headless core-auth endpoints (login/logout/register/password/profile) from a stock-contract table, with request bodies always emitted and response bodies gated on the Fortify response contract being unmodified. (#134)
 
 ## [0.1.0] - 2026-05-18
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/annotations": "^2.0",
         "fakerphp/faker": "^1.24",
         "larastan/larastan": "^v3.9.6",
+        "laravel/fortify": "^1.21",
         "laravel/passport": "^13.7.5",
         "laravel/pint": "^1.29.1",
         "league/fractal": "~0.20.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "053e16445606cc8b4049eb8249927d59",
+    "content-hash": "c0ca38b6698ddc2d6423d929a33ec812",
     "packages": [
         {
             "name": "brick/math",
@@ -6394,6 +6394,61 @@
     ],
     "packages-dev": [
         {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+            },
+            "time": "2026-04-05T21:06:35+00:00"
+        },
+        {
             "name": "brianium/paratest",
             "version": "v7.20.0",
             "source": {
@@ -6707,6 +6762,56 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -7402,6 +7507,70 @@
             "time": "2026-04-16T10:02:43+00:00"
         },
         {
+            "name": "laravel/fortify",
+            "version": "v1.37.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/fortify.git",
+                "reference": "5d4b6a53527edd19ecc4f13e8e74ec91bdefab0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/5d4b6a53527edd19ecc4f13e8e74ec91bdefab0c",
+                "reference": "5d4b6a53527edd19ecc4f13e8e74ec91bdefab0c",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^3.0",
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "laravel/passkeys": "^0.2.0",
+                "php": "^8.2",
+                "pragmarx/google2fa": "^9.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Fortify\\FortifyServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Fortify\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Backend controllers and scaffolding for Laravel authentication.",
+            "keywords": [
+                "auth",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/fortify/issues",
+                "source": "https://github.com/laravel/fortify"
+            },
+            "time": "2026-05-15T22:59:10+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.6",
             "source": {
@@ -7480,6 +7649,74 @@
                 "source": "https://github.com/laravel/pail"
             },
             "time": "2026-02-09T13:44:54+00:00"
+        },
+        {
+            "name": "laravel/passkeys",
+            "version": "v0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/passkeys-server.git",
+                "reference": "a76656ada41b2b4a591f075eddae5ddc67e8ab9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/passkeys-server/zipball/a76656ada41b2b4a591f075eddae5ddc67e8ab9c",
+                "reference": "a76656ada41b2b4a591f075eddae5ddc67e8ab9c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/http": "^11.0|^12.0|^13.0",
+                "illuminate/routing": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "web-auth/webauthn-lib": "5.3.x"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.28.0",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.0",
+                "rector/rector": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Passkeys\\PasskeysServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Passkeys\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Passwordless authentication using WebAuthn/passkeys for Laravel",
+            "homepage": "https://github.com/laravel/passkeys-server",
+            "keywords": [
+                "Authentication",
+                "Passwordless",
+                "laravel",
+                "passkeys",
+                "webauthn"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/passkeys-server/issues",
+                "source": "https://github.com/laravel/passkeys-server"
+            },
+            "time": "2026-05-18T16:26:00+00:00"
         },
         {
             "name": "laravel/passport",
@@ -10260,6 +10497,58 @@
             "time": "2026-05-01T04:21:04+00:00"
         },
         {
+            "name": "pragmarx/google2fa",
+            "version": "v9.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antonioribeiro/google2fa.git",
+                "reference": "e6bc62dd6ae83acc475f57912e27466019a1f2cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antonioribeiro/google2fa/zipball/e6bc62dd6ae83acc475f57912e27466019a1f2cf",
+                "reference": "e6bc62dd6ae83acc475f57912e27466019a1f2cf",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1.0|^2.0|^3.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^7.5.15|^8.5|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PragmaRX\\Google2FA\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio Carlos Ribeiro",
+                    "email": "acr@antoniocarlosribeiro.com",
+                    "role": "Creator & Designer"
+                }
+            ],
+            "description": "A One Time Password Authentication package, compatible with Google Authenticator.",
+            "keywords": [
+                "2fa",
+                "Authentication",
+                "Two Factor Authentication",
+                "google2fa"
+            ],
+            "support": {
+                "issues": "https://github.com/antonioribeiro/google2fa/issues",
+                "source": "https://github.com/antonioribeiro/google2fa/tree/v9.0.0"
+            },
+            "time": "2025-09-19T22:51:08+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "3.0.0",
             "source": {
@@ -11839,6 +12128,187 @@
             "time": "2026-04-28T06:26:02+00:00"
         },
         {
+            "name": "spomky-labs/cbor-php",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/cbor-php.git",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "roave/security-advisories": "dev-latest",
+                "symfony/error-handler": "^6.4|^7.1|^8.0",
+                "symfony/var-dumper": "^6.4|^7.1|^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath extensions will drastically improve the library performance. BCMath extension needed to handle the Big Float and Decimal Fraction Tags",
+                "ext-gmp": "GMP or BCMath extensions will drastically improve the library performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CBOR\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/cbor-php/contributors"
+                }
+            ],
+            "description": "CBOR Encoder/Decoder for PHP",
+            "keywords": [
+                "Concise Binary Object Representation",
+                "RFC7049",
+                "cbor"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-01T12:15:20+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
+        },
+        {
             "name": "staabm/side-effects-detector",
             "version": "1.0.5",
             "source": {
@@ -11971,6 +12441,173 @@
             "time": "2026-05-26T12:51:13+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "9261ef060f26cc7b728f67f141ba19b98a6209a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/9261ef060f26cc7b728f67f141ba19b98a6209a9",
+                "reference": "9261ef060f26cc7b728f67f141ba19b98a6209a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/property-info": "^7.4.4|^8.0.4"
+            },
+            "require-dev": {
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "4721e8c56d0cd2378e0ef9a9899f810008b859f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/4721e8c56d0cd2378e0ef9a9899f810008b859f7",
+                "reference": "4721e8c56d0cd2378e0ef9a9899f810008b859f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/string": "^7.4|^8.0",
+                "symfony/type-info": "^7.4.7|^8.0.7"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/serializer": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
             "name": "symfony/psr-http-message-bridge",
             "version": "v8.1.0",
             "source": {
@@ -12036,6 +12673,105 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/psr-http-message-bridge/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "d101886195c5f772cf7033641fe9c40c3e3969e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/d101886195c5f772cf7033641fe9c40c3e3969e1",
+                "reference": "d101886195c5f772cf7033641fe9c40c3e3969e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/property-access": "<8.1",
+                "symfony/property-info": "<7.4",
+                "symfony/type-info": "<7.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/cache": "^7.4|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/form": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/property-access": "^8.1",
+                "symfony/property-info": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/type-info": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0",
+                "symfony/var-exporter": "^7.4|^8.0",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -12165,6 +12901,163 @@
                 }
             ],
             "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "web-auth/cose-lib",
+            "version": "4.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/cose-lib.git",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "reference": "5b38660f90070a8e45f3dbc9528ade3b608dd77d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "php": ">=8.1",
+                "spomky-labs/pki-framework": "^1.0"
+            },
+            "require-dev": {
+                "spomky-labs/cbor-php": "^3.2.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "ext-gmp": "For better performance, please install either GMP (recommended) or BCMath extension",
+                "spomky-labs/cbor-php": "For COSE Signature support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cose\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/cose/contributors"
+                }
+            ],
+            "description": "CBOR Object Signing and Encryption (COSE) For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "COSE",
+                "RFC8152"
+            ],
+            "support": {
+                "issues": "https://github.com/web-auth/cose-lib/issues",
+                "source": "https://github.com/web-auth/cose-lib/tree/4.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-03T09:49:50+00:00"
+        },
+        {
+            "name": "web-auth/webauthn-lib",
+            "version": "5.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-auth/webauthn-lib.git",
+                "reference": "9e0986d999f4102e24ac8a598d3a80d98b56c19f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/9e0986d999f4102e24ac8a598d3a80d98b56c19f",
+                "reference": "9e0986d999f4102e24ac8a598d3a80d98b56c19f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "paragonie/constant_time_encoding": "^2.6|^3.0",
+                "php": ">=8.2",
+                "phpdocumentor/reflection-docblock": "^5.3|^6.0",
+                "psr/clock": "^1.0",
+                "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "spomky-labs/cbor-php": "^3.0",
+                "spomky-labs/pki-framework": "^1.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^3.2",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "web-auth/cose-lib": "^4.2.3"
+            },
+            "suggest": {
+                "psr/log-implementation": "Recommended to receive logs from the library",
+                "symfony/event-dispatcher": "Recommended to use dispatched events",
+                "web-token/jwt-library": "Mandatory for fetching Metadata Statement from distant sources"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/web-auth/webauthn-framework",
+                    "name": "web-auth/webauthn-framework"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webauthn\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-auth/webauthn-library/contributors"
+                }
+            ],
+            "description": "FIDO2/Webauthn Support For PHP",
+            "homepage": "https://github.com/web-auth",
+            "keywords": [
+                "FIDO2",
+                "fido",
+                "webauthn"
+            ],
+            "support": {
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-31T15:00:08+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/openapi.php
+++ b/config/openapi.php
@@ -499,6 +499,10 @@ return [
         // Uncomment to enable:
         // \Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin::class,
 
+        // Requires `composer require laravel/fortify`. Documents Fortify's headless core-auth
+        // endpoints (login/register/password/profile) from a stock-contract table. Uncomment:
+        // \Radiergummi\OpenApi\Plugins\Fortify\FortifyPlugin::class,
+
         // Harvests hand-authored swagger-php annotations (`#[OA\Schema]` / `@OA\Schema` and
         // operation-level `@OA`) into the generated document. Harvesting `@OA` PHPDoc annotations
         // additionally requires `composer require doctrine/annotations` (`#[OA\*]` attributes work

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,7 +1,7 @@
 # Plugins
 
 A plugin registers resolvers, extractors, and lint rules for a specific
-package or convention. Five plugins ship with the package:
+package or convention. Six plugins ship with the package:
 
 | Plugin | Default | Requires | Documents |
 |---|---|---|---|
@@ -10,6 +10,7 @@ package or convention. Five plugins ship with the package:
 | [`QueryBuilder`](#querybuilder) | disabled | `spatie/laravel-query-builder` | `filter[]` / `sort` / `include` query parameters |
 | [`Fractal`](#fractal) | disabled | `league/fractal` | Fractal transformer responses |
 | [`SwaggerPhp`](#swaggerphp) | disabled | swagger-php (bundled); `doctrine/annotations` for PHPDoc | Hand-authored `#[OA\*]` / `@OA` annotations |
+| [`Fortify`](#fortify) | disabled | `laravel/fortify` | Fortify headless core-auth endpoints |
 
 `FormRequest` request bodies are supported natively. No plugin required.
 
@@ -600,3 +601,48 @@ that: run `php artisan openapi:lint --only 'migration.*'` to find the redundant
 [Migrating from L5-Swagger](migrating-from-l5-swagger.md) for the end-to-end path.
 
 Worked endpoint: [`examples/swagger-php/`](../examples/swagger-php/).
+
+## Fortify
+
+Documents Laravel [Fortify](https://laravel.com/docs/fortify)'s headless core-auth
+endpoints — login, logout, register, password reset/update, password confirmation,
+and profile-information update — from a hand-maintained stock-contract table. Fortify
+exposes no typed request or response DTOs the generator could read, so the table
+encodes the framework's documented request rules and JSON responses directly.
+
+**Off by default.** It is the one bundled plugin scoped to a third-party auth package,
+so it ships disabled.
+
+### Enable
+
+1. `composer require laravel/fortify`.
+2. Uncomment `FortifyPlugin::class` under `plugins` in `config/openapi.php`.
+
+The plugin no-ops if Fortify is not installed.
+
+### What it documents
+
+Matched purely by **route name** (the body-bearing actions — `login.store`,
+`register.store`, `password.confirm.store` — plus `logout`, `password.email`,
+`password.update`, `password.confirmation`, `user-password.update`,
+`user-profile-information.update`). For each matched route it emits:
+
+- **The stock request body** — always. The documented validation rules become a JSON
+  object schema (e.g. login → `email` + `password` + optional `remember`).
+- **The stock success response** — *only when the route's Fortify response contract is
+  unmodified*. The plugin inspects the container binding for the governing contract
+  (e.g. `LoginResponse`): if it still maps to a `Laravel\Fortify\…` class, the stock
+  body and status are emitted; if the app has rebound it to a custom response, the body
+  is unknowable, so the plugin emits the **status code only** — never a possibly-wrong
+  body. A binding it cannot read statically (a closure that constructs the response
+  inline) is treated as customized, conservatively.
+
+Error responses fall through to the configured [`error_envelope`](config.md). An
+authoring attribute on a route always overrides what the plugin would emit.
+
+### Scope
+
+v1 covers the **core auth** surface above. Two-factor authentication and email
+verification are deferred to a follow-up. Response-body fidelity tracks the documented
+stock contract of the supported Fortify line; an app that customizes a response contract
+gets the honest status-only fallback for that endpoint.

--- a/examples/_shared/TestbenchBoot.php
+++ b/examples/_shared/TestbenchBoot.php
@@ -7,10 +7,13 @@ namespace Examples\Shared;
 use Examples\Shared\Database\Seeder;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
+use Laravel\Fortify\Fortify;
 use Laravel\Passport\PassportServiceProvider;
 use Orchestra\Testbench\Foundation\Application as TestbenchApplication;
 use Radiergummi\OpenApi\OpenApiServiceProvider;
 use Spatie\LaravelData\LaravelDataServiceProvider;
+
+use function class_exists;
 
 /**
  * Boots a real Laravel container (via Testbench) configured for one example
@@ -38,6 +41,14 @@ final class TestbenchBoot
             basePath: null,
             options: ['enables-package-discoveries' => false],
         );
+
+        // laravel/fortify (a dev dependency) force-registers its provider even with package
+        // discovery disabled, and its boot() loads ~20 auth routes that would pollute every
+        // example snapshot. Suppress that route registration before bootstrap — example flavors
+        // never exercise Fortify's own routes.
+        if (class_exists(Fortify::class)) {
+            Fortify::ignoreRoutes();
+        }
 
         $app->register(LaravelDataServiceProvider::class);
         $app->register(PassportServiceProvider::class);

--- a/src/Plugins/Fortify/FortifyPlugin.php
+++ b/src/Plugins/Fortify/FortifyPlugin.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fortify;
+
+use Laravel\Fortify\Fortify;
+use Override;
+use Radiergummi\OpenApi\Contracts\Registry\Plugin;
+use Radiergummi\OpenApi\Plugins\Fortify\Resolvers\FortifyRequestSchemaResolver;
+use Radiergummi\OpenApi\Plugins\Fortify\Resolvers\FortifyResponseResolver;
+use Radiergummi\OpenApi\Registry\OpenApiRegistry;
+
+use function class_exists;
+
+/**
+ * Teaches the OpenAPI core to document Laravel Fortify's headless core-auth endpoints from a
+ * hand-maintained stock-contract table. No-ops when Fortify is not installed.
+ */
+final class FortifyPlugin implements Plugin
+{
+    #[Override]
+    public function register(OpenApiRegistry $registry): void
+    {
+        if (!class_exists(Fortify::class)) {
+            return;
+        }
+
+        $registry->addRequestSchemaResolver(FortifyRequestSchemaResolver::class);
+        $registry->addPrimaryResponseResolver(FortifyResponseResolver::class);
+    }
+}

--- a/src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php
+++ b/src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fortify\Resolvers;
+
+use Illuminate\Container\Attributes\Scoped;
+use Override;
+use Radiergummi\OpenApi\Contracts\Registry\RequestSchemaResolver;
+use Radiergummi\OpenApi\Enums\MediaType;
+use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
+use Radiergummi\OpenApi\Support\Registry\ResolvedSchema;
+
+/**
+ * Emits the stock Fortify request body for a matched core-auth route, by route name.
+ *
+ * @internal
+ */
+#[Scoped]
+final readonly class FortifyRequestSchemaResolver implements RequestSchemaResolver
+{
+    public function __construct(private ComponentSchemaRegistry $registry) {}
+
+    #[Override]
+    public function resolveRequestSchema(ActionDescriptor $descriptor): ?ResolvedSchema
+    {
+        $name = $descriptor->route->getName();
+
+        if ($name === null) {
+            return null;
+        }
+
+        $entry = FortifyContractTable::for($name);
+
+        if ($entry === null || $entry->requestSchema === null) {
+            return null;
+        }
+
+        $key = $this->registry->reserveKey('Fortify\\Request\\' . $name);
+        $this->registry->registerNamed($key, $entry->requestSchema);
+
+        return new ResolvedSchema(componentKey: $key, mediaType: MediaType::Json);
+    }
+}

--- a/src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php
+++ b/src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php
@@ -34,11 +34,12 @@ final readonly class FortifyRequestSchemaResolver implements RequestSchemaResolv
 
         $entry = FortifyContractTable::for($name);
 
-        if ($entry === null || $entry->requestSchema === null) {
+        if ($entry === null || $entry->requestSchema === null || $entry->requestSchemaName === null) {
             return null;
         }
 
-        $key = $this->registry->reserveKey('Fortify\\Request\\' . $name);
+        // Use the clean, framework-agnostic component name — never a Fortify/namespace string.
+        $key = $this->registry->reserveKey($entry->requestSchemaName);
         $this->registry->registerNamed($key, $entry->requestSchema);
 
         return new ResolvedSchema(componentKey: $key, mediaType: MediaType::Json);

--- a/src/Plugins/Fortify/Resolvers/FortifyResponseResolver.php
+++ b/src/Plugins/Fortify/Resolvers/FortifyResponseResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fortify\Resolvers;
+
+use Illuminate\Container\Attributes\Scoped;
+use Illuminate\Contracts\Container\Container;
+use OpenApi\Annotations as OA;
+use Override;
+use Radiergummi\OpenApi\Contracts\Registry\PrimaryResponseResolver;
+use Radiergummi\OpenApi\Enums\MediaType;
+use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
+use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyResponseCustomization;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+
+use function sprintf;
+
+/**
+ * Emits the stock Fortify success response for a matched core-auth route. When the route's
+ * response contract has been rebound to a non-Fortify class, emits the status code only (the
+ * body is unknowable), never a possibly-wrong stock body.
+ *
+ * @internal
+ */
+#[Scoped]
+final readonly class FortifyResponseResolver implements PrimaryResponseResolver
+{
+    private FortifyResponseCustomization $customization;
+
+    public function __construct(Container $container)
+    {
+        $this->customization = new FortifyResponseCustomization($container);
+    }
+
+    #[Override]
+    public function resolvePrimaryResponse(ActionDescriptor $descriptor): ?OA\Response
+    {
+        $name = $descriptor->route->getName();
+
+        if ($name === null) {
+            return null;
+        }
+
+        $entry = FortifyContractTable::for($name);
+
+        if ($entry === null) {
+            return null;
+        }
+
+        $status = $entry->successStatus;
+        $description = HttpFoundationResponse::$statusTexts[$status] ?? sprintf('HTTP %d', $status);
+
+        // Emit the stock body only when we have one AND the governing contract is unmodified.
+        $emitBody = $entry->successSchema !== null
+            && $this->customization->isStock($entry->responseContract);
+
+        if (!$emitBody) {
+            return new OA\Response(['response' => (string) $status, 'description' => $description]);
+        }
+
+        return new OA\Response([
+            'response' => (string) $status,
+            'description' => $description,
+            'content' => [MediaType::Json->schema($entry->successSchema)],
+        ]);
+    }
+}

--- a/src/Plugins/Fortify/Support/FortifyContractEntry.php
+++ b/src/Plugins/Fortify/Support/FortifyContractEntry.php
@@ -7,20 +7,25 @@ namespace Radiergummi\OpenApi\Plugins\Fortify\Support;
 use OpenApi\Annotations as OA;
 
 /**
- * One row of the {@see FortifyContractTable}: the stock request body, the stock success body and
- * status, and the FQCN of the Fortify response contract that governs the body (consulted by the
- * customization gate — null when no contract governs it, e.g. the password-confirmation status
- * endpoint that returns JSON directly from its controller).
+ * One row of the {@see FortifyContractTable}: the stock request body and its public component name,
+ * the stock success body and status, and the FQCN of the Fortify response contract that governs the
+ * body (consulted by the customization gate — null when no contract governs it, e.g. the
+ * password-confirmation status endpoint that returns JSON directly from its controller).
+ *
+ * `requestSchemaName` is a clean, framework-agnostic component name (e.g. `LoginRequest`) — it must
+ * never leak Fortify/PHP/namespace internals into the public document.
  *
  * @internal
  */
 final readonly class FortifyContractEntry
 {
     /**
-     * @param ?class-string $responseContract
+     * @param ?non-empty-string $requestSchemaName Public component name for the request body; null when body-less.
+     * @param ?class-string     $responseContract
      */
     public function __construct(
         public ?OA\Schema $requestSchema,
+        public ?string $requestSchemaName,
         public ?string $responseContract,
         public int $successStatus,
         public ?OA\Schema $successSchema,

--- a/src/Plugins/Fortify/Support/FortifyContractEntry.php
+++ b/src/Plugins/Fortify/Support/FortifyContractEntry.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fortify\Support;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * One row of the {@see FortifyContractTable}: the stock request body, the stock success body and
+ * status, and the FQCN of the Fortify response contract that governs the body (consulted by the
+ * customization gate — null when no contract governs it, e.g. the password-confirmation status
+ * endpoint that returns JSON directly from its controller).
+ *
+ * @internal
+ */
+final readonly class FortifyContractEntry
+{
+    /**
+     * @param ?class-string $responseContract
+     */
+    public function __construct(
+        public ?OA\Schema $requestSchema,
+        public ?string $responseContract,
+        public int $successStatus,
+        public ?OA\Schema $successSchema,
+    ) {}
+}

--- a/src/Plugins/Fortify/Support/FortifyContractTable.php
+++ b/src/Plugins/Fortify/Support/FortifyContractTable.php
@@ -12,6 +12,7 @@ use Laravel\Fortify\Contracts\PasswordUpdateResponse;
 use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
 use Laravel\Fortify\Contracts\RegisterResponse;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Fortify;
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Support\Generator\SchemaFromArrayDefinition;
 
@@ -22,10 +23,18 @@ use Radiergummi\OpenApi\Support\Generator\SchemaFromArrayDefinition;
  * (routes/routes.php + src/Http/Responses/*). The body-bearing endpoints are the `*.store`
  * POST routes — `login` / `register` / `password.confirm` (without `.store`) are GET *view*
  * routes that a headless API typically disables, so the table keys on the action routes:
- * `login.store`, `register.store`, `password.confirm.store`. Request bodies are the documented,
- * stable validation rules (login/reset rules read `Fortify::username()`/`Fortify::email()`,
- * which default to `email`; the confirmation `password_confirmation` keys come from the
- * published app stubs).
+ * `login.store`, `register.store`, `password.confirm.store`.
+ *
+ * Field names are read from Fortify's own Tier-0 accessors rather than hardcoded:
+ * {@see Fortify::username()} (defaults to `email`) names the login identifier, and
+ * {@see Fortify::email()} names the email field on register/reset/profile — so the body reflects
+ * the app's `fortify.username` / `fortify.email` config. Password fields stay a plain `string` with
+ * `format: password`: the active constraints live in `Password::default()` (and the published app
+ * stubs), whose values are not statically readable here without reflecting protected state, so the
+ * stock shape is documented and the specifics are left to runtime validation.
+ *
+ * Public component names ({@see FortifyContractEntry::$requestSchemaName}) are clean and
+ * framework-agnostic — they must never leak Fortify/PHP/namespace internals into the document.
  *
  * @internal
  */
@@ -33,14 +42,18 @@ final class FortifyContractTable
 {
     public static function for(string $routeName): ?FortifyContractEntry
     {
+        $username = Fortify::username();
+        $email = Fortify::email();
+
         return match ($routeName) {
             // POST /login — JSON returns {two_factor: false} at 200 (LoginResponse).
             'login.store' => new FortifyContractEntry(
                 requestSchema: self::object([
-                    'email' => ['type' => 'string', 'format' => 'email'],
+                    $username => ['type' => 'string'],
                     'password' => ['type' => 'string', 'format' => 'password'],
                     'remember' => ['type' => 'boolean'],
-                ], required: ['email', 'password']),
+                ], required: [$username, 'password']),
+                requestSchemaName: 'LoginRequest',
                 responseContract: LoginResponse::class,
                 successStatus: 200,
                 successSchema: self::object(['two_factor' => ['type' => 'boolean']]),
@@ -48,6 +61,7 @@ final class FortifyContractTable
             // POST /logout — JSON returns '' at 204 (LogoutResponse).
             'logout' => new FortifyContractEntry(
                 requestSchema: null,
+                requestSchemaName: null,
                 responseContract: LogoutResponse::class,
                 successStatus: 204,
                 successSchema: null,
@@ -56,10 +70,11 @@ final class FortifyContractTable
             'register.store' => new FortifyContractEntry(
                 requestSchema: self::object([
                     'name' => ['type' => 'string'],
-                    'email' => ['type' => 'string', 'format' => 'email'],
+                    $email => ['type' => 'string', 'format' => 'email'],
                     'password' => ['type' => 'string', 'format' => 'password'],
                     'password_confirmation' => ['type' => 'string', 'format' => 'password'],
-                ], required: ['name', 'email', 'password', 'password_confirmation']),
+                ], required: ['name', $email, 'password', 'password_confirmation']),
+                requestSchemaName: 'RegisterRequest',
                 responseContract: RegisterResponse::class,
                 successStatus: 201,
                 successSchema: null,
@@ -67,8 +82,9 @@ final class FortifyContractTable
             // POST /forgot-password — JSON returns {message} at 200.
             'password.email' => new FortifyContractEntry(
                 requestSchema: self::object([
-                    'email' => ['type' => 'string', 'format' => 'email'],
-                ], required: ['email']),
+                    $email => ['type' => 'string', 'format' => 'email'],
+                ], required: [$email]),
+                requestSchemaName: 'ForgotPasswordRequest',
                 responseContract: SuccessfulPasswordResetLinkRequestResponse::class,
                 successStatus: 200,
                 successSchema: self::object(['message' => ['type' => 'string']]),
@@ -77,10 +93,11 @@ final class FortifyContractTable
             'password.update' => new FortifyContractEntry(
                 requestSchema: self::object([
                     'token' => ['type' => 'string'],
-                    'email' => ['type' => 'string', 'format' => 'email'],
+                    $email => ['type' => 'string', 'format' => 'email'],
                     'password' => ['type' => 'string', 'format' => 'password'],
                     'password_confirmation' => ['type' => 'string', 'format' => 'password'],
-                ], required: ['token', 'email', 'password', 'password_confirmation']),
+                ], required: ['token', $email, 'password', 'password_confirmation']),
+                requestSchemaName: 'ResetPasswordRequest',
                 responseContract: PasswordResetResponse::class,
                 successStatus: 200,
                 successSchema: self::object(['message' => ['type' => 'string']]),
@@ -90,6 +107,7 @@ final class FortifyContractTable
                 requestSchema: self::object([
                     'password' => ['type' => 'string', 'format' => 'password'],
                 ], required: ['password']),
+                requestSchemaName: 'ConfirmPasswordRequest',
                 responseContract: PasswordConfirmedResponse::class,
                 successStatus: 201,
                 successSchema: null,
@@ -97,6 +115,7 @@ final class FortifyContractTable
             // GET /user/confirmed-password-status — controller returns {confirmed} directly (no contract).
             'password.confirmation' => new FortifyContractEntry(
                 requestSchema: null,
+                requestSchemaName: null,
                 responseContract: null,
                 successStatus: 200,
                 successSchema: self::object(['confirmed' => ['type' => 'boolean']]),
@@ -108,6 +127,7 @@ final class FortifyContractTable
                     'password' => ['type' => 'string', 'format' => 'password'],
                     'password_confirmation' => ['type' => 'string', 'format' => 'password'],
                 ], required: ['current_password', 'password', 'password_confirmation']),
+                requestSchemaName: 'UpdatePasswordRequest',
                 responseContract: PasswordUpdateResponse::class,
                 successStatus: 200,
                 successSchema: null,
@@ -116,8 +136,9 @@ final class FortifyContractTable
             'user-profile-information.update' => new FortifyContractEntry(
                 requestSchema: self::object([
                     'name' => ['type' => 'string'],
-                    'email' => ['type' => 'string', 'format' => 'email'],
-                ], required: ['name', 'email']),
+                    $email => ['type' => 'string', 'format' => 'email'],
+                ], required: ['name', $email]),
+                requestSchemaName: 'UpdateProfileInformationRequest',
                 responseContract: ProfileInformationUpdatedResponse::class,
                 successStatus: 200,
                 successSchema: null,

--- a/src/Plugins/Fortify/Support/FortifyContractTable.php
+++ b/src/Plugins/Fortify/Support/FortifyContractTable.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fortify\Support;
+
+use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Fortify\Contracts\LogoutResponse;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse;
+use Laravel\Fortify\Contracts\PasswordResetResponse;
+use Laravel\Fortify\Contracts\PasswordUpdateResponse;
+use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
+use Laravel\Fortify\Contracts\RegisterResponse;
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Support\Generator\SchemaFromArrayDefinition;
+
+/**
+ * Hand-maintained stock contract for Fortify's headless core-auth routes, keyed by route name.
+ *
+ * Route names and response bodies were reconciled against laravel/fortify v1.37 source
+ * (routes/routes.php + src/Http/Responses/*). The body-bearing endpoints are the `*.store`
+ * POST routes — `login` / `register` / `password.confirm` (without `.store`) are GET *view*
+ * routes that a headless API typically disables, so the table keys on the action routes:
+ * `login.store`, `register.store`, `password.confirm.store`. Request bodies are the documented,
+ * stable validation rules (login/reset rules read `Fortify::username()`/`Fortify::email()`,
+ * which default to `email`; the confirmation `password_confirmation` keys come from the
+ * published app stubs).
+ *
+ * @internal
+ */
+final class FortifyContractTable
+{
+    public static function for(string $routeName): ?FortifyContractEntry
+    {
+        return match ($routeName) {
+            // POST /login — JSON returns {two_factor: false} at 200 (LoginResponse).
+            'login.store' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'email' => ['type' => 'string', 'format' => 'email'],
+                    'password' => ['type' => 'string', 'format' => 'password'],
+                    'remember' => ['type' => 'boolean'],
+                ], required: ['email', 'password']),
+                responseContract: LoginResponse::class,
+                successStatus: 200,
+                successSchema: self::object(['two_factor' => ['type' => 'boolean']]),
+            ),
+            // POST /logout — JSON returns '' at 204 (LogoutResponse).
+            'logout' => new FortifyContractEntry(
+                requestSchema: null,
+                responseContract: LogoutResponse::class,
+                successStatus: 204,
+                successSchema: null,
+            ),
+            // POST /register — JSON returns '' at 201 (RegisterResponse).
+            'register.store' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'name' => ['type' => 'string'],
+                    'email' => ['type' => 'string', 'format' => 'email'],
+                    'password' => ['type' => 'string', 'format' => 'password'],
+                    'password_confirmation' => ['type' => 'string', 'format' => 'password'],
+                ], required: ['name', 'email', 'password', 'password_confirmation']),
+                responseContract: RegisterResponse::class,
+                successStatus: 201,
+                successSchema: null,
+            ),
+            // POST /forgot-password — JSON returns {message} at 200.
+            'password.email' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'email' => ['type' => 'string', 'format' => 'email'],
+                ], required: ['email']),
+                responseContract: SuccessfulPasswordResetLinkRequestResponse::class,
+                successStatus: 200,
+                successSchema: self::object(['message' => ['type' => 'string']]),
+            ),
+            // POST /reset-password — JSON returns {message} at 200.
+            'password.update' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'token' => ['type' => 'string'],
+                    'email' => ['type' => 'string', 'format' => 'email'],
+                    'password' => ['type' => 'string', 'format' => 'password'],
+                    'password_confirmation' => ['type' => 'string', 'format' => 'password'],
+                ], required: ['token', 'email', 'password', 'password_confirmation']),
+                responseContract: PasswordResetResponse::class,
+                successStatus: 200,
+                successSchema: self::object(['message' => ['type' => 'string']]),
+            ),
+            // POST /user/confirm-password — JSON returns '' at 201 (PasswordConfirmedResponse).
+            'password.confirm.store' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'password' => ['type' => 'string', 'format' => 'password'],
+                ], required: ['password']),
+                responseContract: PasswordConfirmedResponse::class,
+                successStatus: 201,
+                successSchema: null,
+            ),
+            // GET /user/confirmed-password-status — controller returns {confirmed} directly (no contract).
+            'password.confirmation' => new FortifyContractEntry(
+                requestSchema: null,
+                responseContract: null,
+                successStatus: 200,
+                successSchema: self::object(['confirmed' => ['type' => 'boolean']]),
+            ),
+            // PUT /user/password — JSON returns '' at 200 (PasswordUpdateResponse).
+            'user-password.update' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'current_password' => ['type' => 'string', 'format' => 'password'],
+                    'password' => ['type' => 'string', 'format' => 'password'],
+                    'password_confirmation' => ['type' => 'string', 'format' => 'password'],
+                ], required: ['current_password', 'password', 'password_confirmation']),
+                responseContract: PasswordUpdateResponse::class,
+                successStatus: 200,
+                successSchema: null,
+            ),
+            // PUT /user/profile-information — JSON returns '' at 200 (ProfileInformationUpdatedResponse).
+            'user-profile-information.update' => new FortifyContractEntry(
+                requestSchema: self::object([
+                    'name' => ['type' => 'string'],
+                    'email' => ['type' => 'string', 'format' => 'email'],
+                ], required: ['name', 'email']),
+                responseContract: ProfileInformationUpdatedResponse::class,
+                successStatus: 200,
+                successSchema: null,
+            ),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $properties
+     * @param list<string>                        $required
+     */
+    private static function object(array $properties, array $required = []): OA\Schema
+    {
+        $definition = ['type' => 'object', 'properties' => $properties];
+
+        if ($required !== []) {
+            $definition['required'] = $required;
+        }
+
+        return SchemaFromArrayDefinition::build($definition);
+    }
+}

--- a/src/Plugins/Fortify/Support/FortifyResponseCustomization.php
+++ b/src/Plugins/Fortify/Support/FortifyResponseCustomization.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\Fortify\Support;
+
+use Closure;
+use Illuminate\Contracts\Container\Container;
+use ReflectionFunction;
+
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Best-effort detector for whether a Fortify response contract still maps to a stock Fortify
+ * implementation. Inspects the registered binding's concrete class name WITHOUT resolving it; a
+ * binding we cannot read as a concrete class (or an unbound contract) is treated as customized —
+ * we never emit a possibly-wrong stock body.
+ *
+ * Note on the binding shape: Laravel's container wraps a string concrete in a closure inside
+ * `bind()`/`singleton()` (see `Container::getClosure()`), so `getBindings()[...]['concrete']` is a
+ * Closure even for `singleton($contract, ConcreteClass::class)` — the form Fortify uses for every
+ * response. We therefore recover the original class name from the wrapper's captured `concrete`
+ * variable, falling back to a directly-stored string concrete for other binding paths.
+ *
+ * @internal
+ */
+final readonly class FortifyResponseCustomization
+{
+    private const string FORTIFY_NAMESPACE = 'Laravel\\Fortify\\';
+
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param ?class-string $responseContract
+     */
+    public function isStock(?string $responseContract): bool
+    {
+        // No contract governs this route's body (e.g. the password-confirmation status endpoint).
+        if ($responseContract === null) {
+            return true;
+        }
+
+        if (!$this->container->bound($responseContract)) {
+            // Unbound: Fortify's service provider binds all of these, so an unbound contract means
+            // Fortify isn't fully wired — be conservative.
+            return false;
+        }
+
+        $concrete = $this->concreteClassName($responseContract);
+
+        return $concrete !== null && str_starts_with($concrete, self::FORTIFY_NAMESPACE);
+    }
+
+    /**
+     * Recovers the bound concrete *class name* without resolving the binding, or null when it
+     * cannot be read statically (a user closure that constructs an instance inline).
+     */
+    private function concreteClassName(string $responseContract): ?string
+    {
+        $concrete = $this->container->getBindings()[$responseContract]['concrete'] ?? null;
+
+        // A directly-stored string concrete (older/alternative binding paths).
+        if (is_string($concrete)) {
+            return $concrete;
+        }
+
+        // Laravel wraps a string concrete in a closure that captures it as `$concrete`; recover it.
+        if ($concrete instanceof Closure) {
+            $captured = (new ReflectionFunction($concrete))->getClosureUsedVariables();
+            $value = $captured['concrete'] ?? null;
+
+            return is_string($value) ? $value : null;
+        }
+
+        return null;
+    }
+}

--- a/src/Plugins/Fortify/Support/FortifyResponseCustomization.php
+++ b/src/Plugins/Fortify/Support/FortifyResponseCustomization.php
@@ -4,25 +4,18 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Fortify\Support;
 
-use Closure;
 use Illuminate\Contracts\Container\Container;
-use ReflectionException;
-use ReflectionFunction;
+use ReflectionClass;
+use Throwable;
 
-use function is_string;
 use function str_starts_with;
 
 /**
- * Best-effort detector for whether a Fortify response contract still maps to a stock Fortify
- * implementation. Inspects the registered binding's concrete class name WITHOUT resolving it; a
- * binding we cannot read as a concrete class (or an unbound contract) is treated as customized —
- * we never emit a possibly-wrong stock body.
- *
- * Note on the binding shape: Laravel's container wraps a string concrete in a closure inside
- * `bind()`/`singleton()` (see `Container::getClosure()`), so `getBindings()[...]['concrete']` is a
- * Closure even for `singleton($contract, ConcreteClass::class)` — the form Fortify uses for every
- * response. We therefore recover the original class name from the wrapper's captured `concrete`
- * variable, falling back to a directly-stored string concrete for other binding paths.
+ * Detects whether a Fortify response contract still maps to a stock Fortify implementation. At
+ * generation time the app is booted, so we resolve the contract from the container and check
+ * whether the concrete is a `Laravel\Fortify\…` class. Anything else — a custom implementation, an
+ * unbound contract, or a resolution that throws — is treated as customized: the body is unknowable,
+ * so the response resolver falls back to status-only and never emits a possibly-wrong stock body.
  *
  * @internal
  */
@@ -42,44 +35,21 @@ final readonly class FortifyResponseCustomization
             return true;
         }
 
-        if (!$this->container->bound($responseContract)) {
-            // Unbound: Fortify's service provider binds all of these, so an unbound contract means
-            // Fortify isn't fully wired — be conservative.
+        try {
+            // Two stock responses (the password-reset {message} bodies) take a required
+            // `string $status`; pass an empty one so resolving them doesn't throw. The argument is
+            // ignored by responses that don't declare it, including custom implementations.
+            $instance = $this->container->make($responseContract, ['status' => '']);
+
+            // An anonymous class implementing a Fortify contract inherits the contract's namespace
+            // in its synthetic name (`Laravel\Fortify\Contracts\X@anonymous…`), so a bare namespace
+            // check would mistake a custom inline response for stock — exclude anonymous classes.
+            $isAnonymous = (new ReflectionClass($instance))->isAnonymous();
+        } catch (Throwable) {
+            // Unbound, or a binding that throws when constructed — be conservative.
             return false;
         }
 
-        $concrete = $this->concreteClassName($responseContract);
-
-        return $concrete !== null && str_starts_with($concrete, self::FORTIFY_NAMESPACE);
-    }
-
-    /**
-     * Recovers the bound concrete *class name* without resolving the binding, or null when it
-     * cannot be read statically (a user closure that constructs an instance inline).
-     */
-    private function concreteClassName(string $responseContract): ?string
-    {
-        $concrete = $this->container->getBindings()[$responseContract]['concrete'] ?? null;
-
-        // A directly-stored string concrete (older/alternative binding paths).
-        if (is_string($concrete)) {
-            return $concrete;
-        }
-
-        if (!$concrete instanceof Closure) {
-            return null;
-        }
-
-        // Laravel wraps a string concrete in a closure that captures it as `$concrete`; recover it.
-        // Reflecting a Closure never throws, but degrade to null rather than propagate if it ever does.
-        try {
-            $captured = (new ReflectionFunction($concrete))->getClosureUsedVariables();
-        } catch (ReflectionException) {
-            return null;
-        }
-
-        $value = $captured['concrete'] ?? null;
-
-        return is_string($value) ? $value : null;
+        return !$isAnonymous && str_starts_with($instance::class, self::FORTIFY_NAMESPACE);
     }
 }

--- a/src/Plugins/Fortify/Support/FortifyResponseCustomization.php
+++ b/src/Plugins/Fortify/Support/FortifyResponseCustomization.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Plugins\Fortify\Support;
 
 use Closure;
 use Illuminate\Contracts\Container\Container;
+use ReflectionException;
 use ReflectionFunction;
 
 use function is_string;
@@ -65,14 +66,20 @@ final readonly class FortifyResponseCustomization
             return $concrete;
         }
 
-        // Laravel wraps a string concrete in a closure that captures it as `$concrete`; recover it.
-        if ($concrete instanceof Closure) {
-            $captured = (new ReflectionFunction($concrete))->getClosureUsedVariables();
-            $value = $captured['concrete'] ?? null;
-
-            return is_string($value) ? $value : null;
+        if (!$concrete instanceof Closure) {
+            return null;
         }
 
-        return null;
+        // Laravel wraps a string concrete in a closure that captures it as `$concrete`; recover it.
+        // Reflecting a Closure never throws, but degrade to null rather than propagate if it ever does.
+        try {
+            $captured = (new ReflectionFunction($concrete))->getClosureUsedVariables();
+        } catch (ReflectionException) {
+            return null;
+        }
+
+        $value = $captured['concrete'] ?? null;
+
+        return is_string($value) ? $value : null;
     }
 }

--- a/tests/Feature/Plugins/Fortify/FortifyPluginTest.php
+++ b/tests/Feature/Plugins/Fortify/FortifyPluginTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature\Plugins\Fortify;
+
+use Closure;
+use Illuminate\Support\Facades\Route;
+use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Fortify\Contracts\LogoutResponse;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse;
+use Laravel\Fortify\Contracts\PasswordResetResponse;
+use Laravel\Fortify\Contracts\PasswordUpdateResponse;
+use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
+use Laravel\Fortify\Contracts\RegisterResponse;
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Http\Responses as FortifyResponses;
+use Radiergummi\OpenApi\Plugins\Fortify\FortifyPlugin;
+
+use function array_keys;
+
+uses()->group('openapi', 'plugin:fortify');
+
+/**
+ * Binds the stock Fortify response contracts exactly as FortifyServiceProvider does (string-class
+ * singletons) so the customization gate sees real bindings, then runs generation with the plugin
+ * enabled and the fixture routes loaded.
+ *
+ * @param ?Closure(\Illuminate\Contracts\Foundation\Application): void $rebind Optional contract rebinding.
+ *
+ * @return array<string, mixed>
+ */
+function generateWithFortifyPlugin(?Closure $rebind = null): array
+{
+    config(['openapi.plugins' => [FortifyPlugin::class]]);
+
+    $app = app();
+    $app->singleton(LoginResponse::class, FortifyResponses\LoginResponse::class);
+    $app->singleton(LogoutResponse::class, FortifyResponses\LogoutResponse::class);
+    $app->singleton(RegisterResponse::class, FortifyResponses\RegisterResponse::class);
+    $app->singleton(SuccessfulPasswordResetLinkRequestResponse::class, FortifyResponses\SuccessfulPasswordResetLinkRequestResponse::class);
+    $app->singleton(PasswordResetResponse::class, FortifyResponses\PasswordResetResponse::class);
+    $app->singleton(PasswordConfirmedResponse::class, FortifyResponses\PasswordConfirmedResponse::class);
+    $app->singleton(PasswordUpdateResponse::class, FortifyResponses\PasswordUpdateResponse::class);
+    $app->singleton(ProfileInformationUpdatedResponse::class, FortifyResponses\ProfileInformationUpdatedResponse::class);
+
+    if ($rebind !== null) {
+        $rebind($app);
+    }
+
+    require __DIR__ . '/../../../Fixtures/Fortify/routes.php';
+
+    return generateSpec();
+}
+
+it('documents the login request body from the stock table', function (): void {
+    $doc = generateWithFortifyPlugin();
+
+    $op = $doc['paths']['/login']['post'];
+    $ref = $op['requestBody']['content']['application/json']['schema']['$ref'];
+    $key = substr((string) $ref, strlen('#/components/schemas/'));
+    $schema = $doc['components']['schemas'][$key];
+
+    expect($schema['properties'])->toHaveKeys(['email', 'password', 'remember'])
+        ->and($schema['required'])->toContain('email', 'password');
+});
+
+it('emits the stock success body when the response contract is default Fortify', function (): void {
+    $doc = generateWithFortifyPlugin();
+
+    $op = $doc['paths']['/forgot-password']['post'];
+
+    expect($op['responses'])->toHaveKey('200')
+        ->and($op['responses']['200']['content']['application/json']['schema']['properties'])
+        ->toHaveKey('message');
+});
+
+it('drops the success body (status only) when the response contract is rebound', function (): void {
+    $doc = generateWithFortifyPlugin(static function ($app): void {
+        $app->bind(
+            SuccessfulPasswordResetLinkRequestResponse::class,
+            static fn(): SuccessfulPasswordResetLinkRequestResponse => new class () implements SuccessfulPasswordResetLinkRequestResponse {
+                public function toResponse($request)
+                {
+                    return response()->json(['x' => 1]);
+                }
+            },
+        );
+    });
+
+    $op = $doc['paths']['/forgot-password']['post'];
+
+    expect($op['responses'])->toHaveKey('200')
+        ->and($op['responses']['200'])->not->toHaveKey('content'); // body dropped, status retained
+});
+
+it('emits a 201 status-only response for register (stock has no body)', function (): void {
+    $doc = generateWithFortifyPlugin();
+
+    $op = $doc['paths']['/register']['post'];
+
+    expect($op['responses'])->toHaveKey('201')
+        ->and($op['responses']['201'])->not->toHaveKey('content')
+        ->and($op['requestBody']['content']['application/json']['schema']['$ref'] ?? null)
+        ->toStartWith('#/components/schemas/');
+});
+
+it('does not document a route that is not registered', function (): void {
+    config(['openapi.plugins' => [FortifyPlugin::class]]);
+    Route::post('/login', static fn() => null)->name('login.store');
+
+    $doc = generateSpec();
+
+    expect(array_keys($doc['paths'] ?? []))->toContain('/login')
+        ->and($doc['paths'] ?? [])->not->toHaveKey('/register');
+});

--- a/tests/Feature/Plugins/Fortify/FortifyPluginTest.php
+++ b/tests/Feature/Plugins/Fortify/FortifyPluginTest.php
@@ -53,16 +53,33 @@ function generateWithFortifyPlugin(?Closure $rebind = null): array
     return generateSpec();
 }
 
-it('documents the login request body from the stock table', function (): void {
+it('documents the login request body under a clean, framework-agnostic component name', function (): void {
     $doc = generateWithFortifyPlugin();
 
     $op = $doc['paths']['/login']['post'];
     $ref = $op['requestBody']['content']['application/json']['schema']['$ref'];
-    $key = substr((string) $ref, strlen('#/components/schemas/'));
-    $schema = $doc['components']['schemas'][$key];
+
+    expect($ref)->toBe('#/components/schemas/LoginRequest');
+
+    $schema = $doc['components']['schemas']['LoginRequest'];
 
     expect($schema['properties'])->toHaveKeys(['email', 'password', 'remember'])
         ->and($schema['required'])->toContain('email', 'password');
+});
+
+it('leaks no Fortify/namespace internals into any consumer-visible component key or $ref', function (): void {
+    $doc = generateWithFortifyPlugin();
+
+    $serialized = json_encode($doc, JSON_THROW_ON_ERROR);
+    $keys = array_keys($doc['components']['schemas'] ?? []);
+
+    expect($keys)->toContain('LoginRequest', 'RegisterRequest', 'ForgotPasswordRequest')
+        ->and($serialized)->not->toContain('Fortify')
+        ->and($serialized)->not->toContain('\\\\'); // no escaped backslash (namespace separator)
+
+    foreach ($keys as $key) {
+        expect($key)->not->toContain('\\');
+    }
 });
 
 it('emits the stock success body when the response contract is default Fortify', function (): void {

--- a/tests/Fixtures/Fortify/routes.php
+++ b/tests/Fixtures/Fortify/routes.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+// Registers the v1 core-auth route NAMES the FortifyContractTable keys on. The plugin matches by
+// name, not action, so minimal closures suffice. Names mirror laravel/fortify's real action
+// routes (the body-bearing POSTs are the `*.store` names; the bare `login`/`register` are GET view
+// routes a headless API disables).
+Route::post('/login', static fn() => null)->name('login.store');
+Route::post('/logout', static fn() => null)->name('logout');
+Route::post('/register', static fn() => null)->name('register.store');
+Route::post('/forgot-password', static fn() => null)->name('password.email');
+Route::post('/reset-password', static fn() => null)->name('password.update');
+Route::post('/user/confirm-password', static fn() => null)->name('password.confirm.store');
+Route::get('/user/confirmed-password-status', static fn() => null)->name('password.confirmation');
+Route::put('/user/password', static fn() => null)->name('user-password.update');
+Route::put('/user/profile-information', static fn() => null)->name('user-profile-information.update');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Tests;
 
 use Illuminate\Foundation\Application;
+use Laravel\Fortify\Fortify;
 use Laravel\Passport\PassportServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Radiergummi\OpenApi\OpenApiServiceProvider;
 use Radiergummi\OpenApi\Support\Generator\ExampleFileLoader;
 use RuntimeException;
 use Spatie\LaravelData\LaravelDataServiceProvider;
+
+use function class_exists;
 
 abstract class TestCase extends Orchestra
 {
@@ -39,6 +42,14 @@ abstract class TestCase extends Orchestra
     protected function defineEnvironment($app): void
     {
         $app['config']->set('filesystems.disks.local.serve', false);
+
+        // laravel/fortify (a dev dependency) force-registers its provider even with package
+        // discovery off; its boot() loads ~20 auth routes that would otherwise appear in every
+        // generated spec under test. Suppress route registration globally for the suite — the
+        // Fortify plugin tests register their own fixture routes by name.
+        if (class_exists(Fortify::class)) {
+            Fortify::ignoreRoutes();
+        }
     }
 
     /**

--- a/tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
@@ -7,8 +7,6 @@ use Laravel\Fortify\Fortify;
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
 
-use function array_map;
-
 uses()->group('openapi', 'plugin:fortify');
 
 it('exposes an entry for each v1 core-auth route name', function (): void {

--- a/tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Fortify\Contracts\LoginResponse;
+use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
+
+uses()->group('openapi', 'plugin:fortify');
+
+it('exposes an entry for each v1 core-auth route name', function (): void {
+    $names = ['login.store', 'logout', 'register.store', 'password.email', 'password.update',
+        'password.confirm.store', 'password.confirmation', 'user-password.update',
+        'user-profile-information.update'];
+
+    foreach ($names as $name) {
+        expect(FortifyContractTable::for($name))->not->toBeNull();
+    }
+
+    expect(FortifyContractTable::for('two-factor.login'))->toBeNull() // deferred, not in v1
+        ->and(FortifyContractTable::for('login'))->toBeNull(); // GET view route, not the action
+});
+
+it('returns a request schema and response contract for login', function (): void {
+    $entry = FortifyContractTable::for('login.store');
+
+    expect($entry->requestSchema)->toBeInstanceOf(OA\Schema::class)
+        ->and($entry->responseContract)->toBe(LoginResponse::class)
+        ->and($entry->successStatus)->toBe(200)
+        ->and($entry->successSchema)->toBeInstanceOf(OA\Schema::class); // {two_factor: boolean}
+});
+
+it('carries no request body for the body-less endpoints', function (): void {
+    expect(FortifyContractTable::for('logout')->requestSchema)->toBeNull()
+        ->and(FortifyContractTable::for('logout')->successStatus)->toBe(204)
+        ->and(FortifyContractTable::for('password.confirmation')->requestSchema)->toBeNull()
+        ->and(FortifyContractTable::for('password.confirmation')->responseContract)->toBeNull();
+});

--- a/tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
@@ -3,8 +3,11 @@
 declare(strict_types=1);
 
 use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Fortify\Fortify;
 use OpenApi\Annotations as OA;
 use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
+
+use function array_map;
 
 uses()->group('openapi', 'plugin:fortify');
 
@@ -25,9 +28,29 @@ it('returns a request schema and response contract for login', function (): void
     $entry = FortifyContractTable::for('login.store');
 
     expect($entry->requestSchema)->toBeInstanceOf(OA\Schema::class)
+        ->and($entry->requestSchemaName)->toBe('LoginRequest') // clean, framework-agnostic name
         ->and($entry->responseContract)->toBe(LoginResponse::class)
         ->and($entry->successStatus)->toBe(200)
         ->and($entry->successSchema)->toBeInstanceOf(OA\Schema::class); // {two_factor: boolean}
+});
+
+it('names the login identifier field from Fortify::username() rather than hardcoding it', function (): void {
+    $default = array_map(
+        static fn(OA\Property $p): string => (string) $p->property,
+        FortifyContractTable::for('login.store')->requestSchema->properties,
+    );
+    expect($default)->toContain('email'); // default config
+
+    config(['fortify.username' => 'login_id']);
+
+    $custom = array_map(
+        static fn(OA\Property $p): string => (string) $p->property,
+        FortifyContractTable::for('login.store')->requestSchema->properties,
+    );
+
+    expect($custom)->toContain('login_id')
+        ->and($custom)->not->toContain('email')
+        ->and(Fortify::username())->toBe('login_id');
 });
 
 it('carries no request body for the body-less endpoints', function (): void {

--- a/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
@@ -19,7 +19,7 @@ it('reports stock when the contract resolves to a Fortify class', function (): v
 
 it('reports customized when rebound to a non-Fortify class via a closure', function (): void {
     $container = new Container();
-    $container->bind(LoginResponse::class, fn (): LoginResponse => new class () implements LoginResponse {
+    $container->bind(LoginResponse::class, fn(): LoginResponse => new class () implements LoginResponse {
         public function toResponse($request)
         {
             return response()->noContent();

--- a/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
@@ -8,6 +8,15 @@ use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyResponseCustomization;
 
 uses()->group('openapi', 'plugin:fortify');
 
+/** A non-Fortify, app-owned login response — the common class-string customization form. */
+class CustomLoginResponse implements LoginResponse
+{
+    public function toResponse($request)
+    {
+        return response()->noContent();
+    }
+}
+
 it('reports stock when the contract resolves to a Fortify class', function (): void {
     $container = new Container();
     $container->singleton(LoginResponse::class, Laravel\Fortify\Http\Responses\LoginResponse::class);
@@ -15,6 +24,17 @@ it('reports stock when the contract resolves to a Fortify class', function (): v
     $gate = new FortifyResponseCustomization($container);
 
     expect($gate->isStock(LoginResponse::class))->toBeTrue();
+});
+
+it('reports customized when rebound to a non-Fortify class-string singleton', function (): void {
+    $container = new Container();
+    $container->singleton(LoginResponse::class, CustomLoginResponse::class);
+
+    $gate = new FortifyResponseCustomization($container);
+
+    // The FQCN is recovered successfully from the wrapper closure, but it is not in the Fortify
+    // namespace — distinct from the inline-closure path where no class-string is recoverable.
+    expect($gate->isStock(LoginResponse::class))->toBeFalse();
 });
 
 it('reports customized when rebound to a non-Fortify class via a closure', function (): void {

--- a/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Illuminate\Container\Container;
 use Laravel\Fortify\Contracts\LoginResponse;
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Http\Responses as FortifyResponses;
 use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyResponseCustomization;
 
 uses()->group('openapi', 'plugin:fortify');
@@ -19,11 +21,25 @@ class CustomLoginResponse implements LoginResponse
 
 it('reports stock when the contract resolves to a Fortify class', function (): void {
     $container = new Container();
-    $container->singleton(LoginResponse::class, Laravel\Fortify\Http\Responses\LoginResponse::class);
+    $container->singleton(LoginResponse::class, FortifyResponses\LoginResponse::class);
 
     $gate = new FortifyResponseCustomization($container);
 
     expect($gate->isStock(LoginResponse::class))->toBeTrue();
+});
+
+it('reports stock for a Fortify response with a required constructor argument', function (): void {
+    // SuccessfulPasswordResetLinkRequestResponse takes `string $status`; the gate must still
+    // resolve it as stock rather than choke on the constructor.
+    $container = new Container();
+    $container->singleton(
+        SuccessfulPasswordResetLinkRequestResponse::class,
+        FortifyResponses\SuccessfulPasswordResetLinkRequestResponse::class,
+    );
+
+    $gate = new FortifyResponseCustomization($container);
+
+    expect($gate->isStock(SuccessfulPasswordResetLinkRequestResponse::class))->toBeTrue();
 });
 
 it('reports customized when rebound to a non-Fortify class-string singleton', function (): void {
@@ -32,8 +48,6 @@ it('reports customized when rebound to a non-Fortify class-string singleton', fu
 
     $gate = new FortifyResponseCustomization($container);
 
-    // The FQCN is recovered successfully from the wrapper closure, but it is not in the Fortify
-    // namespace — distinct from the inline-closure path where no class-string is recoverable.
     expect($gate->isStock(LoginResponse::class))->toBeFalse();
 });
 
@@ -51,14 +65,25 @@ it('reports customized when rebound to a non-Fortify class via a closure', funct
     expect($gate->isStock(LoginResponse::class))->toBeFalse();
 });
 
-it('reports stock for a null contract (no contract governs the body)', function (): void {
-    $gate = new FortifyResponseCustomization(new Container());
+it('reports customized when the bound concrete throws on construction', function (): void {
+    $container = new Container();
+    $container->bind(LoginResponse::class, function (): LoginResponse {
+        throw new RuntimeException('boom');
+    });
 
-    expect($gate->isStock(null))->toBeTrue();
+    $gate = new FortifyResponseCustomization($container);
+
+    expect($gate->isStock(LoginResponse::class))->toBeFalse();
 });
 
 it('reports customized when the contract is unbound', function (): void {
     $gate = new FortifyResponseCustomization(new Container());
 
     expect($gate->isStock(LoginResponse::class))->toBeFalse();
+});
+
+it('reports stock for a null contract (no contract governs the body)', function (): void {
+    $gate = new FortifyResponseCustomization(new Container());
+
+    expect($gate->isStock(null))->toBeTrue();
 });

--- a/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
+++ b/tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Container\Container;
+use Laravel\Fortify\Contracts\LoginResponse;
+use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyResponseCustomization;
+
+uses()->group('openapi', 'plugin:fortify');
+
+it('reports stock when the contract resolves to a Fortify class', function (): void {
+    $container = new Container();
+    $container->singleton(LoginResponse::class, Laravel\Fortify\Http\Responses\LoginResponse::class);
+
+    $gate = new FortifyResponseCustomization($container);
+
+    expect($gate->isStock(LoginResponse::class))->toBeTrue();
+});
+
+it('reports customized when rebound to a non-Fortify class via a closure', function (): void {
+    $container = new Container();
+    $container->bind(LoginResponse::class, fn (): LoginResponse => new class () implements LoginResponse {
+        public function toResponse($request)
+        {
+            return response()->noContent();
+        }
+    });
+
+    $gate = new FortifyResponseCustomization($container);
+
+    expect($gate->isStock(LoginResponse::class))->toBeFalse();
+});
+
+it('reports stock for a null contract (no contract governs the body)', function (): void {
+    $gate = new FortifyResponseCustomization(new Container());
+
+    expect($gate->isStock(null))->toBeTrue();
+});
+
+it('reports customized when the contract is unbound', function (): void {
+    $gate = new FortifyResponseCustomization(new Container());
+
+    expect($gate->isStock(LoginResponse::class))->toBeFalse();
+});


### PR DESCRIPTION
Closes #134

# Fortify auth plugin — Implementation Plan

> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

**Goal:** A bundled, opt-in `Fortify` plugin that documents Laravel Fortify's headless core-auth endpoints from a hand-maintained stock-contract table, honestly gated so it never emits a confidently-wrong response.

**Architecture:** Two resolvers sharing a `FortifyContractTable` (route name → request body + success response + status + response-contract class). `FortifyRequestSchemaResolver` always emits the stock request body; `FortifyResponseResolver` emits the stock success body only when the route's Fortify response contract still resolves to a `Laravel\Fortify\` class (else status-only). Matched purely by `$route->getName()`. Errors fall through to the existing `openapi.error_envelope` machinery.

**Tech Stack:** PHP 8.4, swagger-php (`OpenApi\Annotations`), Pest + Orchestra Testbench, `laravel/fortify` (dev-only).

Full agreed design: issue #134 (comment "Agreed design — v1").

---

## File structure

- Create `src/Plugins/Fortify/FortifyPlugin.php` — `Plugin` impl, `class_exists` guard, registers the two resolvers.
- Create `src/Plugins/Fortify/Support/FortifyContractTable.php` — the hand-maintained data (route name → entry).
- Create `src/Plugins/Fortify/Support/FortifyResponseCustomization.php` — the binding-inspection gate.
- Create `src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php` — `RequestSchemaResolver`.
- Create `src/Plugins/Fortify/Resolvers/FortifyResponseResolver.php` — `PrimaryResponseResolver`.
- Modify `config/openapi.php` — add a commented-out `FortifyPlugin::class` entry under `plugins`.
- Add `laravel/fortify` to `require-dev` in `composer.json`.
- Create `tests/Fixtures/Fortify/` fixture controllers/routes + `tests/Feature/Plugins/Fortify/FortifyPluginTest.php`.
- Modify `docs/plugins.md` (new section) + `CHANGELOG.md`.

---

## Task 1: Add the dev dependency + plugin scaffold (off by default)

**Files:**
- Modify: `composer.json` (require-dev)
- Create: `src/Plugins/Fortify/FortifyPlugin.php`
- Modify: `config/openapi.php` (plugins array)

- [ ] **Step 1: Add `laravel/fortify` to require-dev**

```bash
composer require --dev "laravel/fortify:^1.21"
```
Expected: installs cleanly on PHP 8.4 / Laravel 12 & 13.

- [ ] **Step 2: Create the plugin class (guarded, registers nothing yet)**

`src/Plugins/Fortify/FortifyPlugin.php`:
```php
<?php

declare(strict_types=1);

namespace Radiergummi\OpenApi\Plugins\Fortify;

use Laravel\Fortify\Fortify;
use Override;
use Radiergummi\OpenApi\Contracts\Registry\Plugin;
use Radiergummi\OpenApi\Plugins\Fortify\Resolvers\FortifyRequestSchemaResolver;
use Radiergummi\OpenApi\Plugins\Fortify\Resolvers\FortifyResponseResolver;
use Radiergummi\OpenApi\Registry\OpenApiRegistry;

use function class_exists;

/**
 * Teaches the OpenAPI core to document Laravel Fortify's headless core-auth endpoints from a
 * hand-maintained stock-contract table. No-ops when Fortify is not installed.
 */
final class FortifyPlugin implements Plugin
{
    #[Override]
    public function register(OpenApiRegistry $registry): void
    {
        if (!class_exists(Fortify::class)) {
            return;
        }

        $registry->addRequestSchemaResolver(FortifyRequestSchemaResolver::class);
        $registry->addPrimaryResponseResolver(FortifyResponseResolver::class);
    }
}
```
(The resolver classes are created in Tasks 3–4; this won't autoload-resolve until they exist — that's fine, `register()` isn't called at file-load.)

- [ ] **Step 3: Add the commented config entry**

In `config/openapi.php`, under `'plugins' => [`, after the Fractal block, add:
```php
        // Requires `composer require laravel/fortify`. Documents Fortify's headless core-auth
        // endpoints (login/register/password/profile) from a stock-contract table. Uncomment:
        // \Radiergummi\OpenApi\Plugins\Fortify\FortifyPlugin::class,
```

- [ ] **Step 4: Commit**

```bash
git add composer.json composer.lock src/Plugins/Fortify/FortifyPlugin.php config/openapi.php
git commit -m "feat(#134): scaffold Fortify plugin (off by default)"
```

---

## Task 2: The contract table

**Files:**
- Create: `src/Plugins/Fortify/Support/FortifyContractTable.php`
- Test: `tests/Unit/Plugins/Fortify/FortifyContractTableTest.php`

The table is the single source of truth. Each entry: stock request `OA\Schema`, stock success `OA\Schema|null` (null = no body, e.g. 204), success status, and the FQCN of the Fortify response contract that governs the response (for the customization gate in Task 5). Request bodies are the stable, documented Fortify validation rules. **Response bodies and statuses MUST be verified against the installed Fortify source** in Step 1 below — they are version-sensitive; do not trust this draft blindly.

- [ ] **Step 1: Verify the stock contract against Fortify source**

Read these and reconcile the table values:
- `vendor/laravel/fortify/routes/routes.php` — confirm route NAMES for the v1 set: `login`, `logout`, `register`, `password.email`, `password.update`, `password.confirm`, `password.confirmation`, `user-password.update`, `user-profile-information.update`.
- `vendor/laravel/fortify/src/Actions/*` (e.g. `CreateNewUser`, `AttemptToAuthenticate`) — confirm request validation rule keys.
- `vendor/laravel/fortify/src/Http/Responses/*` and `src/Contracts/*Response.php` — confirm each route's response contract FQCN and the actual JSON success body/status in headless mode.

Record any deviations from this draft as a code comment in the table.

- [ ] **Step 2: Write the failing test**

`tests/Unit/Plugins/Fortify/FortifyContractTableTest.php`:
```php
<?php

declare(strict_types=1);

use OpenApi\Annotations as OA;
use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;

it('exposes an entry for each v1 core-auth route name', function (): void {
    $names = ['login', 'logout', 'register', 'password.email', 'password.update',
        'password.confirm', 'password.confirmation', 'user-password.update',
        'user-profile-information.update'];

    foreach ($names as $name) {
        expect(FortifyContractTable::for($name))->not->toBeNull();
    }
    expect(FortifyContractTable::for('two-factor.login'))->toBeNull(); // deferred, not in v1
});

it('returns a request schema and response contract for login', function (): void {
    $entry = FortifyContractTable::for('login');
    expect($entry->requestSchema)->toBeInstanceOf(OA\Schema::class)
        ->and($entry->responseContract)->toBe(\Laravel\Fortify\Contracts\LoginResponse::class)
        ->and($entry->successStatus)->toBe(200);
});
```

- [ ] **Step 3: Run it (fails — class missing)**

Run: `vendor/bin/pest tests/Unit/Plugins/Fortify/FortifyContractTableTest.php`
Expected: FAIL (`FortifyContractTable` not found).

- [ ] **Step 4: Implement the table + entry value object**

`src/Plugins/Fortify/Support/FortifyContractTable.php`:
```php
<?php

declare(strict_types=1);

namespace Radiergummi\OpenApi\Plugins\Fortify\Support;

use Laravel\Fortify\Contracts\LoginResponse;
use Laravel\Fortify\Contracts\LogoutResponse;
use Laravel\Fortify\Contracts\PasswordConfirmedResponse;
use Laravel\Fortify\Contracts\PasswordResetResponse;
use Laravel\Fortify\Contracts\PasswordUpdateResponse;
use Laravel\Fortify\Contracts\ProfileInformationUpdatedResponse;
use Laravel\Fortify\Contracts\RegisterResponse;
use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
use OpenApi\Annotations as OA;
use Radiergummi\OpenApi\Support\Generator\SchemaFromArrayDefinition;

/**
 * Hand-maintained stock contract for Fortify's headless core-auth routes, keyed by route name.
 *
 * @internal
 */
final class FortifyContractTable
{
    /** @return FortifyContractEntry|null */
    public static function for(string $routeName): ?FortifyContractEntry
    {
        return match ($routeName) {
            'login' => new FortifyContractEntry(
                requestSchema: self::object([
                    'email' => ['type' => 'string', 'format' => 'email'],
                    'password' => ['type' => 'string', 'format' => 'password'],
                    'remember' => ['type' => 'boolean'],
                ], required: ['email', 'password']),
                responseContract: LoginResponse::class,
                successStatus: 200,
                successSchema: null, // verify: Fortify JSON login returns 200 empty / {two_factor}
            ),
            'logout' => new FortifyContractEntry(
                requestSchema: null,
                responseContract: LogoutResponse::class,
                successStatus: 204,
                successSchema: null,
            ),
            'register' => new FortifyContractEntry(
                requestSchema: self::object([
                    'name' => ['type' => 'string'],
                    'email' => ['type' => 'string', 'format' => 'email'],
                    'password' => ['type' => 'string', 'format' => 'password'],
                    'password_confirmation' => ['type' => 'string', 'format' => 'password'],
                ], required: ['name', 'email', 'password', 'password_confirmation']),
                responseContract: RegisterResponse::class,
                successStatus: 201,
                successSchema: null,
            ),
            'password.email' => new FortifyContractEntry(
                requestSchema: self::object([
                    'email' => ['type' => 'string', 'format' => 'email'],
                ], required: ['email']),
                responseContract: SuccessfulPasswordResetLinkRequestResponse::class,
                successStatus: 200,
                successSchema: self::object(['message' => ['type' => 'string']]),
            ),
            'password.update' => new FortifyContractEntry(
                requestSchema: self::object([
                    'token' => ['type' => 'string'],
                    'email' => ['type' => 'string', 'format' => 'email'],
                    'password' => ['type' => 'string', 'format' => 'password'],
                    'password_confirmation' => ['type' => 'string', 'format' => 'password'],
                ], required: ['token', 'email', 'password', 'password_confirmation']),
                responseContract: PasswordResetResponse::class,
                successStatus: 200,
                successSchema: self::object(['message' => ['type' => 'string']]),
            ),
            'password.confirm' => new FortifyContractEntry(
                requestSchema: self::object([
                    'password' => ['type' => 'string', 'format' => 'password'],
                ], required: ['password']),
                responseContract: PasswordConfirmedResponse::class,
                successStatus: 201,
                successSchema: null,
            ),
            'password.confirmation' => new FortifyContractEntry(
                requestSchema: null,
                responseContract: null, // GET status endpoint, returns JSON directly (no contract)
                successStatus: 200,
                successSchema: self::object(['confirmed' => ['type' => 'boolean']]),
            ),
            'user-password.update' => new FortifyContractEntry(
                requestSchema: self::object([
                    'current_password' => ['type' => 'string', 'format' => 'password'],
                    'password' => ['type' => 'string', 'format' => 'password'],
                    'password_confirmation' => ['type' => 'string', 'format' => 'password'],
                ], required: ['current_password', 'password', 'password_confirmation']),
                responseContract: PasswordUpdateResponse::class,
                successStatus: 200,
                successSchema: null,
            ),
            'user-profile-information.update' => new FortifyContractEntry(
                requestSchema: self::object([
                    'name' => ['type' => 'string'],
                    'email' => ['type' => 'string', 'format' => 'email'],
                ], required: ['name', 'email']),
                responseContract: ProfileInformationUpdatedResponse::class,
                successStatus: 200,
                successSchema: null,
            ),
            default => null,
        };
    }

    /**
     * @param array<string, array<string, mixed>> $properties
     * @param list<string> $required
     */
    private static function object(array $properties, array $required = []): OA\Schema
    {
        $definition = ['type' => 'object', 'properties' => $properties];
        if ($required !== []) {
            $definition['required'] = $required;
        }
        return SchemaFromArrayDefinition::build($definition);
    }
}
```

`src/Plugins/Fortify/Support/FortifyContractEntry.php`:
```php
<?php

declare(strict_types=1);

namespace Radiergummi\OpenApi\Plugins\Fortify\Support;

use OpenApi\Annotations as OA;

/** @internal */
final readonly class FortifyContractEntry
{
    public function __construct(
        public ?OA\Schema $requestSchema,
        public ?string $responseContract,
        public int $successStatus,
        public ?OA\Schema $successSchema,
    ) {}
}
```
(Confirm `SchemaFromArrayDefinition::build()` accepts a nested `properties` map of `name => definition`; if it expects `OA\Property` objects instead, build them with `SchemaFromArrayDefinition::buildProperty($name, $def)` — see `src/Support/Generator/SchemaFromArrayDefinition.php`.)

- [ ] **Step 5: Run the test (passes)**

Run: `vendor/bin/pest tests/Unit/Plugins/Fortify/FortifyContractTableTest.php`
Expected: PASS.

- [ ] **Step 6: Commit**

```bash
git add src/Plugins/Fortify/Support/ tests/Unit/Plugins/Fortify/FortifyContractTableTest.php
git commit -m "feat(#134): Fortify stock-contract table"
```

---

## Task 3: Request-schema resolver

**Files:**
- Create: `src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php`
- Test: covered end-to-end in Task 6 (it needs a booted app + routes)

- [ ] **Step 1: Implement the resolver**

```php
<?php

declare(strict_types=1);

namespace Radiergummi\OpenApi\Plugins\Fortify\Resolvers;

use Illuminate\Container\Attributes\Scoped;
use OpenApi\Annotations as OA;
use Override;
use Radiergummi\OpenApi\Contracts\Registry\RequestSchemaResolver;
use Radiergummi\OpenApi\Enums\MediaType;
use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
use Radiergummi\OpenApi\Routing\ActionDescriptor;
use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
use Radiergummi\OpenApi\Support\Registry\ResolvedSchema;

/**
 * Emits the stock Fortify request body for a matched core-auth route, by route name.
 *
 * @internal
 */
#[Scoped]
final readonly class FortifyRequestSchemaResolver implements RequestSchemaResolver
{
    public function __construct(private ComponentSchemaRegistry $registry) {}

    #[Override]
    public function resolveRequestSchema(ActionDescriptor $descriptor): ?ResolvedSchema
    {
        $name = $descriptor->route->getName();
        if ($name === null) {
            return null;
        }

        $entry = FortifyContractTable::for($name);
        if ($entry === null || $entry->requestSchema === null) {
            return null;
        }

        $key = $this->registry->reserveKey('Fortify\\Request\\' . $name);
        $this->registry->registerNamed($key, $entry->requestSchema);

        return new ResolvedSchema(componentKey: $key, mediaType: MediaType::Json);
    }
}
```
(`registerNamed` is idempotent, so re-resolution is safe. `reserveKey` derives a stable component key from the synthetic class string.)

- [ ] **Step 2: Commit**

```bash
git add src/Plugins/Fortify/Resolvers/FortifyRequestSchemaResolver.php
git commit -m "feat(#134): Fortify request-schema resolver"
```

---

## Task 4: The customization gate

**Files:**
- Create: `src/Plugins/Fortify/Support/FortifyResponseCustomization.php`
- Test: `tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php`

The gate answers: "is the route's Fortify response contract still bound to a `Laravel\Fortify\` class?" Inspect the binding WITHOUT resolving where possible; if indeterminate (closure binding) → treat as customized (conservative).

- [ ] **Step 1: Write the failing test**

```php
<?php

declare(strict_types=1);

use Illuminate\Container\Container;
use Laravel\Fortify\Contracts\LoginResponse;
use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyResponseCustomization;

it('reports stock when the contract resolves to a Fortify class', function (): void {
    $container = new Container();
    $container->bind(LoginResponse::class, \Laravel\Fortify\Http\Responses\LoginResponse::class);
    $gate = new FortifyResponseCustomization($container);
    expect($gate->isStock(LoginResponse::class))->toBeTrue();
});

it('reports customized when rebound to a non-Fortify class', function (): void {
    $container = new Container();
    $container->bind(LoginResponse::class, fn () => new class implements LoginResponse {
        public function toResponse($request) { return response()->noContent(); }
    });
    $gate = new FortifyResponseCustomization($container);
    expect($gate->isStock(LoginResponse::class))->toBeFalse(); // closure binding => conservative
});

it('reports stock for a null contract (no contract governs the body)', function (): void {
    $gate = new FortifyResponseCustomization(new Container());
    expect($gate->isStock(null))->toBeTrue();
});
```

- [ ] **Step 2: Run it (fails)**

Run: `vendor/bin/pest tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php`
Expected: FAIL (class missing).

- [ ] **Step 3: Implement the gate**

```php
<?php

declare(strict_types=1);

namespace Radiergummi\OpenApi\Plugins\Fortify\Support;

use Illuminate\Contracts\Container\Container;

use function is_string;
use function str_starts_with;

/**
 * Best-effort detector for whether a Fortify response contract still maps to a stock Fortify
 * implementation. Inspects the registered binding's concrete WITHOUT resolving it; a closure
 * binding (or unbound) is treated as customized — we never emit a possibly-wrong stock body.
 *
 * @internal
 */
final readonly class FortifyResponseCustomization
{
    private const string FORTIFY_NAMESPACE = 'Laravel\\Fortify\\';

    public function __construct(private Container $container) {}

    public function isStock(?string $responseContract): bool
    {
        // No contract governs this route's body (e.g. the password-confirmation status endpoint).
        if ($responseContract === null) {
            return true;
        }

        if (!$this->container->bound($responseContract)) {
            // Unbound: Fortify's service provider binds all of these, so an unbound contract means
            // Fortify isn't fully wired — be conservative.
            return false;
        }

        $concrete = $this->container->getBindings()[$responseContract]['concrete'] ?? null;

        // Only a string concrete (a class name) is inspectable without invoking a closure.
        return is_string($concrete) && str_starts_with($concrete, self::FORTIFY_NAMESPACE);
    }
}
```
(Confirm the binding array shape: Laravel's `Container::getBindings()` returns `[$abstract => ['concrete' => Closure|string, 'shared' => bool]]`. Fortify binds its responses via `singleton($contract, $concreteClassString)` in most versions — verify in `vendor/laravel/fortify/src/FortifyServiceProvider.php`; if it binds via closures returning `new X`, the gate correctly falls to conservative status-only, which is acceptable.)

- [ ] **Step 4: Run the test (passes)**

Run: `vendor/bin/pest tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php`
Expected: PASS.

- [ ] **Step 5: Commit**

```bash
git add src/Plugins/Fortify/Support/FortifyResponseCustomization.php tests/Unit/Plugins/Fortify/FortifyResponseCustomizationTest.php
git commit -m "feat(#134): Fortify response-customization gate"
```

---

## Task 5: Response resolver

**Files:**
- Create: `src/Plugins/Fortify/Resolvers/FortifyResponseResolver.php`
- Test: end-to-end in Task 6

- [ ] **Step 1: Implement the resolver**

```php
<?php

declare(strict_types=1);

namespace Radiergummi\OpenApi\Plugins\Fortify\Resolvers;

use Illuminate\Container\Attributes\Scoped;
use Illuminate\Contracts\Container\Container;
use OpenApi\Annotations as OA;
use Override;
use Radiergummi\OpenApi\Contracts\Registry\PrimaryResponseResolver;
use Radiergummi\OpenApi\Enums\MediaType;
use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyContractTable;
use Radiergummi\OpenApi\Plugins\Fortify\Support\FortifyResponseCustomization;
use Radiergummi\OpenApi\Routing\ActionDescriptor;
use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;

use function sprintf;

/**
 * Emits the stock Fortify success response for a matched core-auth route. When the route's
 * response contract has been rebound to a non-Fortify class, emits the status code only (the
 * body is unknowable), never a possibly-wrong stock body.
 *
 * @internal
 */
#[Scoped]
final readonly class FortifyResponseResolver implements PrimaryResponseResolver
{
    public function __construct(private Container $container) {}

    #[Override]
    public function resolvePrimaryResponse(ActionDescriptor $descriptor): ?OA\Response
    {
        $name = $descriptor->route->getName();
        if ($name === null) {
            return null;
        }

        $entry = FortifyContractTable::for($name);
        if ($entry === null) {
            return null;
        }

        $status = $entry->successStatus;
        $description = HttpFoundationResponse::$statusTexts[$status] ?? sprintf('HTTP %d', $status);

        $gate = new FortifyResponseCustomization($this->container);
        $emitBody = $entry->successSchema !== null && $gate->isStock($entry->responseContract);

        if (!$emitBody) {
            return new OA\Response(['response' => (string) $status, 'description' => $description]);
        }

        return new OA\Response([
            'response' => (string) $status,
            'description' => $description,
            'content' => [MediaType::Json->schema($entry->successSchema)],
        ]);
    }
}
```

- [ ] **Step 2: Commit**

```bash
git add src/Plugins/Fortify/Resolvers/FortifyResponseResolver.php
git commit -m "feat(#134): Fortify response resolver with customization gate"
```

---

## Task 6: End-to-end feature tests

**Files:**
- Create: `tests/Fixtures/Fortify/routes.php` (registers Fortify's core routes by name)
- Create: `tests/Feature/Plugins/Fortify/FortifyPluginTest.php`

Match the existing plugin feature-test harness — look at `tests/Feature/Plugins/ApiResources/` or `tests/Feature/Plugins/Fractal/` for how a fixture app registers routes, enables a plugin, runs generation, and asserts on the produced document. Reuse that bootstrapping; don't invent a new one.

- [ ] **Step 1: Register the v1 routes in a fixture**

`tests/Fixtures/Fortify/routes.php` (register the route NAMES the table keys on — minimal closures suffice; the plugin keys off names, not actions):
```php
<?php
use Illuminate\Support\Facades\Route;
Route::post('/login', fn () => null)->name('login');
Route::post('/logout', fn () => null)->name('logout');
Route::post('/register', fn () => null)->name('register');
Route::post('/forgot-password', fn () => null)->name('password.email');
Route::post('/reset-password', fn () => null)->name('password.update');
Route::post('/user/confirm-password', fn () => null)->name('password.confirm');
Route::get('/user/confirmed-password-status', fn () => null)->name('password.confirmation');
Route::put('/user/password', fn () => null)->name('user-password.update');
Route::put('/user/profile-information', fn () => null)->name('user-profile-information.update');
```

- [ ] **Step 2: Write the feature tests**

`tests/Feature/Plugins/Fortify/FortifyPluginTest.php` (adapt the bootstrap to the existing harness):
```php
<?php

declare(strict_types=1);

use Laravel\Fortify\Contracts\LoginResponse;

// Helper `generateWithFortifyPlugin()` should: register the FortifyPlugin, load the fixture
// routes, run the generator, and return the decoded OpenAPI document as an array.

it('documents the login request body from the stock table', function (): void {
    $doc = generateWithFortifyPlugin();
    $op = $doc['paths']['/login']['post'];
    $ref = $op['requestBody']['content']['application/json']['schema']['$ref'];
    $schema = resolveRef($doc, $ref);
    expect($schema['properties'])->toHaveKeys(['email', 'password', 'remember'])
        ->and($schema['required'])->toContain('email', 'password');
});

it('emits the stock success body when the response contract is default Fortify', function (): void {
    $doc = generateWithFortifyPlugin();
    $op = $doc['paths']['/forgot-password']['post'];
    expect($op['responses'])->toHaveKey('200')
        ->and($op['responses']['200']['content']['application/json']['schema']['properties'])
        ->toHaveKey('message');
});

it('drops the success body (status only) when the response contract is rebound', function (): void {
    $doc = generateWithFortifyPlugin(function ($app): void {
        $app->bind(\Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse::class,
            fn () => new class implements \Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse {
                public function toResponse($request) { return response()->json(['x' => 1]); }
            });
    });
    $op = $doc['paths']['/forgot-password']['post'];
    expect($op['responses'])->toHaveKey('200')
        ->and($op['responses']['200'])->not->toHaveKey('content'); // body dropped
});

it('emits nothing for a route that is not registered', function (): void {
    $doc = generateWithFortifyPlugin(routes: ['login']); // only register login
    expect($doc['paths'] ?? [])->not->toHaveKey('/register');
});
```

- [ ] **Step 3: Run the suite**

Run: `vendor/bin/pest tests/Feature/Plugins/Fortify/FortifyPluginTest.php`
Expected: all PASS. Fix wiring until green.

- [ ] **Step 4: Full local gate**

Run: `composer format && composer check`
Expected: Pint clean, PHPStan level 8 clean, full Pest suite green (including the byte-exact snapshot group — the Fortify fixtures must not be wired into any snapshot flavor).

- [ ] **Step 5: Commit**

```bash
git add tests/
git commit -m "feat(#134): Fortify plugin end-to-end tests"
```

---

## Task 7: Docs + CHANGELOG

**Files:**
- Modify: `docs/plugins.md`
- Modify: `CHANGELOG.md`

- [ ] **Step 1: Document the plugin**

Add a `Fortify` section to `docs/plugins.md` mirroring the existing plugin sections: what it does (documents Fortify's headless core-auth endpoints from a stock table), that it's **off by default** (uncomment in `config/openapi.plugins`, requires `laravel/fortify`), the v1 scope (core auth; 2FA + email verification deferred), and the customization behavior (stock request bodies always; stock response bodies only when the response contract is unmodified, else status-only; authoring attributes override).

- [ ] **Step 2: CHANGELOG entry**

Add to `CHANGELOG.md` under `[Unreleased] > Added`, as its own line at the END of the section:
```markdown
- **Fortify plugin** (opt-in): documents Laravel Fortify's headless core-auth endpoints (login/logout/register/password/profile) from a stock-contract table, with request bodies always emitted and response bodies gated on the Fortify response contract being unmodified. (#134)
```

- [ ] **Step 3: Commit**

```bash
git add docs/plugins.md CHANGELOG.md
git commit -m "docs(#134): document the Fortify plugin"
```

---

## Verification checklist (before marking ready)

- [ ] `composer check` green (Pint + PHPStan L8 + full Pest suite).
- [ ] Snapshot (byte-exact) group unaffected — Fortify fixtures are NOT referenced by any snapshot flavor.
- [ ] Plugin is OFF by default — generation output is byte-identical without the config entry uncommented.
- [ ] Remote CI green across the full matrix incl. swagger-php 5.8 (no raw nested-array schemas — the table uses `OA\Schema`/`SchemaFromArrayDefinition`, so this should hold; confirm).
- [ ] Response-body table values verified against the pinned Fortify version's actual JSON responses (Task 2 Step 1).

## Notes / soft spots flagged during design

- **Response-body fidelity is version-sensitive.** Task 2 Step 1 is mandatory: transcribe the real stock responses from the installed Fortify, don't trust this draft's `successSchema`/`successStatus` guesses.
- **The binding gate is best-effort.** If Fortify binds responses via closures, the gate can't read the concrete class → it conservatively emits status-only even for stock apps. Acceptable (never wrong, occasionally less detailed). If verification shows Fortify binds via class-string singletons, the gate reads them precisely.
- **2FA + email verification are deferred** — a follow-up issue should extend `FortifyContractTable` + the route set once v1 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)