### PR TITLE
docs(#385): documentation-coverage PR-comment + gate CI recipe

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,6 +43,111 @@ To turn this into a hard gate rather than advisory annotations, add a coverage f
       - run: php artisan openapi:lint --format=github --diff --min-coverage=100
 ```
 
+### Coverage comment + gate
+
+There is no first-party GitHub Action — `openapi:lint` is a peer linter, and the PHP tools it sits
+next to (PHPStan, Pint, Pest) don't ship Actions either. The CLI already emits everything an Action
+would, so the "Action" is just a few steps: write the linter's report to a file, post it as a
+sticky PR comment with a generic comment action, and gate the job on `--min-coverage`.
+
+```yaml
+name: OpenAPI
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write   # the sticky comment writes to the PR
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # --diff resolves the merge-base from history
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+
+      - run: composer install --no-interaction --no-progress
+
+      # One run, three outputs: a report file for the comment, inline ::warning
+      # annotations on the diff, and a non-zero exit when coverage drops below the floor.
+      - name: Lint documentation coverage
+        run: |
+          php artisan openapi:lint \
+            --diff \
+            --format=markdown:coverage.md \
+            --format=github \
+            --min-coverage=90
+
+      # Post (and update in place) the report as a single PR comment. `if: always()`
+      # keeps the comment landing even when the gate above fails the step.
+      - name: Sticky coverage comment
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: openapi-coverage   # the key that makes it update, not duplicate
+          path: coverage.md
+```
+
+A few things worth knowing about this recipe:
+
+- **The `markdown` target emits the linter's report, not Markdown tables.** `--format=markdown` is
+  currently an alias for the `cli` formatter with color codes stripped — the file holds the same
+  finding tree and `Coverage: NN%` summary you see in the terminal, which reads fine inside a PR
+  comment. The sticky-comment action posts the file verbatim; wrap it in a fenced block first if you
+  want the monospace tree to line up:
+
+````yaml
+      - name: Wrap report for the comment
+        if: always()
+        run: |
+          { echo '```text'; cat coverage.md; echo '```'; } > coverage-comment.md
+      - name: Sticky coverage comment
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: openapi-coverage
+          path: coverage-comment.md
+````
+
+- **`--diff` resolves its base ref from git history.** With no value it diffs against the
+  merge-base with the default branch, which needs the full history — hence `fetch-depth: 0` on the
+  checkout. To pin the base to the PR target explicitly, pass the event's base SHA:
+
+  ```yaml
+      - run: php artisan openapi:lint --diff=${{ github.event.pull_request.base.sha }} --min-coverage=100
+  ```
+
+- **Make the job a required check.** The `--min-coverage` exit code only blocks a merge once the
+  job is required: in **Settings → Branches → Branch protection rules**, enable *Require status
+  checks to pass before merging* and add the `coverage` job. Until then the failing run is advisory.
+
+> Set the floor with judgement. A whole-suite `--min-coverage=90` on a large existing API will fail
+> on day one; either start from the current percentage and ratchet it up, or scope the gate to the
+> diff (`--diff --min-coverage=100`) so a PR is judged only on the operations it touched.
+
+### Codecov / SonarQube instead of a comment
+
+If you already push coverage to Codecov, Coveralls, or SonarQube, skip the PR comment entirely and
+feed those tools the `cobertura` report — they render patch coverage on the PR themselves:
+
+```yaml
+      - run: php artisan openapi:lint --format=cobertura:coverage.xml --min-coverage=90
+
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          flags: openapi
+```
+
+The `cobertura` (and `lcov`) reports key documentation coverage to controller source lines, so the
+external tool shows exactly which operations are undocumented. See
+[Linting → Output targets](linting.md#output-targets) for the full format list.
+
 ## Spec drift check
 
 If you commit the generated spec to the repo (to publish it, or to review API changes in the


### PR DESCRIPTION
## What

Extends `docs/ci.md` (GitHub Actions section) with a copy-pasteable **documentation-coverage
PR-comment + gate** recipe, in lieu of the declined custom Action (#157). Docs-only, no new code.

The recipe:

- runs `openapi:lint --diff --format=markdown:coverage.md --format=github --min-coverage=90` in one
  job (report file + inline `::warning` annotations + a gate exit code, from a single run);
- posts/updates a **sticky PR comment** from the report file via
  `marocchino/sticky-pull-request-comment`, with a fenced-block wrapping variant;
- documents `--diff` base-ref resolution (`fetch-depth: 0` for the merge-base; or
  `--diff=${{ github.event.pull_request.base.sha }}` to pin the PR target) and how to make the job
  a **required check** in branch protection;
- documents the **Codecov / SonarQube** alternative: feed `--format=cobertura:coverage.xml` directly
  and skip the comment step.

Also adds a `docs/ci.md` → `linting.md#output-targets` cross-link. `ci.md` is already in the
`docs/README.md` index, so no index change. Docs-only with no behaviour change, so no `CHANGELOG`
entry (the changelog tracks behaviour changes).

## Decision recorded: the `markdown` format caveat

The issue references `--format=markdown:coverage.md` as "the PR-comment body". I verified the CLI
before writing:

- `markdown` **is** a real `--format` value (`LinterOutputFormat::Markdown`; `FormatTargetParser`
  accepts it; the file is written), **but** `LintCommand::formatterFor()` aliases `Markdown` →
  `CliFormatter`. There is **no GFM/Markdown formatter**.
- Empirically (`--format=markdown:<file>` against the broken-fixture routes): the file contains the
  CLI finding tree — emoji (⚠️/ℹ️), box connectors (`├─`/`╰─`/`│`), `Suggested Fix:` lines, and the
  `Coverage: NN%` summary. Termwind color/`<href>` tags **are** stripped on file output, but it is
  not Markdown tables/headings.

So the recipe documents this honestly ("the `markdown` target emits the linter's report, not
Markdown tables"), posts the file verbatim, and shows wrapping it in a ```text fence. This keeps the
acceptance criterion — references only existing flags, no new code — while not overclaiming.

**Follow-up (separate, code):** a true GFM `MarkdownFormatter` would make the comment body native
Markdown. That's an `area:cli` feature, out of scope for this docs-only issue; I'll file it
separately.

## Verification

- Only `docs/ci.md` changed (+105 lines); no `.php` touched, so `tests` / Pint / PHPStan are
  unaffected.
- Markdown fences balanced (the wrapping example that contains literal ```` ``` ```` uses a
  4-backtick outer fence so it doesn't break rendering).
- All referenced flags confirmed present on `main`: `--format=github`, `--format=markdown`,
  `--format=cobertura`, `--min-coverage`, `--diff` (and `--diff=<ref>`).

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)