### PR TITLE
fix(#374): lint rule catches class-level #[ResourceField] on JsonResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project are documented here.
 - `#[RequestField]` ref support: a class-string `type:` resolves to a `$ref`, and a class-string `items:` on a `type: 'array'` field resolves to `items: { $ref }` — mirroring the response-side `#[ResourceField]`; an unresolvable class degrades to a permissive object. (#150)
 - A non-paginator action whose body unconditionally calls `paginate()`/`simplePaginate()`/`cursorPaginate()` now gets the matching paginated response envelope, with a declared item class (`#[ResponseResource(Model::class)]` or `@return Paginator<Item>`). Guarded so it never overrides a response API Resources or Spatie Data would shape — a resource/`Data` return type or a resource-naming `#[ResponseResource]` defers to those plugins. (#353)
 - **Fortify plugin** (opt-in): documents Laravel Fortify's headless core-auth endpoints (login/logout/register/password/profile) from a stock-contract table, with request bodies always emitted and response bodies gated on the Fortify response contract being unmodified. (#134)
+- `schema.class-attribute-conflicts-with-field-attributes` now also flags class-level `#[ResourceField]` declarations on a `JsonResource` that carries a class-level `#[RawSchema]`, alongside the property-level `#[RequestField]`/`#[ResponseField]` it already detected. (#374)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -515,7 +515,7 @@ is enabled.
 | `query-builder.filter-duplicate` | 3 | Two or more #[AllowedFilter] attributes on the same action share the same name — only the last is emitted. (QueryBuilder plugin.) |
 | `query-builder.filter-type-missing` | 3 | An #[AllowedFilter] is declared without an explicit value type. (QueryBuilder plugin.) |
 | `response.status-unconventional` | 3 | Response uses a status code that is unusual for the HTTP method. |
-| `schema.class-attribute-conflicts-with-field-attributes` | 3 | A class carries a class-level #[RawSchema] together with field-level attributes (#[RequestField]/#[ResponseField]); the raw schema replaces the inferred body wholesale, so the field attributes have no effect. |
+| `schema.class-attribute-conflicts-with-field-attributes` | 3 | A class carries a class-level #[RawSchema] together with field attributes (#[RequestField]/#[ResponseField]/#[ResourceField]); the raw schema replaces the inferred body wholesale, so the field attributes have no effect. |
 | `schema.composite-fields-uninspected` | 3 | Schema is a oneOf/anyOf of multiple alternatives whose fields are not inspected by field-level rules (property, component schema, response body, or request body). |
 | `scope.overly-broad` | 3 | Operation requires a scope that is broader than the resource warrants. |
 | `spec.config-orphaned` | 3 | A configured spec has zero assigned routes after evaluation. |

--- a/src/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributes.php
+++ b/src/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributes.php
@@ -19,12 +19,14 @@ use ReflectionNamedType;
 
 use function class_exists;
 use function implode;
+use function is_string;
 use function sprintf;
 
 /**
- * Flags a payload/return class that carries a class-level `#[RawSchema]` alongside property-level
- * field attributes (`#[RequestField]`, `#[ResponseField]`, …). The raw schema replaces the
- * inferred body wholesale, so the field attributes never contribute and are dead.
+ * Flags a payload/return class that carries a class-level `#[RawSchema]` alongside field
+ * attributes, whether property-level (`#[RequestField]`, `#[ResponseField]`) or class-level
+ * (`#[ResourceField]` on a `JsonResource`). The raw schema replaces the inferred body wholesale,
+ * so the field attributes never contribute and are dead.
  */
 final class SchemaClassAttributeConflictsWithFieldAttributes implements OperationRuleVisitor, Rule
 {
@@ -46,9 +48,9 @@ final class SchemaClassAttributeConflictsWithFieldAttributes implements Operatio
     #[Override]
     public function description(): string
     {
-        return 'A class carries a class-level #[RawSchema] together with field-level attributes '
-            . '(#[RequestField]/#[ResponseField]); the raw schema replaces the inferred body '
-            . 'wholesale, so the field attributes have no effect.';
+        return 'A class carries a class-level #[RawSchema] together with field attributes '
+            . '(#[RequestField]/#[ResponseField]/#[ResourceField]); the raw schema replaces the '
+            . 'inferred body wholesale, so the field attributes have no effect.';
     }
 
     /**
@@ -113,6 +115,19 @@ final class SchemaClassAttributeConflictsWithFieldAttributes implements Operatio
             }
         }
 
+        // #[ResourceField] is class-level and repeatable: a JsonResource's keys are toArray()
+        // entries, not typed properties, so each key is declared on the class itself.
+        foreach (
+            $reflection->getAttributes(FieldAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute
+        ) {
+            $shortName = new ReflectionClass($attribute->getName())->getShortName();
+            $key = $this->fieldAttributeKey($attribute);
+
+            $dead[] = $key === null
+                ? sprintf('#[%s]', $shortName)
+                : sprintf('#[%s] (key "%s")', $shortName, $key);
+        }
+
         if ($dead === []) {
             return;
         }
@@ -130,6 +145,20 @@ final class SchemaClassAttributeConflictsWithFieldAttributes implements Operatio
             . 'them, or drop #[RawSchema] if the field attributes are the intended source.',
             context: [Finding::CONTEXT_SOURCE_CLASS => $className],
         );
+    }
+
+    /**
+     * Reads the declared output key of a class-level field attribute without instantiating it.
+     * `#[ResourceField]` takes the key as its first (`name`) argument, positional or named.
+     *
+     * @param ReflectionAttribute<object> $attribute
+     */
+    private function fieldAttributeKey(ReflectionAttribute $attribute): ?string
+    {
+        $arguments = $attribute->getArguments();
+        $name = $arguments['name'] ?? $arguments[0] ?? null;
+
+        return is_string($name) && $name !== '' ? $name : null;
     }
 
     #[Override]

--- a/tests/Fixtures/RawSchema/RawSchemaController.php
+++ b/tests/Fixtures/RawSchema/RawSchemaController.php
@@ -19,6 +19,16 @@ class RawSchemaController extends Controller
         return new RawSchemaResource(null);
     }
 
+    public function resourceWithFieldAttribute(): RawSchemaResourceWithFieldAttribute
+    {
+        return new RawSchemaResourceWithFieldAttribute(null);
+    }
+
+    public function resourceFieldOnly(): ResourceFieldOnlyResource
+    {
+        return new ResourceFieldOnlyResource(null);
+    }
+
     public function formRequest(RawSchemaFormRequest $request): array
     {
         return [];

--- a/tests/Fixtures/RawSchema/RawSchemaResourceWithFieldAttribute.php
+++ b/tests/Fixtures/RawSchema/RawSchemaResourceWithFieldAttribute.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Radiergummi\OpenApi\Attributes\RawSchema;
+use Radiergummi\OpenApi\Plugins\ApiResources\Attributes\ResourceField;
+
+/**
+ * A `JsonResource` carrying both a class-level `#[RawSchema]` and class-level `#[ResourceField]`
+ * declarations. The raw schema replaces the inferred body, so the resource fields have no effect.
+ */
+#[RawSchema([
+    'oneOf' => [
+        ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+        ['type' => 'string'],
+    ],
+])]
+#[ResourceField('id', type: 'integer')]
+#[ResourceField('owner', type: 'string')]
+class RawSchemaResourceWithFieldAttribute extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray($request): array
+    {
+        return ['ignored' => 'this would be inferred without #[RawSchema]'];
+    }
+}

--- a/tests/Fixtures/RawSchema/ResourceFieldOnlyResource.php
+++ b/tests/Fixtures/RawSchema/ResourceFieldOnlyResource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\RawSchema;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Radiergummi\OpenApi\Plugins\ApiResources\Attributes\ResourceField;
+
+/**
+ * A `JsonResource` carrying class-level `#[ResourceField]` declarations but no `#[RawSchema]`.
+ * The conflict rule must stay silent: the resource fields are the intended source of truth.
+ */
+#[ResourceField('id', type: 'integer')]
+class ResourceFieldOnlyResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray($request): array
+    {
+        return ['id' => 1];
+    }
+}

