### PR TITLE
fix(responses): resolve API-Resource schema for untyped controller returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project are documented here.
 - `#[AllowedFilter(nullable: true)]` widens the generated `filter[…]` schema to a nullable type array.
 - `--path` / `--diff` no longer leak findings for out-of-scope routes (#50).
 - `ValidationRulesToSchema` maps additional rules (`multiple_of`, Email/Exists/Unique/NotIn objects, wildcard keys) it previously dropped (#83).
+- ApiResources: actions that return an API Resource without declaring a return type (relying on convention or a third-party doc attribute) now resolve their response schema via the return-expression reader, instead of emitting no content; the refusal notice is suppressed on the untyped path to avoid a notice per non-resource action. (#391)
 
 ### Documentation
 - README refreshed for the current feature set (Tier-1 method-body inference, SwaggerPhp plugin) and trimmed to a gentle overview that defers detail to `docs/`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -144,9 +144,10 @@ degrades to a permissive `items: { type: object }`.
 
 Many actions type their return as a **base** resource class — `JsonResource`, a
 bare `ResourceCollection`, or `AnonymousResourceCollection` — and name the
-concrete resource only in the method body. When the signature yields nothing
-concrete, the generator reads the method's **return expression** (a bounded scan
-of the first 10 statements; no dataflow):
+concrete resource only in the method body. Others declare **no return type at
+all** (relying on convention or a third-party doc attribute). In both cases the
+signature yields nothing concrete, so the generator reads the method's **return
+expression** (a bounded scan of the first 10 statements; no dataflow):
 
 ```php
 public function index(): AnonymousResourceCollection
@@ -192,7 +193,9 @@ since attributes carry no body context.
 Anything else — a conditional return, a variable of unknown origin, an
 unrecognised chained call, a receiver that would need dataflow — degrades to the
 previous behaviour with a generation-log note; `#[ResponseResource]` is the
-escape hatch and always wins.
+escape hatch and always wins. On the **untyped** path that note is suppressed:
+the scan runs on every untyped action and most are not resources, so a notice
+per non-resource would be pure noise. The base-resource paths keep their notes.
 
 ### Collection endpoints
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,11 +99,15 @@ parameters:
                 - tests/Fixtures/Lint/
         # The ReturnTypeNudgeController fixture intentionally omits return types — the missing
         # return type is exactly what the `operation.return-type-missing` lint rule detects, so
-        # adding types would defeat the fixture.
+        # adding types would defeat the fixture. The untyped-return resolution fixtures reproduce
+        # the AureusERP/Koel pattern (resource returned from an untyped action), where the missing
+        # return type is the input under test.
         -
             identifier: missingType.return
             paths:
                 - tests/Fixtures/Lint/ReturnTypeNudgeController.php
+                - tests/Feature/Plugins/ApiResources/UntypedReturnResolutionTest.php
+                - tests/Unit/Plugins/ApiResources/ResourceClassLocatorTest.php
         # Attribute-misuse fixtures intentionally trip the bundled PHPStan rules so the linter
         # / generator tests have something to consume. The static rules report the misuse for
         # everyone else; here the misuse is the test input. Identifiers use camelCase because

--- a/src/Plugins/ApiResources/Support/ResourceClassLocator.php
+++ b/src/Plugins/ApiResources/Support/ResourceClassLocator.php
@@ -29,9 +29,10 @@ use function is_string;
  * {@see ResourceResponseResolver} and the ApiResources lint rules so resolution is defined once.
  *
  * Resolution order: `#[ResponseResource]`, then concrete return type (or `#[Collects]` /
- * `$collects`). Only when the signature names a base resource type does
- * {@see ReturnExpressionResourceReader} inspect the return expression; refusal leaves the
- * endpoint ambiguous.
+ * `$collects`). When the signature names a base resource type, or declares no resource return type
+ * at all (absent/builtin), {@see ReturnExpressionResourceReader} inspects the return expression;
+ * refusal leaves the endpoint ambiguous. On the untyped path the refusal notice is suppressed,
+ * since the reader then runs on every action and most are not resources.
  */
 final readonly class ResourceClassLocator implements ResourceTargetLocator
 {
@@ -73,7 +74,10 @@ final readonly class ResourceClassLocator implements ResourceTargetLocator
         }
 
         if (!$returnType instanceof ReflectionNamedType || $returnType->isBuiltin()) {
-            return null;
+            // Untyped actions (no resource return type) still commonly return a resource by
+            // convention. Consult the body scan; a non-resource shape reads back as null and
+            // keeps today's no-content behaviour, silently to avoid a notice per non-resource.
+            return $this->locateFromReturnExpression($descriptor, silent: true);
         }
 
         $name = $returnType->getName();
@@ -194,12 +198,14 @@ final readonly class ResourceClassLocator implements ResourceTargetLocator
     /**
      * @throws ReflectionException
      */
-    private function locateFromReturnExpression(ActionDescriptor $descriptor): ?ResourceTarget
-    {
+    private function locateFromReturnExpression(
+        ActionDescriptor $descriptor,
+        bool $silent = false,
+    ): ?ResourceTarget {
         if ($descriptor->method === null) {
             return null;
         }
 
-        return $this->returnExpressionReader->read($descriptor->method);
+        return $this->returnExpressionReader->read($descriptor->method, silent: $silent);
     }
 }

--- a/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
+++ b/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
@@ -117,9 +117,12 @@ final class ReturnExpressionResourceReader
     }
 
     /**
+     * @param bool $silent Suppress the refusal notice (untyped path: the scan runs on every action,
+     *                     most of which are not resources). Never affects the resolved target.
+     *
      * @throws ReflectionException
      */
