### PR TITLE
feat(#46): regression guard — openapi:why explains globally-filtered routes

### DIFF
--- a/tests/Unit/Console/WhyCommandTest.php
+++ b/tests/Unit/Console/WhyCommandTest.php
@@ -4,9 +4,22 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Tests\Unit\Console;
 
+use Illuminate\Routing\Route as RoutingRoute;
 use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Contracts\Routing\RouteFilter;
 
 uses()->group('openapi');
+
+/**
+ * Test-local global filter that skips the `api/v1/flights` fixture route.
+ */
+final class FlightsRouteFilter implements RouteFilter
+{
+    public function shouldSkip(RoutingRoute $route): bool
+    {
+        return $route->uri() === 'api/v1/flights';
+    }
+}
 
 beforeEach(function (): void {
     Route::get('api/v1/flights', fn() => 'x')->name('v1.flights.index');
@@ -23,6 +36,22 @@ it('explains why a route is included in each spec', function (): void {
         ->expectsOutputToContain('default:')
         ->expectsOutputToContain('v1:')
         ->expectsOutputToContain('Result:')
+        ->assertSuccessful();
+});
+
+it('explains a globally-filtered route as filtered, not as not-found', function (): void {
+    config(['openapi.filters' => [FlightsRouteFilter::class]]);
+    app()->forgetScopedInstances();
+
+    // The route is discovered (discover() stays unfiltered) and explained as excluded by the
+    // global filter, never reported as not-found. Chained expectsOutputToContain matches the
+    // buffer in document order, so the summary line (which already names the filter class) is
+    // asserted last; a separate class-name assertion would consume the trace-line occurrence first.
+    $this
+        ->artisan('openapi:why api/v1/flights')
+        ->expectsOutputToContain('Route:')
+        ->expectsOutputToContain('global-filter')
+        ->expectsOutputToContain('excluded by global filter ' . FlightsRouteFilter::class)
         ->assertSuccessful();
 });
 

--- a/tests/Unit/Console/WhyCommandTest.php
+++ b/tests/Unit/Console/WhyCommandTest.php
@@ -44,9 +44,8 @@ it('explains a globally-filtered route as filtered, not as not-found', function 
     app()->forgetScopedInstances();
 
     // The route is discovered (discover() stays unfiltered) and explained as excluded by the
-    // global filter, never reported as not-found. Chained expectsOutputToContain matches the
-    // buffer in document order, so the summary line (which already names the filter class) is
-    // asserted last; a separate class-name assertion would consume the trace-line occurrence first.
+    // global filter, never reported as not-found. The summary assertion already names the filter
+    // class, so a separate bare class-name assertion would be redundant.
     $this
         ->artisan('openapi:why api/v1/flights')
         ->expectsOutputToContain('Route:')

--- a/tests/Unit/Console/WhyCommandTest.php
+++ b/tests/Unit/Console/WhyCommandTest.php
@@ -44,12 +44,12 @@ it('explains a globally-filtered route as filtered, not as not-found', function 
     app()->forgetScopedInstances();
 
     // The route is discovered (discover() stays unfiltered) and explained as excluded by the
-    // global filter, never reported as not-found. The summary assertion already names the filter
-    // class, so a separate bare class-name assertion would be redundant.
+    // global filter, never reported as not-found. Both fragments include the filter class so the
+    // stage label and the summary wording are each pinned, not loosely matched.
     $this
         ->artisan('openapi:why api/v1/flights')
         ->expectsOutputToContain('Route:')
-        ->expectsOutputToContain('global-filter')
+        ->expectsOutputToContain('global-filter ' . FlightsRouteFilter::class)
         ->expectsOutputToContain('excluded by global filter ' . FlightsRouteFilter::class)
         ->assertSuccessful();
 });


### PR DESCRIPTION
Closes #46

## Implementation plan

Add a regression-test guard so `openapi:why` can never silently stop explaining
**globally-filtered** routes. The explanation is already wired end to end; the gap is a missing
test.

**Wiring confirmed against the named files** (premise holds — no re-architecture):
- `RouteIntrospector::discover()` (`src/Support/Routing/RouteIntrospector.php:47`) yields **every**
  route unconditionally — no filtering. ✓
- `InclusionEvaluator::decide()` (`src/Support/Inclusion/InclusionEvaluator.php:78-96`) iterates the
  configured filters, emits a `TraceEntry{ stage: 'global-filter', name: <class>, passed: false }`,
  and on a match returns summary `"excluded by global filter {$name}"` (`SkipReason::GlobalFilter`). ✓
- `WhyCommand::printSpecDecision()` (`src/Console/WhyCommand.php:140-150`) prints
  `{mark} {stage} {name} — {reason}` per trace entry and `→ {summary}`. ✓
- Filters are bound from `config('openapi.filters')` in the `InclusionEvaluator` factory
  (`src/OpenApiServiceProvider.php:187`). ✓

So the output for a filtered route already contains `global-filter`, the filter class name, and
`excluded by global filter <Class>`. The test locks that in.

### Tier

Not an inference change — a CLI regression guard. No body parsing.

### Test deliverable (primary)

**Modify** `tests/Unit/Console/WhyCommandTest.php` — one new test, following the file's existing
conventions (register routes in/before the test, set config, then `app()->forgetScopedInstances()`
so the scoped `InclusionEvaluator` rebinds with the new config):

1. Define a test-local `RouteFilter` (a small named fixture class or an `implements RouteFilter`
   class in the test file) whose `shouldSkip(Route $route): bool` returns true for the known route
   (e.g. matches the `api/v1/flights` URI registered in `beforeEach`).
2. `config(['openapi.filters' => [TheFilter::class]])` — the real channel `InclusionEvaluator`
   reads (`config/openapi.php:474`), then `app()->forgetScopedInstances()`.
3. Run `artisan('openapi:why api/v1/flights')` and assert the output:
   - contains `global-filter` (the stage),
   - contains the filter class name (`expectsOutputToContain` the `::class` basename/FQCN — match
     what `printSpecDecision` prints, which is `$entry->name` = the FQCN),
   - contains the reason/summary (`excluded by global filter` — names the filter),
   - and `assertSuccessful()` (the route IS found; it's explained as filtered, **not** reported as
     not-found).

Edge cases / branches to keep the guard meaningful:
- **Found, not missing**: assert the command exits successfully and prints the `Route:` block — i.e.
  the filtered route reaches `findCandidates()` (proves `discover()` stays unfiltered). This is the
  core anti-regression assertion (if filtering crept back into `discover()`, the route would be
  reported not-found and the command would fail).
- Optionally assert the non-filtered spec/decision path still prints alongside (the existing
  "explains why a route is included" test already covers the passing-filter case, so no duplication
  needed).

A test-local filter class is the minimal fixture; the one-method `RouteFilter` contract
(`src/Contracts/Routing/RouteFilter.php`) needs no new production fixture.

### Conditional code change

- **If the test passes as-is** (expected, per the confirmed wiring) → **tests-only**, no `src/`
  change. Survey **N/A** (area:cli, no generation impact). Non-controversial.
- **If the test reveals the `global-filter` stage is not surfaced** (e.g. the trace entry is dropped
  before `printSpecDecision()`) → fix only that surfacing in `WhyCommand` /
  `InclusionEvaluator`. This would **not** touch `Contracts\` (`RouteFilter` is the existing,
  unchanged contract) and must **not** reintroduce filtering into `RouteIntrospector::discover()`.
  Flag to the lead, but it stays non-`Contracts`.

### Files

- **Modify** `tests/Unit/Console/WhyCommandTest.php` (+ a test-local `RouteFilter` fixture).
- **Conditional code branch only:** `src/Console/WhyCommand.php` and/or
  `src/Support/Inclusion/InclusionEvaluator.php`; `CHANGELOG.md [Unreleased]`.
- No `docs/` change for the tests-only branch (no observable behaviour change — guarding existing,
  documented behaviour).

### Controversy

Tests-only: none, survey N/A, fast-path eligible (area:cli, additive test). The code branch (only
if the guard fails) stays off `Contracts\`/stage-order/public signatures; flag to the lead if it
materialises.

### Verify

`vendor/bin/pest tests/Unit/Console/WhyCommandTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)