--- a/tests/Unit/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributesTest.php
+++ b/tests/Unit/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributesTest.php
@@ -48,6 +48,25 @@ it('flags a class carrying both #[RawSchema] and a field attribute', function ()
         ->toContain('#[RequestField]');
 });
 
+it('flags a JsonResource carrying both #[RawSchema] and class-level #[ResourceField]', function (): void {
+    $findings = classAttributeConflictFindings('resourceWithFieldAttribute');
+
+    expect($findings)
+        ->toHaveCount(1)
+        ->and($findings[0]->ruleId)->toBe('schema.class-attribute-conflicts-with-field-attributes')
+        ->and($findings[0]->level)->toBe(3)
+        ->and($findings[0]->message)
+        ->toContain('replaces the inferred body')
+        ->toContain('have no effect')
+        ->toContain('#[ResourceField]')
+        ->toContain('id')
+        ->toContain('owner');
+});
+
+it('stays silent for class-level #[ResourceField] without a #[RawSchema]', function (): void {
+    expect(classAttributeConflictFindings('resourceFieldOnly'))->toBe([]);
+});
+
 it('stays silent for a #[RawSchema] without field attributes', function (): void {
     expect(classAttributeConflictFindings('data'))->toBe([]);
 });


### PR DESCRIPTION
Closes #374