-    public function read(ReflectionMethod $method): ?ResourceTarget
+    public function read(ReflectionMethod $method, bool $silent = false): ?ResourceTarget
     {
         $key = $method->getDeclaringClass()->getName() . '::' . $method->getName();
 
@@ -127,13 +130,13 @@ final class ReturnExpressionResourceReader
             return $this->cache[$key];
         }
 
-        return $this->cache[$key] = $this->resolve($method);
+        return $this->cache[$key] = $this->resolve($method, $silent);
     }
 
     /**
      * @throws ReflectionException
      */
-    private function resolve(ReflectionMethod $method): ?ResourceTarget
+    private function resolve(ReflectionMethod $method, bool $silent): ?ResourceTarget
     {
         $documented = $this->targetFromReturnTag($method);
 
@@ -142,21 +145,21 @@ final class ReturnExpressionResourceReader
         }
 
         $statements = $this->scanner->firstStatements($method, self::STATEMENT_LIMIT);
-        $returnExpression = $this->canonicalReturnExpression($statements, $method);
+        $returnExpression = $this->canonicalReturnExpression($statements, $method, log: !$silent);
 
         if ($returnExpression === null) {
             return null;
         }
 
         $expression = $returnExpression instanceof Variable
-            ? $this->expressionAssignedTo($returnExpression, $statements, $method)
+            ? $this->expressionAssignedTo($returnExpression, $statements, $method, log: !$silent)
             : $returnExpression;
 
         if ($expression === null) {
             return null;
         }
 
-        return $this->targetFromExpression($expression, $method);
+        return $this->targetFromExpression($expression, $method, $silent);
     }
 
     // region Return-expression location
@@ -315,8 +318,12 @@ final class ReturnExpressionResourceReader
         return $topLevelReturn->expr;
     }
 
