### PR TITLE
feat(responses): infer collection schema for X::collect(...) resource factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project are documented here.
 - Regression guard: `#[RawSchema]` documents using the nested-schema keywords `additionalProperties` (as a schema), `patternProperties`, `propertyNames`, `contains`, and `discriminator` produce a document that passes swagger-php's `validate()` (the raw-array-under-a-schema-keyword shape is accepted on both supported majors, 5.8 and 6.x), with the serialised shape pinned by per-keyword assertions. No conversion is needed. (#352)
 - `#[ResponseExampleFile('path.json')]` authoring attribute attaches a JSON file's contents as the singular `example` on a response (the auto-derived primary by default, `status:` targets a declared response). Skipped silently for a conventionally bodyless status (204/205/304) or a status with no matching response, and yields to named `#[ResponseExample]`s already on the same media type (`example`/`examples` are mutually exclusive). (#40)
 - `openapi:lint --format=markdown` now renders a real GitHub-Flavored Markdown body (a coverage summary line and a `Severity | Rule | Location | Message` findings table) instead of aliasing the CLI tree dump, so the CI coverage-comment recipe can post it verbatim. (#389)
+- ApiResources: the return-expression reader now recognises the `X::collect(...)` static resource-collection factory, emitting the same collection response schema as `X::collection(...)`. (#390)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -158,10 +158,10 @@ public function index(): AnonymousResourceCollection
 resolves the item resource to `ProjectResource` — no annotation needed.
 Recognised shapes:
 
-- `X::collection(...)` → collection of `X`; `X::make(...)` / `new X(...)` → a
-  single `X`. `X` must be a concrete resource — a call on the base
-  `JsonResource` itself or on an abstract subclass refuses (there is no field
-  shape to document).
+- `X::collection(...)` / `X::collect(...)` → collection of `X`; `X::make(...)` /
+  `new X(...)` → a single `X`. `X` must be a concrete resource — a call on the
+  base `JsonResource` itself or on an abstract subclass refuses (there is no
+  field shape to document).
 - The two-statement form `$projects = X::collection(...); return $projects;`,
   as long as the variable is assigned exactly once on the unconditional path.
 - `->toResource(X::class)` / `->toResourceCollection(X::class)` — the literal

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -131,6 +131,15 @@ parameters:
             identifier: openapi.allowedFilter.duplicate
             paths:
                 - tests/Unit/Plugins/QueryBuilder/Lint/QueryBuilderFilterDuplicateTest.php
+        # `JsonResource::collect()` is a recent Laravel static factory the vendored framework
+        # (and the Laravel 12 CI leg) does not declare; the return-expression fixtures call it
+        # only to be parsed by the AST-name-based reader, never invoked. PHPStan resolves the
+        # static call and rightly reports it missing against the installed framework.
+        -
+            identifier: staticMethod.notFound
+            paths:
+                - tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
+                - tests/Feature/Plugins/ApiResources/ReturnExpressionResolutionTest.php
         # The abort-scan fixture deliberately passes an unknown named argument (`status:` instead
         # of `code:`) to prove the body scan degrades gracefully. The malformed call against the
         # real abort_if signature is the test input; for everyone else PHPStan rightly rejects it.

--- a/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
+++ b/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
@@ -55,8 +55,8 @@ use function sprintf;
  * The `@return` generic wins over the body scan. The scan then matches a narrow whitelist in the
  * first {@see self::STATEMENT_LIMIT} statements: one unconditional return (or the variable it
  * names, assigned exactly once on the unconditional path), unwrapped through resource-preserving
- * chains (`->additional(...)`). Recognised shapes: `X::collection(...)`, `X::make(...)`,
- * `new X(...)`, `->toResource(X::class)`, `->toResourceCollection(X::class)`, bare
+ * chains (`->additional(...)`). Recognised shapes: `X::collection(...)`, `X::collect(...)`,
+ * `X::make(...)`, `new X(...)`, `->toResource(X::class)`, `->toResourceCollection(X::class)`, bare
  * `$model->toResource()` on a Model-typed parameter, and `new JsonResource($model)` wrapping one.
  *
  * Pagination evidence is derived from the argument/receiver ending in a `paginate()`-family call.
@@ -250,7 +250,7 @@ final class ReturnExpressionResourceReader
         if (
             $expression instanceof StaticCall
             && $expression->name instanceof Identifier
-            && $expression->name->toLowerString() === 'collection'
+            && in_array($expression->name->toLowerString(), ['collection', 'collect'], true)
         ) {
             $argument = $expression->getArgs()[0]->value ?? null;
 
@@ -520,7 +520,8 @@ final class ReturnExpressionResourceReader
             $this->note(
                 $method,
                 'does not match a recognised resource-returning shape '
-                . '(X::collection(...), X::make(...), new X(...), $model->toResource())',
+                . '(X::collection(...), X::collect(...), X::make(...), new X(...), '
+                . '$model->toResource())',
             );
 
             return null;
@@ -532,7 +533,7 @@ final class ReturnExpressionResourceReader
     // region Class & type resolution
 
     /**
-     * `X::collection(...)` → collection of `X`; `X::make(...)` → single `X`.
+     * `X::collection(...)` / `X::collect(...)` → collection of `X`; `X::make(...)` → single `X`.
      */
     private function targetFromStaticCall(
         StaticCall $call,
@@ -545,7 +546,7 @@ final class ReturnExpressionResourceReader
 
         if (
             $resourceClass === null
-            || !in_array($methodName, ['collection', 'make'], true)
+            || !in_array($methodName, ['collection', 'collect', 'make'], true)
         ) {
             $this->note(
                 $method,
@@ -555,7 +556,7 @@ final class ReturnExpressionResourceReader
             return null;
         }
 
-        if ($methodName === 'collection') {
+        if (in_array($methodName, ['collection', 'collect'], true)) {
             $argument = $call->getArgs()[0]->value ?? null;
 
             return new ResourceTarget(

--- a/tests/Feature/Plugins/ApiResources/ReturnExpressionResolutionTest.php
+++ b/tests/Feature/Plugins/ApiResources/ReturnExpressionResolutionTest.php
@@ -45,6 +45,16 @@ class ReturnExpressionController extends Controller
         return NestedAuthorResource::collection(Author::all());
     }
 
+    public function collectCollection(): AnonymousResourceCollection
+    {
+        return NestedAuthorResource::collect(Author::query()->paginate());
+    }
+
+    public function collectUnpaginated(): AnonymousResourceCollection
+    {
+        return NestedAuthorResource::collect(Author::all());
+    }
+
     public function staticMake(): JsonResource
     {
         return NestedAuthorResource::make(Author::query()->firstOrFail());
@@ -227,6 +237,28 @@ it('keeps the paginated envelope for the two-statement assign-then-return form',
     $schema = successSchema(generateSpec(), '/authors-assigned');
 
     expect($schema['properties'])->toHaveKeys(['data', 'links', 'meta'])
+        ->and($schema['properties']['data']['items']['$ref'])->toBe('#/components/schemas/NestedAuthorResource');
+});
+
+it('resolves X::collect() behind an AnonymousResourceCollection signature', function (): void {
+    Route::get('/authors-collect', [ReturnExpressionController::class, 'collectCollection']);
+
+    $spec = generateSpec();
+    $schema = successSchema($spec, '/authors-collect');
+
+    expect($schema['properties'])->toHaveKeys(['data', 'links', 'meta'])
+        ->and($schema['properties']['data']['type'])->toBe('array')
+        ->and($schema['properties']['data']['items']['$ref'])->toBe('#/components/schemas/NestedAuthorResource')
+        ->and($spec['components']['schemas']['NestedAuthorResource']['properties'])->toHaveKeys(['id', 'name']);
+});
+
+it('documents a plain {data} envelope for an unpaginated X::collect() argument', function (): void {
+    Route::get('/authors-collect-unpaginated', [ReturnExpressionController::class, 'collectUnpaginated']);
+
+    $schema = successSchema(generateSpec(), '/authors-collect-unpaginated');
+
+    expect($schema['properties'])->toHaveKey('data')
+        ->and($schema['properties'])->not->toHaveKeys(['links', 'meta'])
         ->and($schema['properties']['data']['items']['$ref'])->toBe('#/components/schemas/NestedAuthorResource');
 });
 

--- a/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
+++ b/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
@@ -49,6 +49,26 @@ class ReaderFixtureController
         return NestedAuthorResource::collection(Author::query()->simplePaginate());
     }
 
+    public function collectPaginated(): AnonymousResourceCollection
+    {
+        return NestedAuthorResource::collect(Author::query()->paginate());
+    }
+
+    public function collectUnpaginated(): AnonymousResourceCollection
+    {
+        return NestedAuthorResource::collect(Author::all());
+    }
+
+    public function baseClassCollect(): AnonymousResourceCollection
+    {
+        return JsonResource::collect(Author::all());
+    }
+
+    public function abstractClassCollect(): AnonymousResourceCollection
+    {
+        return ReaderFixtureAbstractResource::collect(Author::all());
+    }
+
     public function nonWhitelistedChain(): AnonymousResourceCollection
     {
         return NestedAuthorResource::collection(Author::all())->preserveQuery();
@@ -151,6 +171,44 @@ it('falls back to the plain envelope for an item-mapping ->through() trailing ca
 
     expect($target?->resourceClass)->toBe(NestedAuthorResource::class)
         ->and($target?->paginated)->toBeFalse();
+});
+
+it('resolves X::collect() to a paginated collection of the resource', function (): void {
+    $target = readerFor()->read(readerMethod('collectPaginated'));
+
+    expect($target?->resourceClass)->toBe(NestedAuthorResource::class)
+        ->and($target?->isCollection)->toBeTrue()
+        ->and($target?->paginated)->toBeTrue();
+});
+
+it('marks an unpaginated X::collect() argument as not paginated', function (): void {
+    $target = readerFor()->read(readerMethod('collectUnpaginated'));
+
+    expect($target?->resourceClass)->toBe(NestedAuthorResource::class)
+        ->and($target?->isCollection)->toBeTrue()
+        ->and($target?->paginated)->toBeFalse();
+});
+
+it('refuses a collect() call on the base JsonResource class with a note', function (): void {
+    $logger = recordingLogger();
+    $target = readerFor($logger)->read(readerMethod('baseClassCollect'));
+
+    expect($target)->toBeNull()
+        ->and(array_filter(
+            $logger->records,
+            static fn(array $record): bool => str_contains($record['message'], 'baseClassCollect'),
+        ))->toHaveCount(1);
+});
+
+it('refuses a collect() call on an abstract resource subclass with a note', function (): void {
+    $logger = recordingLogger();
+    $target = readerFor($logger)->read(readerMethod('abstractClassCollect'));
+
+    expect($target)->toBeNull()
+        ->and(array_filter(
+            $logger->records,
+            static fn(array $record): bool => str_contains($record['message'], 'abstractClassCollect'),
+        ))->toHaveCount(1);
 });
 
 it('refuses a collection call on the base JsonResource class with a note', function (): void {


### PR DESCRIPTION
## Implementation plan

### Tier

**Tier 1** — a bounded whitelist addition to the existing return-expression matcher in
`ReturnExpressionResourceReader`. No new body parsing, no variable tracking beyond what the reader
already does: `X::collect(...)` is matched by call shape exactly like `X::collection(...)`. This is
the lowest tier that captures the idiom; it carries the same risk profile as the `::collection()`
shape the reader already matches.

### Root cause / approach

`X::collect(...)` is Laravel's static resource-collection factory (added in Laravel 11.36+); it
produces an `AnonymousResourceCollection` of `X` exactly as `X::collection(...)` does — the only
difference is that `collect()` also wraps a raw value in a `Collection` first. For our purposes the
two are identical: read the static-call class, treat the result as a collection of that resource,
and derive pagination from the argument the same way.

The reader is purely AST-based (it matches the *call name* on a class that is a concrete
`JsonResource` subclass; it never reflects on whether the method exists at runtime), so the match
works regardless of the vendored framework version. Note for the coder: this repo's vendored
Laravel (13.15.0) does **not** define `JsonResource::collect()`, so the fixture actions must remain
**parse-only / never invoked** — which is already the established convention in both touched test
files (`ReturnExpressionController` and `ReaderFixtureController` carry that note).

### Files to modify

1. **`src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php`**
   - `targetFromStaticCall()`: add `'collect'` to the whitelisted static method names
     (`in_array($methodName, ['collection', 'make'], true)` → add `'collect'`), and treat
     `collect` identically to `collection` for the collection/pagination branch (the existing
     `if ($methodName === 'collection')` branch becomes
     `if (in_array($methodName, ['collection', 'collect'], true))`).
   - `paginatedFromBody()`: the `->collection()` static-call probe that derives pagination from the
     argument must also accept `collect` (the `$expression->name->toLowerString() === 'collection'`
     check becomes an `in_array(..., ['collection', 'collect'], true)`), so a
     `@return Collection<X>` docblock + `X::collect($q->paginate())` body still yields the paginated
     envelope.
   - Update the class docblock's recognised-shapes list and the `targetFromExpression()` refusal
     note string to mention `X::collect(...)` alongside `X::collection(...)`.

### Tests (TDD — failing first)

**Feature** — `tests/Feature/Plugins/ApiResources/ReturnExpressionResolutionTest.php`
(add to `ReturnExpressionController` + new `it()` cases; parse-only fixtures):
- `collectCollection()` returning `NestedAuthorResource::collect(Author::query()->paginate())`
  → asserts the **same** paginated `{data, links, meta}` collection schema as the existing
  `::collection()` paginated case, with `data.items.$ref` → `NestedAuthorResource` and the resolved
  resource's fields inferred (parity with the `paginatedCollection` assertion).
- `collectUnpaginated()` returning `NestedAuthorResource::collect(Author::all())` → plain `{data}`
  envelope, no `links`/`meta` (parity with `unpaginatedCollection`), proving pagination evidence
  flows through `collect` too.

**Unit** — `tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php`:
- `collect()` on a concrete resource resolves to `ResourceTarget(isCollection: true)` with the right
  class, mirroring the existing `collection` resolution assertions.
- Pagination evidence: `X::collect($q->paginate())` → `paginated: true`; `X::collect(all())` →
  `paginated: false`.

**Negative / degrade paths (must stay green):**
- `JsonResource::collect(...)` (base class) still refuses with a note and keeps
  `resource.response-ambiguous` alive — add the case mirroring the existing
  `baseClassCollection` / "refuses a collection call on the base JsonResource class" tests so the
  whitelist widening doesn't accidentally accept the base class.
- An abstract-subclass `::collect()` still refuses (mirror the existing abstract-resource refusal).

### Observable behaviour change → docs + CHANGELOG

- **Docs:** add `X::collect(...)` to the recognised return-expression shapes list wherever
  `::collection()`/`::make()`/`toResourceCollection()` are enumerated for the ApiResources plugin
  (`docs/plugins.md`; coder to confirm the exact subsection during implementation — `docs/README.md`
  is the page index).
- **CHANGELOG.md `[Unreleased]`:** `Added` — "ApiResources: the return-expression reader now
  recognises the `X::collect(...)` static resource-collection factory, emitting the same collection
  response schema as `X::collection(...)`." (Closes #390.)

### Controversy assessment

**Non-controversial.** No `src/Contracts/**` change, no stage-order change, no config key, no
public-signature change. It widens a private whitelist inside an `@internal` Core-adjacent reader by
one method name. `area:plugins` + `area:responses`, generation-affecting → **survey gate applies**
(Layer A regression check across the corpus). Lychee is the expected beneficiary (~20 routes per
the #360 re-measure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)