## What & why

`schema.class-attribute-conflicts-with-field-attributes` flags a class that carries a
class-level `#[RawSchema]` alongside dead field attributes (the raw schema replaces the
inferred body wholesale, so the field attributes never contribute).

Today `checkClass()` only scans `$reflection->getProperties()`. That catches `#[RequestField]`
and `#[ResponseField]`, which target properties. It **misses** `#[ResourceField]`
(`Plugins\ApiResources\Attributes\ResourceField`), declared `#[Attribute(TARGET_CLASS |
IS_REPEATABLE)]` — it lives at the **class** level on a `JsonResource` (whose keys are
`toArray()` entries, not typed properties). So the genuine API-resource conflict (class-level
`#[RawSchema]` + class-level `#[ResourceField]`) is never flagged.

PR #373 took the surgical route: it dropped `#[ResourceField]` from the rule's `description()`,
the `docs/linting.md` row, and the CHANGELOG so the rule stopped over-promising. This PR is the
scope expansion (option b): also scan **class-level** `FieldAttribute` attributes, then re-add
`#[ResourceField]` to the description/docs/CHANGELOG now that it is detectable.

## Tier

**Tier 0** — pure reflection. `ReflectionClass::getAttributes(FieldAttribute::class,
ReflectionAttribute::IS_INSTANCEOF)` on the class itself; no body parsing. Same mechanism the
property loop already uses, lifted to the class level.

## Files to modify

- `src/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributes.php`
  - In `checkClass()`, after the existing per-property loop, also collect class-level field
    attributes: `$reflection->getAttributes(FieldAttribute::class, ReflectionAttribute::IS_INSTANCEOF)`.
    Append each to the same `$dead` list. `#[ResourceField]` carries a `name` constructor arg
    (the output key) but the rule does not need it — the message can reference the attribute by
    short name. Use a class-level label distinct from the `$prop (#[Attr])` property form, e.g.
    `#[ResourceField] (key "owner")` if the `name` is cheaply readable via
    `$attribute->getArguments()`, or simply `#[ResourceField]` if reading args adds noise.
    **Decision for the coder:** keep it minimal — emit the short attribute name; only include
    the key if the first positional/`name` argument is trivially available. Don't instantiate
    the attribute (avoid `newInstance()` side effects); read `getArguments()` if a key is wanted.
  - Update the class docblock and `description()`: re-add `#[ResourceField]` to the enumerated
    field attributes (currently lists `#[RequestField]`/`#[ResponseField]`).