-    private function note(ReflectionMethod $method, string $reason): void
+    private function note(ReflectionMethod $method, string $reason, bool $silent = false): void
     {
+        if ($silent) {
+            return;
+        }
+
         $this->logger->notice(
             sprintf(
                 'The return expression of %s::%s %s; the concrete resource stays unresolved.'
@@ -473,16 +480,17 @@ final class ReturnExpressionResourceReader
     private function targetFromExpression(
         Expr $expression,
         ReflectionMethod $method,
+        bool $silent,
     ): ?ResourceTarget {
         $current = $expression;
 
         while (true) {
             if ($current instanceof StaticCall) {
-                return $this->targetFromStaticCall($current, $method);
+                return $this->targetFromStaticCall($current, $method, $silent);
             }
 
             if ($current instanceof NewExpression) {
-                return $this->targetFromNewExpression($current, $method);
+                return $this->targetFromNewExpression($current, $method, $silent);
             }
 
             if ($current instanceof MethodCall && $current->name instanceof Identifier) {
@@ -503,6 +511,7 @@ final class ReturnExpressionResourceReader
                         $current,
                         $methodName,
                         $method,
+                        $silent,
                     );
                 }
 
@@ -512,6 +521,7 @@ final class ReturnExpressionResourceReader
                         'is chained into ->%s(), which the scan does not recognise',
                         $current->name->toString(),
                     ),
+                    $silent,
                 );
 
                 return null;
@@ -522,6 +532,7 @@ final class ReturnExpressionResourceReader
                 'does not match a recognised resource-returning shape '
                 . '(X::collection(...), X::collect(...), X::make(...), new X(...), '
                 . '$model->toResource())',
+                $silent,
             );
 
             return null;
@@ -538,6 +549,7 @@ final class ReturnExpressionResourceReader
     private function targetFromStaticCall(
         StaticCall $call,
         ReflectionMethod $method,
+        bool $silent,
     ): ?ResourceTarget {
         $resourceClass = $call->class instanceof Name
             ? $this->concreteResourceClass($call->class->toString())
@@ -551,6 +563,7 @@ final class ReturnExpressionResourceReader
             $this->note(
                 $method,
                 'is a static call that does not name a concrete JsonResource subclass',
+                $silent,
             );
 
             return null;
@@ -576,9 +589,10 @@ final class ReturnExpressionResourceReader
     private function targetFromNewExpression(
         NewExpression $new,
         ReflectionMethod $method,
+        bool $silent,
     ): ?ResourceTarget {
         if (!$new->class instanceof Name) {
-            $this->note($method, 'instantiates a dynamically-resolved class');
+            $this->note($method, 'instantiates a dynamically-resolved class', $silent);
 
             return null;
         }
@@ -595,6 +609,7 @@ final class ReturnExpressionResourceReader
                 $this->note(
                     $method,
                     'wraps a value of unknown model type in the base JsonResource',
+                    $silent,
                 );
 
                 return null;
@@ -613,6 +628,7 @@ final class ReturnExpressionResourceReader
             $this->note(
                 $method,
                 'instantiates a class that is not a concrete JsonResource subclass',
+                $silent,
             );
 
             return null;
@@ -662,6 +678,7 @@ final class ReturnExpressionResourceReader
         MethodCall $call,
         string $methodName,
         ReflectionMethod $method,
+        bool $silent,
     ): ?ResourceTarget {
         $arguments = $call->getArgs();
 
@@ -675,6 +692,7 @@ final class ReturnExpressionResourceReader
                         'passes a non-literal or non-resource class to ->%s()',
                         $call->name instanceof Identifier ? $call->name->toString() : $methodName,
                     ),
+                    $silent,
                 );
 
                 return null;
@@ -692,7 +710,11 @@ final class ReturnExpressionResourceReader
         }
 
         if ($methodName === 'toresourcecollection') {
-            $this->note($method, 'calls ->toResourceCollection() without naming the resource class');
+            $this->note(
+                $method,
+                'calls ->toResourceCollection() without naming the resource class',
+                $silent,
+            );
 
             return null;
         }
@@ -702,7 +724,11 @@ final class ReturnExpressionResourceReader
             : null;
 
         if ($modelClass === null) {
-            $this->note($method, 'calls ->toResource() on a receiver whose model type is not statically knowable');
+            $this->note(
+                $method,
+                'calls ->toResource() on a receiver whose model type is not statically knowable',
+                $silent,
+            );
 
             return null;
         }
@@ -716,6 +742,7 @@ final class ReturnExpressionResourceReader
                     'calls ->toResource() on %s, but no conventional resource class could be resolved for it',
                     $modelClass,
                 ),
+                $silent,
             );
 
             return null;

--- a/tests/Feature/Plugins/ApiResources/UntypedReturnResolutionTest.php
+++ b/tests/Feature/Plugins/ApiResources/UntypedReturnResolutionTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Feature\Plugins\ApiResources;
+
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Route;
+use Psr\Log\LoggerInterface;
+use Radiergummi\OpenApi\Plugins\ApiResources\Lint\Rules\ResourceResponseAmbiguous;
+use Radiergummi\OpenApi\Plugins\ApiResources\Support\ResourceClassLocator;
+use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
+use Radiergummi\OpenApi\Tests\Fixtures\Resources\UntypedReturnResource;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
+use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
+
+use function array_any;
+use function iterator_to_array;
+use function random_int;
+use function str_contains;
+
+uses()->group('openapi', 'plugin:api-resources');
+
+/**
+ * Reproduces the AureusERP/Koel pattern: actions return an API Resource but declare no return type
+ * (relying on convention or a third-party doc attribute the library does not read). The concrete
+ * resource is only recoverable from the method body. Actions are never invoked, only parsed.
+ */
+class UntypedReturnController extends Controller
+{
+    public function index()
+    {
+        return UntypedReturnResource::collection(Author::query()->paginate());
+    }
+
+    public function indexUnpaginated()
+    {
+        return UntypedReturnResource::collection(Author::all());
+    }
+
+    public function show()
+    {
+        return new UntypedReturnResource(Author::query()->firstOrFail());
+    }
+
+    public function make()
+    {
+        return UntypedReturnResource::make(Author::query()->firstOrFail());
+    }
+
+    public function destroy()
+    {
+        return response()->json(['ok' => true]);
+    }
+
+    public function untypedConditional(bool $flag)
+    {
+        if ($flag) {
+            return UntypedReturnResource::make(Author::query()->firstOrFail());
+        }
+
+        return new UntypedReturnResource(Author::query()->firstOrFail());
+    }
+
+    public function untypedScalar()
+    {
+        return random_int(0, 1);
+    }
+}
+
+/**
+ * @param array<string, mixed> $spec
+ *
+ * @return array<string, mixed>
+ */
+function untypedSuccessSchema(array $spec, string $path): array
+{
+    $schema = $spec['paths'][$path]['get']['responses']['200']['content']['application/json']['schema'] ?? null;
+
+    expect($schema)->not->toBeNull();
+
+    return $schema;
+}
+
+// region Resolved shapes
+
+it('resolves a paginated collection from an untyped index() action', function (): void {
+    Route::get('/untyped-authors', [UntypedReturnController::class, 'index']);
+
+    $spec = generateSpec();
+    $schema = untypedSuccessSchema($spec, '/untyped-authors');
+
+    expect($schema['properties'])->toHaveKeys(['data', 'links', 'meta'])
+        ->and($schema['properties']['data']['type'])->toBe('array')
+        ->and($schema['properties']['data']['items']['$ref'])->toBe('#/components/schemas/UntypedReturnResource')
+        ->and($spec['components']['schemas']['UntypedReturnResource']['properties'])->toHaveKeys(['id', 'title']);
+});
+
+it('resolves a plain {data} envelope from an untyped unpaginated collection', function (): void {
+    Route::get('/untyped-authors-unpaginated', [UntypedReturnController::class, 'indexUnpaginated']);
+
+    $schema = untypedSuccessSchema(generateSpec(), '/untyped-authors-unpaginated');
+
+    expect($schema['properties'])->toHaveKey('data')
+        ->and($schema['properties'])->not->toHaveKeys(['links', 'meta'])
+        ->and($schema['properties']['data']['items']['$ref'])->toBe('#/components/schemas/UntypedReturnResource');
+});
+
+it('resolves a single resource from an untyped show() returning new X()', function (): void {
+    Route::get('/untyped-author', [UntypedReturnController::class, 'show']);
+
+    $schema = untypedSuccessSchema(generateSpec(), '/untyped-author');
+
+    expect($schema['properties']['data']['$ref'])->toBe('#/components/schemas/UntypedReturnResource');
+});
+
+it('resolves a single resource from an untyped X::make() action', function (): void {
+    Route::get('/untyped-author-make', [UntypedReturnController::class, 'make']);
+
+    $schema = untypedSuccessSchema(generateSpec(), '/untyped-author-make');
+
+    expect($schema['properties']['data']['$ref'])->toBe('#/components/schemas/UntypedReturnResource');
+});
+
+// endregion
+
+// region Negatives & silent degradation
+
+it('does not resolve a resource for an untyped response()->json() action and emits no refusal notice', function (): void {
+    Route::get('/untyped-destroy', [UntypedReturnController::class, 'destroy']);
+
+    $logger = recordingLogger();
+    app()->instance(LoggerInterface::class, $logger);
+
+    $spec = generateSpec();
+    $schema = untypedSuccessSchema($spec, '/untyped-destroy');
+
+    // Core's inline response()->json() reader still types the literal body; the ApiResources
+    // locator must not turn the untyped action into a resource schema.
+    expect($schema['properties'] ?? [])->toHaveKey('ok')
+        ->and($schema)->not->toHaveKey('$ref')
+        ->and($spec['components']['schemas'] ?? [])->not->toHaveKey('UntypedReturnResource');
+
+    // Silent fallback on the untyped path: the high-volume non-resource case must not log.
+    $noted = array_any(
+        $logger->records,
+        static fn(array $record): bool => str_contains($record['message'], 'destroy'),
+    );
+
+    expect($noted)->toBeFalse();
+});
+
+it('leaves an untyped conditional-return action as no content without a refusal notice', function (): void {
+    Route::get('/untyped-conditional', [UntypedReturnController::class, 'untypedConditional']);
+
+    $logger = recordingLogger();
+    app()->instance(LoggerInterface::class, $logger);
+
+    $spec = generateSpec();
+    $response = $spec['paths']['/untyped-conditional']['get']['responses']['200'] ?? null;
+
+    expect($response)->not->toBeNull()
+        ->and($response['content'] ?? [])->not->toHaveKey('application/json');
+
+    $noted = array_any(
+        $logger->records,
+        static fn(array $record): bool => str_contains($record['message'], 'untypedConditional'),
+    );
+
+    expect($noted)->toBeFalse();
+});
+
+it('leaves an untyped scalar-return action as no content without a refusal notice', function (): void {
+    Route::get('/untyped-scalar', [UntypedReturnController::class, 'untypedScalar']);
+
+    $logger = recordingLogger();
+    app()->instance(LoggerInterface::class, $logger);
+
+    $spec = generateSpec();
+    $response = $spec['paths']['/untyped-scalar']['get']['responses']['200'] ?? null;
+
+    expect($response)->not->toBeNull()
+        ->and($response['content'] ?? [])->not->toHaveKey('application/json');
+
+    $noted = array_any(
+        $logger->records,
+        static fn(array $record): bool => str_contains($record['message'], 'untypedScalar'),
+    );
+
+    expect($noted)->toBeFalse();
+});
+
+// endregion
+
+// region Lint-rule delta
+
+it('does not flag resource.response-ambiguous for an untyped non-resource action', function (): void {
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        UntypedReturnController::class,
+        'destroy',
+        '/untyped-destroy',
+    );
+
+    $rule = new ResourceResponseAmbiguous(ResourceClassLocator::create());
+    $findings = iterator_to_array($rule->checkOperation(
+        OperationNodeFactory::forDescriptor($descriptor),
+        OperationNodeFactory::emptyContext(),
+    ));
+
+    expect($findings)->toBe([]);
+});
+
+it('does not flag resource.response-ambiguous for an untyped body-resolved collection', function (): void {
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        UntypedReturnController::class,
+        'index',
+        '/untyped-authors',
+    );
+
+    $rule = new ResourceResponseAmbiguous(ResourceClassLocator::create());
+    $findings = iterator_to_array($rule->checkOperation(
+        OperationNodeFactory::forDescriptor($descriptor),
+        OperationNodeFactory::emptyContext(),
+    ));
+
+    expect($findings)->toBe([]);
+});
+
+// endregion