- `docs/linting.md` (line ~518, inside the `lint-rule-catalog` markers): update the description
  cell to re-include `#[ResourceField]`. Keep it consistent with `description()`.
- `CHANGELOG.md` `[Unreleased]`: add an entry under the appropriate section noting the rule now
  also detects class-level `#[ResourceField]` on a `JsonResource` (reference #374). The #351
  line stays; this is a follow-up addition, not a rewrite (pre-1.0, no migration framing).

## Fixtures

- New fixture `tests/Fixtures/RawSchema/RawSchemaResourceWithFieldAttribute.php`: a
  `JsonResource` carrying class-level `#[RawSchema]` **and** one or more class-level
  `#[ResourceField]`. Mirror `RawSchemaResource` (oneOf raw schema) but add e.g.
  `#[ResourceField('id', type: 'integer')]`. Its `toArray()` returns a stub array.
- New controller method on `RawSchemaController`, e.g. `resourceWithFieldAttribute(): RawSchemaResourceWithFieldAttribute`,
  returning the new resource — so the rule reaches it via the non-builtin return-type candidate
  branch (the existing `resource()` path).

## Tests (TDD — failing first)

In `tests/Unit/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributesTest.php`:

1. **Positive (the gap):** `it('flags a JsonResource carrying both #[RawSchema] and class-level
   #[ResourceField]')` → `classAttributeConflictFindings('resourceWithFieldAttribute')` asserts
   exactly **one** finding, `ruleId`/`level` correct, message contains `replaces the inferred
   body`, `have no effect`, and `#[ResourceField]`. This fails before the change.
2. **Negative — class-level field attribute without `#[RawSchema]`:** a fixture (or existing
   `resource()` if it has no ResourceField — it doesn't) returning a resource that has
   `#[ResourceField]` but **no** `#[RawSchema]` → asserts `[]`. Confirms the new branch is still
   gated by the existing `RawSchema` early return. Add a small fixture for this
   (`JsonResource` with only `#[ResourceField]`).
3. **Mixed counting:** if the positive fixture carries two `#[ResourceField]`s, assert the
   message lists both (or assert count stays 1 finding — one finding per class, listing all
   dead attributes, matching current property behaviour). Keep one finding per class.

Existing tests must stay green: `withFieldAttribute` (property `#[RequestField]`), the three
silent cases, and the no-descriptor case are unaffected.

## Edge cases / branches covered

- Class-level `#[ResourceField]` + `#[RawSchema]` → flagged (one finding, lists the field attrs).
- Class-level `#[ResourceField]` without `#[RawSchema]` → silent (early return holds).
- Property-level `#[RequestField]` + `#[RawSchema]` (existing) → still flagged, unchanged.
- A class with **both** property-level and class-level field attributes alongside `#[RawSchema]`
  → all collected into one finding (no double-counting, `$seen` dedup unchanged).
- Repeatable: multiple `#[ResourceField]` on one class are all enumerated.

## Observable changes & docs

- Behaviour: rule now flags class-level `#[ResourceField]` conflicts. → `docs/linting.md`
  catalog row + `CHANGELOG.md [Unreleased]`.
- `openapi:lint --list` description string changes (re-adds `#[ResourceField]`).

## Controversy / merge gate

Low. No `Contracts/**`, no stage-order change, no config key, no public-signature change. Pure
lint-rule scope expansion at Tier 0, advisory (level 3). The rule lives in `src/Lint/Rules/`
(plugin-agnostic) and references `FieldAttribute` (the base in `src/Attributes/`), not the
`ApiResources` plugin directly — `IS_INSTANCEOF` catches `ResourceField` without coupling the
rule to the plugin. Auto-merge candidate once survey/CI are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)