--- a/tests/Fixtures/Resources/UntypedReturnResource.php
+++ b/tests/Fixtures/Resources/UntypedReturnResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Minimised reproduction of the AureusERP/Koel pattern: a resource returned from a controller
+ * action that declares no return type. Pure-literal toArray() so the shape is fully inferable.
+ */
+class UntypedReturnResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => 1,
+            'title' => 'untyped',
+        ];
+    }
+}

--- a/tests/Unit/Plugins/ApiResources/ResourceClassLocatorTest.php
+++ b/tests/Unit/Plugins/ApiResources/ResourceClassLocatorTest.php
@@ -74,6 +74,16 @@ class LocatorFixtureController
     {
         throw new LogicException('Signature-only fixture; never invoked.');
     }
+
+    public function untypedResource()
+    {
+        return LocatorFixtureResource::make(new stdClass());
+    }
+
+    public function untypedNonResource()
+    {
+        return response()->json(['ok' => true]);
+    }
 }
 
 function locatorDescriptor(string $method): ActionDescriptor
@@ -145,4 +155,16 @@ it('still reports ambiguous when neither #[Collects] nor $collects is present', 
         ->toBeNull()
         ->and($target?->resourceClass)->toBeNull()
         ->and($target?->isCollection)->toBeTrue();
+});
+
+it('resolves the resource from the body of an untyped action', function (): void {
+    $target = ResourceClassLocator::create()->locate(locatorDescriptor('untypedResource'));
+
+    expect($target?->resourceClass)
+        ->toBe(LocatorFixtureResource::class)
+        ->and($target?->isCollection)->toBeFalse();
+});
+
+it('returns null for an untyped action that does not return a resource', function (): void {
+    expect(ResourceClassLocator::create()->locate(locatorDescriptor('untypedNonResource')))->toBeNull();
 });


### PR DESCRIPTION
## Root-cause investigation (read this first — the symptom has changed)

**The `{}` symptom is NOT reproducible on current `main`.** I freshly regenerated all 11 corpus
specs against the live `$LIB` symlink (HEAD `3791a751`, php@8.4) and scanned every 2xx
`application/json` schema:

| app | empty `{}` 2xx | substantive json 2xx | bare-200 (no json) 2xx |
|-----|----:|----:|----:|
| AureusERP | **0** | 14 | 146 |
| Koel | **0** | 17 | 277 |
| Vito | 0 | 151 | unchanged |
| Lychee | 0 | 87 | unchanged |
| *(all 11 apps)* | **0** | — | — |

Zero empty-object 2xx schemas anywhere in the corpus. The #360 re-measure snapshot that reported 99
`{}` routes predates intervening response-fidelity work; on today's code those same AureusERP/Koel
routes emit **no content at all** (bare 200), not `{}`. So the issue's stated hypothesis — *"the
resource resolves but the property shape is dropped"* — is **wrong against current `main`**: the
resource never resolves, so synthesis (`ResourceToArrayReader`) is never reached. **The fix is not
in schema synthesis.**

### Why these routes under-emit (the real, current root cause)

AureusERP and Koel API controllers **do not type their return values** and lean on Scribe's
`#[ResponseFromApiResource]` attribute (which this library does not read):

- AureusERP: **0 of 277** API controller methods declare a return type. e.g. `TitleController::show()`
  → `return new TitleResource($title);` (no `: JsonResource`), `index()` →
  `return TitleResource::collection($titles);` (no return type).
- Koel `AlbumController`: `index()` → `AlbumResource::collection(...)`, `show()` →
  `AlbumResource::make(...)`, `update()` → `AlbumResource::make(...)` — **all untyped**.
- Vito/Lychee, by contrast, **type their returns** (`index(): Response`, `json(): ResourceCollection`),
  which is exactly why their resource schemas emit.

`ResourceClassLocator::locate()` (`src/Plugins/ApiResources/Support/ResourceClassLocator.php:75`)
bails out — `return null` — whenever the method has no non-builtin return type **and** no
`#[ResponseResource]`. The body-scan reader (`ReturnExpressionResourceReader`, which already resolves
`new X(...)`, `X::make(...)`, `X::collection(...)`) is **only** consulted on the two typed paths
(line 99 for collection return types, line 105 for a bare `JsonResource` return type). So untyped
methods returning a resource never reach the scan. This gate was introduced deliberately by #108
(PR #253); broadening it is the fix.

### Tier

**Tier 1.** The reader is already a bounded body scan; this change only *widens when it runs* to
include untyped methods. No new parsing capability, no variable tracking beyond what exists. The
reader's existing graceful refusal (returns null + one NOTICE per action) means untyped methods that
return non-resources — `destroy()` → `response()->json([...])`, redirects, etc. — are rejected by
shape, so broadening cannot mis-resolve them into bogus schemas. **Not Tier 2** — no dataflow needed;
the return expression is read directly.

## Proposed fix

In `ResourceClassLocator::locate()`, when there is no `#[ResponseResource]` and the return type is
absent/builtin (the current line-75 bail), **first attempt the return-expression reader** before
returning null:

```php
if (!$returnType instanceof ReflectionNamedType || $returnType->isBuiltin()) {
    return $this->locateFromReturnExpression($descriptor);   // null when the body isn't a resource shape
}
```

`locateFromReturnExpression()` already exists and already returns null when `$descriptor->method` is
null or the body doesn't match a whitelisted shape, so non-resource untyped methods stay
no-content exactly as today. The `isCollection`/`paginated` flags come from the reader's
`ResourceTarget` (it derives pagination from a `paginate()`-family argument), so Koel's
`AlbumResource::collection($repo->getForListing(...))` lands as an unpaginated collection and
AureusERP's `TitleResource::collection($qb->paginate())` as a paginated one — matching how the typed
path already behaves.

### Files to modify

1. **`src/Plugins/ApiResources/Support/ResourceClassLocator.php`** — replace the line-75 unconditional
   bail with `return $this->locateFromReturnExpression($descriptor, silent: true);` (new branch,
   parallel to and after the `#[ResponseResource]` branch at L64-73, so attribute precedence is
   preserved and the typed base-Resource branches at L85-110 are untouched). Add the `bool $silent`
   parameter to `locateFromReturnExpression()`. Update the class docblock's resolution-order
   sentence to say the body scan also runs for **untyped** actions.
2. **`src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php`** — thread `bool $silent`
   from `read()` → `resolve()` → all `note()` call sites (and the existing `$log` flags) so the
   untyped-path fall-through can suppress the refusal NOTICE without affecting the typed call sites.
   See "Noise consideration" below for why the planned one-line `log: false` mirror is insufficient.

### Noise consideration — silencing mechanism (plan-review correction)

Broadening means the reader now runs on **every untyped controller action**, logging one NOTICE per
action it can't resolve (memoised once per run). On Koel/AureusERP that is hundreds of non-resource
methods (`destroy` → `response()->json([...])`, redirects, scalar returns). Decision (maintainer):
**silent fallback on the untyped path only** — keep notices on the typed base-Resource paths (#108's
diagnostic value), suppress them when the fall-through is from an absent/builtin return type.

**Plan-review correction — the "mirror `paginatedFromBody` `log: false`" framing is wrong and the
coder must not follow it as written.** Verified against `ReturnExpressionResourceReader`: the `log`
flag exists **only** on `canonicalReturnExpression()` and `expressionAssignedTo()`. The refusal
notices that fire for the high-volume untyped non-resource case live in `targetFromExpression()`
(L509 "is chained into ->json()…", L520 "does not match a recognised resource-returning shape"),
`targetFromStaticCall()`, `targetFromNewExpression()`, and `targetFromTransformCall()` — **none of
which take a `log` flag**. So threading `log: false` through the two methods that have it would
**still** flood NOTICEs for `destroy()`/scalars/redirects, and the planned negative test
(`destroy()` "must not emit a refusal notice") would be **unsatisfiable**.

Correct mechanism: thread a `bool $silent` (defaulting false) from a new
`ResourceClassLocator::locateFromReturnExpression($descriptor, silent: true)` on the **untyped
branch only** → `ReturnExpressionResourceReader::read($method, silent: true)` → `resolve()` → into
`note()` (and the existing `$log` flags). When `$silent`, `note()` either no-ops or drops to
`debug`. The typed-path call sites (L99, L105) pass `silent: false`, so #108's notices are
unchanged. This is a few more touched lines than the plan implies; keep the threaded flag minimal
and defaulted so the typed paths and lint-rule call sites are untouched by default.

### Lint-rule impact (plan-review addition)

`ResourceClassLocator` is shared by `ResourceResponseResolver` **and four lint rules**
(`ResourceResponseAmbiguous`, `ResourceResponseEmpty`, `ResourceFieldTypeMissing`,
`ResourceFieldsUndeclared`). Broadening `locate()` changes what these rules see for untyped actions:
an untyped action that now resolves to `ResourceTarget(resourceClass: null, modelClass: …)` (the
`new JsonResource($model)` wrapped-model shape) or to a concrete target will newly trigger / change
`resource.*` findings where it previously produced none. The coder must confirm the **lint** corpus
delta (run `openapi:lint` on the fixtures and ideally a corpus app), not just the spec delta, and
add a unit assertion that an untyped non-resource action still yields `null` (no spurious
`resource.response-ambiguous`). Note: the `silent` flag is for the **NOTICE log only** and must not
change `locate()`'s return value, so lint behaviour is driven purely by resolution, not by silencing.

## Tests (TDD — failing first)

**Feature** — new `tests/Feature/Plugins/ApiResources/UntypedReturnResolutionTest.php` (parse-only
fixture controller, mirroring `ReturnExpressionController` but with **no return types**):
- `index()` → `return FooResource::collection($q->paginate());` (no return type) → paginated
  `{data,links,meta}` collection schema with `data.items.$ref` → `FooResource`, fields inferred.
- `indexUnpaginated()` → `FooResource::collection($models)` (no paginate, no return type) → plain
  `{data}` envelope.
- `show()` → `return new FooResource($model);` (no return type) → single `{data}` schema with
  resolved fields.
- `make()` → `FooResource::make($model)` (no return type) → single resource schema.
- **Negative / degrade:** `destroy()` → `return response()->json(['ok' => true]);` (no return type)
  → must stay **no content / no spurious resource schema** and must **not** emit a refusal notice
  (asserts the silent-fallback decision); `untypedConditional()` with two differing returns → refuses
  cleanly; `untypedScalar()` → `return 1;` → no resource.

**Unit** — extend `tests/Unit/Plugins/ApiResources/ResourceClassLocatorTest.php`:
- An untyped action returning a recognised resource shape resolves to the right `ResourceTarget`.
- An untyped action returning a non-resource yields `null` (no resolution).
- `#[ResponseResource]` and the typed paths are unchanged (existing cases stay green).

### Minimised regression fixture

A new resource `tests/Fixtures/Resources/UntypedReturnResource.php` (clean literal `toArray()` with
a couple of `$this->resource->field` / literal fields) plus the parse-only controller above. This
reproduces the AureusERP/Koel pattern (untyped method → resource body) in one file.

## Acceptance criteria mapping

- Root cause identified ✔ (locator gate, not synthesis) and minimised regression fixture ✔.
- Restores emission for untyped-return resource actions; Vito/Lychee already emit and are untouched
  by this path (they hit the typed branches) → **survey gate must confirm AureusERP/Koel json-2xx up,
  Vito/Lychee unchanged**.
- CHANGELOG `[Unreleased]` → `Fixed`: "ApiResources: actions that return an API Resource without
  declaring a return type (relying on convention or third-party doc attributes) now resolve their
  response schema via the return-expression reader, instead of emitting no content." (Closes #391.)
- Docs: `docs/plugins.md` ApiResources resolution-order note — mention untyped actions are now scanned.

## Controversy / escalation flag — NEEDS MAINTAINER DECISION

Two things make this **not** a clean auto-merge:

1. **The issue's symptom is stale.** It describes a `{}` synthesis bug; the actual current defect is
   no-content from a resolution gate. The fix lives in a different file than the issue points to.
   The maintainer should confirm the re-scope (fix under-emission via the locator) is acceptable, and
   the issue body/title should be updated to match — or the issue closed as "symptom changed" and a
   fresh one filed. **I did not silently plan a different feature; flagging for the lead.**
2. **It broadens when the body scan runs to every untyped action** — a behavioural expansion that
   touches resolution for the whole corpus, with a stderr-noise tradeoff (the silent-vs-notice
   decision above). Generation-affecting, `area:responses`/`area:plugins` → **survey gate applies**,
   and the noise/severity decision is a judgement call worth a human glance.

No `src/Contracts/**` change, no stage-order change, no config key, no public-signature change —
but the scope-divergence (1) is the reason this should pass through plan-review and likely a
maintainer ack before coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
