### PR TITLE
feat(#382): operationId fixers + AddAttribute AST primitive (lint-fix catalog slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project are documented here.
 - `#[ResponseExampleFile('path.json')]` authoring attribute attaches a JSON file's contents as the singular `example` on a response (the auto-derived primary by default, `status:` targets a declared response). Skipped silently for a conventionally bodyless status (204/205/304) or a status with no matching response, and yields to named `#[ResponseExample]`s already on the same media type (`example`/`examples` are mutually exclusive). (#40)
 - `openapi:lint --format=markdown` now renders a real GitHub-Flavored Markdown body (a coverage summary line and a `Severity | Rule | Location | Message` findings table) instead of aliasing the CLI tree dump, so the CI coverage-comment recipe can post it verbatim. (#389)
 - ApiResources: the return-expression reader now recognises the `X::collect(...)` static resource-collection factory, emitting the same collection response schema as `X::collection(...)`. (#390)
+- `openapi:lint --fix` now repairs missing and codegen-unsafe operationIds (synthesizes/sanitizes the `#[Operation(operationId: …)]`), via the new `AddAttribute` fix primitive. (#382)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -144,9 +144,14 @@ run your formatter over them (e.g., `vendor/bin/pint --dirty`) to match your
 project style. A finding is only auto-fixable when its owning rule opts in
 (by implementing `Lint\Fix\FixableRule`); everything else is reported as before.
 
-Currently fixable (all removals of a redundant or no-op attribute):
+Currently fixable. Removals of a redundant or no-op attribute:
 `tag.duplicate`, `queryparam.duplicate`, `response.duplicate-status`,
-`link.duplicate-name`, and `field.no-effect`.
+`link.duplicate-name`, and `field.no-effect`. Additive/modification fixes on
+the `#[Operation]` attribute: `operation.id-missing` (synthesizes
+`#[Operation(operationId: …)]`, or adds the argument when the attribute already
+exists) and `operation.id-invalid-chars` (rewrites the operationId to the
+codegen-safe character set). Both produce exactly the operationId inference
+would have emitted.
 
 ## Documentation-coverage gate
 

--- a/src/Lint/Fix/AddOperationIdFixer.php
+++ b/src/Lint/Fix/AddOperationIdFixer.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+use Override;
+use Radiergummi\OpenApi\Attributes\Operation;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\Ast\AddAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\SetAttributeArgument;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use ReflectionException;
+use ReflectionMethod;
+
+use function is_a;
+use function is_string;
+use function sprintf;
+
+/**
+ * Adds a missing operationId to the source `#[Operation]` attribute.
+ *
+ * The rule stamps the operationId inference would have emitted (via {@see \Radiergummi\OpenApi\Support\Generator\OperationIdDeriver})
+ * onto the finding, so the fix equals exactly what the generator produces. If the action method
+ * already carries `#[Operation]`, the fixer sets its `operationId:` argument; otherwise it
+ * synthesises a new `#[Operation(operationId: …)]`. Degrades to nothing when the source member or
+ * the stamped operationId is unavailable.
+ *
+ * @internal
+ */
+final readonly class AddOperationIdFixer implements Fixer
+{
+    public const string CONTEXT_OPERATION_ID = 'fixOperationId';
+
+    /**
+     * @return iterable<Fix>
+     */
+    #[Override]
+    public function fix(Finding $finding, FixContext $context): iterable
+    {
+        $class = $finding->context[Finding::CONTEXT_SOURCE_CLASS] ?? null;
+        $member = $finding->context[Finding::CONTEXT_SOURCE_MEMBER] ?? null;
+        $operationId = $finding->context[self::CONTEXT_OPERATION_ID] ?? null;
+
+        if (!is_string($class) || !is_string($member) || !is_string($operationId) || $operationId === '') {
+            return [];
+        }
+
+        $target = new TargetSelector($class, TargetKind::Method, $member);
+        $existingIndex = $this->existingOperationAttributeIndex($class, $member);
+
+        $operation = $existingIndex === null
+            ? new AddAttribute($target, Operation::class, ['operationId' => $operationId])
+            : new SetAttributeArgument($target, $existingIndex, 'operationId', $operationId);
+
+        $file = $this->declaringFile($class, $member);
+
+        if ($file === null) {
+            return [];
+        }
+
+        return [new Fix(
+            file: $file,
+            description: sprintf('Set operationId "%s" on %s::%s', $operationId, $class, $member),
+            ruleId: $finding->ruleId,
+            operation: $operation,
+        )];
+    }
+
+    /**
+     * The flat, source-order position of an existing `#[Operation]` attribute on the method, or null
+     * when the method carries none (so the fixer adds one instead of mutating).
+     */
+    private function existingOperationAttributeIndex(string $class, string $member): ?int
+    {
+        try {
+            $reflector = new ReflectionMethod($class, $member);
+        } catch (ReflectionException) {
+            return null;
+        }
+
+        foreach ($reflector->getAttributes() as $index => $attribute) {
+            if (is_a($attribute->getName(), Operation::class, true)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private function declaringFile(string $class, string $member): ?string
+    {
+        try {
+            $file = new ReflectionMethod($class, $member)->getFileName();
+        } catch (ReflectionException) {
+            return null;
+        }
+
+        return $file ?: null;
+    }
+}

--- a/src/Lint/Fix/Ast/AddAttribute.php
+++ b/src/Lint/Fix/Ast/AddAttribute.php
@@ -19,10 +19,10 @@ namespace Radiergummi\OpenApi\Lint\Fix\Ast;
 final readonly class AddAttribute extends AstOperation
 {
     /**
-     * @param class-string                                  $attributeClass The attribute to add, e.g.
-     *                                                                      `Operation::class`.
-     * @param array<string, string|int|float|bool|null>     $arguments      Named arguments in the
-     *                                                                      order they should render.
+     * @param class-string                              $attributeClass The attribute to add, e.g.
+     *                                                                  `Operation::class`.
+     * @param array<string, null|bool|float|int|string> $arguments      Named arguments in the
+     *                                                                  order they should render.
      */
     public function __construct(
         TargetSelector $target,

--- a/src/Lint/Fix/Ast/AddAttribute.php
+++ b/src/Lint/Fix/Ast/AddAttribute.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix\Ast;
+
+/**
+ * Adds a new attribute application to the target member (a class, method, property, or promoted
+ * parameter), synthesised from a fully-qualified attribute class and an ordered map of named scalar
+ * arguments. The new attribute is prepended as its own {@see \PhpParser\Node\AttributeGroup} above
+ * any existing groups, giving a deterministic, byte-stable position.
+ *
+ * If the member already carries the attribute class, the operation is a no-op (nothing is applied):
+ * the *fixer* decides add-vs-modify, the op only inserts. The argument values share
+ * {@see SetAttributeArgument}'s scalar domain; a structured-value variant is a separate concern.
+ *
+ * @internal
+ */
+final readonly class AddAttribute extends AstOperation
+{
+    /**
+     * @param class-string                                  $attributeClass The attribute to add, e.g.
+     *                                                                      `Operation::class`.
+     * @param array<string, string|int|float|bool|null>     $arguments      Named arguments in the
+     *                                                                      order they should render.
+     */
+    public function __construct(
+        TargetSelector $target,
+        public string $attributeClass,
+        public array $arguments = [],
+    ) {
+        parent::__construct($target);
+    }
+}

--- a/src/Lint/Fix/Ast/FixOperationVisitor.php
+++ b/src/Lint/Fix/Ast/FixOperationVisitor.php
@@ -8,7 +8,10 @@ use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PhpParser\Node\PropertyItem;
 use PhpParser\Node\Scalar;
@@ -17,10 +20,15 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeVisitorAbstract;
 
+use function array_any;
+use function array_keys;
+use function array_map;
+use function array_unshift;
 use function array_values;
 use function is_float;
 use function is_int;
 use function krsort;
+use function ltrim;
 use function rsort;
 use function strcasecmp;
 
@@ -65,6 +73,8 @@ final class FixOperationVisitor extends NodeVisitorAbstract
             $this->setDocComment($member, $this->operation);
         } elseif ($this->operation instanceof SetAttributeArgument) {
             $this->setAttributeArgument($member, $this->operation);
+        } elseif ($this->operation instanceof AddAttribute) {
+            $this->addAttribute($member, $this->operation);
         }
 
         return null;
@@ -312,6 +322,62 @@ final class FixOperationVisitor extends NodeVisitorAbstract
         }
 
         return true;
+    }
+
+    private function addAttribute(ClassLike|ClassMethod|Property|Param $member, AddAttribute $operation): void
+    {
+        // The fixer decides add-vs-modify; the op only inserts. Adding a second application of an
+        // attribute the member already carries is never what a fixer wants, so refuse it here, which
+        // also makes the op idempotent against its own output.
+        if ($this->hasAttributeClass($member, $operation->attributeClass)) {
+            return;
+        }
+
+        $arguments = array_map(
+            fn(string|int|float|bool|null $value, string $name): Arg => new Arg(
+                value: $this->literalToNode($value),
+                name: new Identifier($name),
+            ),
+            array_values($operation->arguments),
+            array_keys($operation->arguments),
+        );
+
+        // Emit the fully-qualified attribute name so the rewrite stays correct without editing the
+        // file's `use` block.
+        $group = new AttributeGroup([
+            new Attribute(new FullyQualified(ltrim($operation->attributeClass, '\\')), $arguments),
+        ]);
+
+        array_unshift($member->attrGroups, $group);
+        $this->applied = true;
+    }
+
+    /**
+     * Whether the member already carries an application of the given attribute class, comparing by
+     * the name {@see \PhpParser\NodeVisitor\NameResolver} resolved (it stamps `resolvedName` on
+     * statically-resolvable names) so a short, `use`-imported reference matches its FQCN.
+     */
+    private function hasAttributeClass(ClassLike|ClassMethod|Property|Param $member, string $attributeClass): bool
+    {
+        $target = ltrim($attributeClass, '\\');
+
+        foreach ($member->attrGroups as $group) {
+            $matches = array_any(
+                $group->attrs,
+                static function (Attribute $attribute) use ($target): bool {
+                    $resolved = $attribute->name->getAttribute('resolvedName');
+                    $name = $resolved instanceof Name ? $resolved : $attribute->name;
+
+                    return ltrim($name->toString(), '\\') === $target;
+                },
+            );
+
+            if ($matches) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function literalToNode(string|int|float|bool|null $value): Node\Expr

--- a/src/Lint/Fix/Ast/FixOperationVisitor.php
+++ b/src/Lint/Fix/Ast/FixOperationVisitor.php
@@ -383,9 +383,9 @@ final class FixOperationVisitor extends NodeVisitorAbstract
     private function literalToNode(string|int|float|bool|null $value): Node\Expr
     {
         return match (true) {
-            $value === null  => new Node\Expr\ConstFetch(new Node\Name('null')),
-            $value === true  => new Node\Expr\ConstFetch(new Node\Name('true')),
-            $value === false => new Node\Expr\ConstFetch(new Node\Name('false')),
+            $value === null  => new Node\Expr\ConstFetch(new Name('null')),
+            $value === true  => new Node\Expr\ConstFetch(new Name('true')),
+            $value === false => new Node\Expr\ConstFetch(new Name('false')),
             is_int($value)   => new Scalar\Int_($value),
             is_float($value) => new Scalar\Float_($value),
             default          => new Scalar\String_($value),

--- a/src/Lint/Fix/SanitizeOperationIdFixer.php
+++ b/src/Lint/Fix/SanitizeOperationIdFixer.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+use Override;
+use Radiergummi\OpenApi\Attributes\Operation;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\Ast\SetAttributeArgument;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use ReflectionException;
+use ReflectionMethod;
+
+use function is_a;
+use function is_string;
+use function sprintf;
+
+/**
+ * Rewrites a codegen-unsafe operationId to the sanitised form on the source `#[Operation]` attribute.
+ *
+ * The rule stamps the sanitised operationId (via {@see \Radiergummi\OpenApi\Support\Generator\OperationIdDeriver::sanitise()})
+ * onto the finding. An invalid operationId can only have come from an explicit attribute, so the
+ * fixer always targets the existing `#[Operation]` attribute and sets its `operationId:` argument.
+ * Degrades to nothing when the source member, the stamped value, or the attribute is unavailable.
+ *
+ * @internal
+ */
+final readonly class SanitizeOperationIdFixer implements Fixer
+{
+    public const string CONTEXT_OPERATION_ID = 'fixOperationId';
+
+    /**
+     * @return iterable<Fix>
+     */
+    #[Override]
+    public function fix(Finding $finding, FixContext $context): iterable
+    {
+        $class = $finding->context[Finding::CONTEXT_SOURCE_CLASS] ?? null;
+        $member = $finding->context[Finding::CONTEXT_SOURCE_MEMBER] ?? null;
+        $operationId = $finding->context[self::CONTEXT_OPERATION_ID] ?? null;
+
+        if (!is_string($class) || !is_string($member) || !is_string($operationId) || $operationId === '') {
+            return [];
+        }
+
+        [$file, $index] = $this->locateOperationAttribute($class, $member);
+
+        if ($file === null || $index === null) {
+            return [];
+        }
+
+        return [new Fix(
+            file: $file,
+            description: sprintf('Sanitise operationId to "%s" on %s::%s', $operationId, $class, $member),
+            ruleId: $finding->ruleId,
+            operation: new SetAttributeArgument(
+                target: new TargetSelector($class, TargetKind::Method, $member),
+                attributeIndex: $index,
+                argumentName: 'operationId',
+                value: $operationId,
+            ),
+        )];
+    }
+
+    /**
+     * The declaring file and flat, source-order position of the method's `#[Operation]` attribute.
+     * Returns `[null, null]` when the method cannot be reflected or carries no `#[Operation]`.
+     *
+     * @return array{0: ?string, 1: ?int}
+     */
+    private function locateOperationAttribute(string $class, string $member): array
+    {
+        try {
+            $reflector = new ReflectionMethod($class, $member);
+        } catch (ReflectionException) {
+            return [null, null];
+        }
+
+        $file = $reflector->getFileName() ?: null;
+
+        foreach ($reflector->getAttributes() as $index => $attribute) {
+            if (is_a($attribute->getName(), Operation::class, true)) {
+                return [$file, $index];
+            }
+        }
+
+        return [$file, null];
+    }
+}

--- a/src/Lint/Rules/OperationIdInvalidChars.php
+++ b/src/Lint/Rules/OperationIdInvalidChars.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use Override;
-use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\FixableRule;
+use Radiergummi\OpenApi\Lint\Fix\Fixer;
+use Radiergummi\OpenApi\Lint\Fix\RemoveAttributeFixer;
+use Radiergummi\OpenApi\Lint\Fix\SanitizeOperationIdFixer;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
+use Radiergummi\OpenApi\Support\Generator\OperationIdDeriver;
 
 use function preg_match;
 use function sprintf;
@@ -19,9 +23,14 @@ use function sprintf;
  * Reports operationIds that don't match `/^[A-Za-z][A-Za-z0-9._-]*$/` (not codegen-safe).
  * Operations without an operationId are skipped; see `operation.id-missing`.
  */
-final class OperationIdInvalidChars implements Rule, OperationRuleVisitor
+final class OperationIdInvalidChars implements FixableRule, OperationRuleVisitor
 {
-    private const string PATTERN = '/^[A-Za-z][A-Za-z0-9._-]*$/';
+    /** The codegen-safe identifier shape; {@see OperationIdDeriver::sanitise()} maps to this set. */
+    public const string PATTERN = '/^[A-Za-z][A-Za-z0-9._-]*$/';
+
+    public function __construct(
+        private readonly OperationIdDeriver $operationIdDeriver = new OperationIdDeriver(),
+    ) {}
 
     /**
      * @return iterable<Finding>
@@ -37,6 +46,19 @@ final class OperationIdInvalidChars implements Rule, OperationRuleVisitor
             return;
         }
 
+        // An invalid operationId can only have come from an explicit attribute, so the fixer always
+        // has an #[Operation] to rewrite; stamp the sanitised value and source member for it.
+        $fixContext = [];
+
+        if ($operation->descriptor !== null) {
+            $fixContext = [
+                ...RemoveAttributeFixer::contextForOperation($operation->descriptor),
+                SanitizeOperationIdFixer::CONTEXT_OPERATION_ID => $this->operationIdDeriver->sanitise(
+                    $operation->operationId,
+                ),
+            ];
+        }
+
         yield new Finding(
             ruleId: $this->id(),
             severity: $this->severity(),
@@ -47,7 +69,14 @@ final class OperationIdInvalidChars implements Rule, OperationRuleVisitor
                 $operation->pathUri,
             ),
             fixHint: 'Use only letters, digits, dots, hyphens and underscores in operationId, starting with a letter.',
+            context: $fixContext,
         );
+    }
+
+    #[Override]
+    public function fixer(): Fixer
+    {
+        return new SanitizeOperationIdFixer();
     }
 
     #[Override]

--- a/src/Lint/Rules/OperationIdMissing.php
+++ b/src/Lint/Rules/OperationIdMissing.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Lint\Rules;
 
 use Override;
-use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\AddOperationIdFixer;
+use Radiergummi\OpenApi\Lint\Fix\FixableRule;
+use Radiergummi\OpenApi\Lint\Fix\Fixer;
+use Radiergummi\OpenApi\Lint\Fix\RemoveAttributeFixer;
 use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
+use Radiergummi\OpenApi\Support\Generator\OperationIdDeriver;
 
 use function sprintf;
 
@@ -18,26 +22,53 @@ use function sprintf;
  * Reports operations that have no operationId, which client generators and documentation tools
  * rely on to identify operations.
  */
-final class OperationIdMissing implements Rule, OperationRuleVisitor
+final class OperationIdMissing implements FixableRule, OperationRuleVisitor
 {
+    public function __construct(
+        private readonly OperationIdDeriver $operationIdDeriver = new OperationIdDeriver(),
+    ) {}
+
     /**
      * @return iterable<Finding>
      */
     #[Override]
     public function checkOperation(OperationNode $operation, LintContext $context): iterable
     {
-        if ($operation->operationId === null) {
-            yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
-                message: sprintf(
-                    'Operation %s %s has no operationId',
-                    $operation->method->forDisplay(),
-                    $operation->pathUri,
-                ),
-                fixHint: 'Add an operationId to the operation via #[Operation(operationId: "...")].',
-            );
+        if ($operation->operationId !== null) {
+            return;
         }
+
+        // Stamp the operationId inference would emit, plus the source member, so the fixer
+        // synthesises exactly that. Only addressable when the operation has a real action behind it.
+        $fixContext = [];
+
+        if ($operation->descriptor !== null) {
+            $fixContext = [
+                ...RemoveAttributeFixer::contextForOperation($operation->descriptor),
+                AddOperationIdFixer::CONTEXT_OPERATION_ID => $this->operationIdDeriver->derive(
+                    $operation->descriptor,
+                    $operation->method,
+                ),
+            ];
+        }
+
+        yield new Finding(
+            ruleId: $this->id(),
+            severity: $this->severity(),
+            message: sprintf(
+                'Operation %s %s has no operationId',
+                $operation->method->forDisplay(),
+                $operation->pathUri,
+            ),
+            fixHint: 'Add an operationId to the operation via #[Operation(operationId: "...")].',
+            context: $fixContext,
+        );
+    }
+
+    #[Override]
+    public function fixer(): Fixer
+    {
+        return new AddOperationIdFixer();
     }
 
     #[Override]

--- a/src/Support/Generator/OperationIdDeriver.php
+++ b/src/Support/Generator/OperationIdDeriver.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Generator;
+
+use Illuminate\Support\Str;
+use Radiergummi\OpenApi\Enums\HttpMethod;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+
+use function array_filter;
+use function config;
+use function count;
+use function preg_replace;
+use function strtolower;
+
+/**
+ * Derives operationIds the way the generator emits them, and sanitises an existing operationId to
+ * the codegen-safe character set.
+ *
+ * Shared by the paths stage (which stamps the inferred operationId onto each operation) and the
+ * lint Fix layer (which synthesises or repairs `#[Operation(operationId: …)]`), so a fixer produces
+ * exactly what inference would have emitted. Stateless and plugin-agnostic.
+ *
+ * @internal
+ */
+final readonly class OperationIdDeriver
+{
+    /**
+     * Derives an operation ID per `openapi.operation_id_strategy`: `route-name` (default) uses the
+     * named route, falling back to `{method}_{path}`; `method-path` always uses `{method}_{path}`.
+     */
+    public function derive(ActionDescriptor $descriptor, HttpMethod $method): string
+    {
+        if (config('openapi.operation_id_strategy') === 'method-path') {
+            return $this->methodPathOperationId($descriptor, $method);
+        }
+
+        return $this->routeNameOperationId($descriptor, $method);
+    }
+
+    /** Replaces invalid characters with `_` and strips leading non-letters; preserves dots. */
+    public function sanitise(string $operationId): string
+    {
+        $sanitised = preg_replace('/[^A-Za-z0-9._-]+/', '_', $operationId) ?? $operationId;
+
+        return preg_replace('/^[^A-Za-z]+/', '', $sanitised) ?? $sanitised;
+    }
+
+    private function methodPathOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
+    {
+        $sanitised = preg_replace('/[^a-zA-Z0-9]+/', '_', $descriptor->route->uri())
+            ?? $descriptor->route->uri();
+
+        return strtolower($method->value) . '_' . $sanitised;
+    }
+
+    /**
+     * Named route: `{name}.{method}` for multi-method routes, `{name}` otherwise.
+     * Generated/unnamed (`generated::*` or null): `{method}_{sanitised_path}`.
+     */
+    private function routeNameOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
+    {
+        $name = $descriptor->route->getName();
+
+        if ($name !== null && !Str::startsWith($name, 'generated::')) {
+            $methods = array_filter(
+                $descriptor->route->methods(),
+                static fn(string $method): bool => HttpMethod::fromString($method) !== HttpMethod::Head,
+            );
+
+            $operationId = count($methods) > 1
+                ? $name . '.' . strtolower($method->value)
+                : $name;
+
+            return $this->sanitise($operationId);
+        }
+
+        return $this->methodPathOperationId($descriptor, $method);
+    }
+}

--- a/src/Support/Generator/Stages/PathsStage.php
+++ b/src/Support/Generator/Stages/PathsStage.php
@@ -17,6 +17,7 @@ use Radiergummi\OpenApi\Extensions\OperationContext;
 use Radiergummi\OpenApi\Generator\GenerationContext;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\Generator\OperationBuilder;
+use Radiergummi\OpenApi\Support\Generator\OperationIdDeriver;
 use Radiergummi\OpenApi\Support\Generator\OverrideMatcher;
 use Radiergummi\OpenApi\Support\Generator\TagDeriver;
 use Radiergummi\OpenApi\Support\Inclusion\InclusionEvaluator;
@@ -26,13 +27,8 @@ use RuntimeException;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use UnexpectedValueException;
 
-use function array_filter;
 use function array_values;
 use function assert;
-use function config;
-use function count;
-use function preg_replace;
-use function strtolower;
 
 /**
  * Walks discovered routes, building `paths` and `webhooks` entries.
@@ -51,6 +47,7 @@ final readonly class PathsStage implements SpecStage
         private InclusionEvaluator $evaluator,
         private Dispatcher $events,
         private TagDeriver $tagDeriver = new TagDeriver(),
+        private OperationIdDeriver $operationIdDeriver = new OperationIdDeriver(),
     ) {}
 
     /**
@@ -132,7 +129,7 @@ final readonly class PathsStage implements SpecStage
 
             $resolved = $operation->operationId !== null
                 ? $operation
-                : $operation->withOperationId($this->buildOperationId($verbAction, $method));
+                : $operation->withOperationId($this->operationIdDeriver->derive($verbAction, $method));
 
             $operationSchema = $resolved->attachTo($pathItem, $method);
 
@@ -147,59 +144,6 @@ final readonly class PathsStage implements SpecStage
                 new OperationContext($verbAction, $method),
             );
         }
-    }
-
-    /**
-     * Derives an operation ID per `openapi.operation_id_strategy`: `route-name` (default) uses
-     * the named route, falling back to `{method}_{path}`; `method-path` always uses `{method}_{path}`.
-     */
-    private function buildOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
-    {
-        if (config('openapi.operation_id_strategy') === 'method-path') {
-            return $this->methodPathOperationId($descriptor, $method);
-        }
-
-        return $this->routeNameOperationId($descriptor, $method);
-    }
-
-    private function methodPathOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
-    {
-        $sanitised = preg_replace('/[^a-zA-Z0-9]+/', '_', $descriptor->route->uri())
-            ?? $descriptor->route->uri();
-
-        return strtolower($method->value) . '_' . $sanitised;
-    }
-
-    /**
-     * Named route: `{name}.{method}` for multi-method routes, `{name}` otherwise.
-     * Generated/unnamed (`generated::*` or null): `{method}_{sanitised_path}`.
-     */
-    private function routeNameOperationId(ActionDescriptor $descriptor, HttpMethod $method): string
-    {
-        $name = $descriptor->route->getName();
-
-        if ($name !== null && !Str::startsWith($name, 'generated::')) {
-            $methods = array_filter(
-                $descriptor->route->methods(),
-                static fn(string $method): bool => HttpMethod::fromString($method) !== HttpMethod::Head,
-            );
-
-            $operationId = count($methods) > 1
-                ? $name . '.' . strtolower($method->value)
-                : $name;
-
-            return $this->sanitiseOperationId($operationId);
-        }
-
-        return $this->methodPathOperationId($descriptor, $method);
-    }
-
-    /** Replaces invalid characters with `_` and strips leading non-letters; preserves dots. */
-    private function sanitiseOperationId(string $operationId): string
-    {
-        $sanitised = preg_replace('/[^A-Za-z0-9._-]+/', '_', $operationId) ?? $operationId;
-
-        return preg_replace('/^[^A-Za-z]+/', '', $sanitised) ?? $sanitised;
     }
 
     private function normalisePath(string $uri): string

--- a/tests/Fixtures/Lint/Fix/InvalidOperationIdFixtureController.php
+++ b/tests/Fixtures/Lint/Fix/InvalidOperationIdFixtureController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix;
+
+use Radiergummi\OpenApi\Attributes\Operation;
+
+class InvalidOperationIdFixtureController
+{
+    #[Operation(operationId: 'list users!')]
+    public function withSpaces(): void {}
+
+    #[Operation(operationId: '123-users')]
+    public function withLeadingDigits(): void {}
+}

--- a/tests/Fixtures/Lint/Fix/MissingOperationIdFixtureController.php
+++ b/tests/Fixtures/Lint/Fix/MissingOperationIdFixtureController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix;
+
+use Radiergummi\OpenApi\Attributes\Operation;
+
+class MissingOperationIdFixtureController
+{
+    public function withoutAttribute(): void {}
+
+    #[Operation(summary: 'List users')]
+    public function withAttribute(): void {}
+}

--- a/tests/Support/AttributeFixFixture.php
+++ b/tests/Support/AttributeFixFixture.php
@@ -31,7 +31,9 @@ use function unlink;
 final class AttributeFixFixture
 {
     /**
-     * @param class-string $class
+     * @param class-string          $class
+     * @param array<string, string> $extraContext additional finding context keys a fixer reads
+     *                                            (e.g. a value the owning rule stamps at check time)
      *
      * @return array{before: string, after: string, fixes: list<Fix>}
      */
@@ -40,6 +42,7 @@ final class AttributeFixFixture
         string $class,
         string $member,
         ?string $discriminator = null,
+        array $extraContext = [],
     ): array {
         $sourceFile = new ReflectionClass($class)->getFileName() ?: '';
         $before = file_get_contents($sourceFile) ?: '';
@@ -50,6 +53,7 @@ final class AttributeFixFixture
         $context = [
             Finding::CONTEXT_SOURCE_CLASS => $class,
             Finding::CONTEXT_SOURCE_MEMBER => $member,
+            ...$extraContext,
         ];
 
         if ($discriminator !== null) {

--- a/tests/Unit/Lint/Fix/AddAttributeOperationTest.php
+++ b/tests/Unit/Lint/Fix/AddAttributeOperationTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Fix\Ast\AddAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixApplicator;
+
+uses()->group('openapi', 'lint', 'fix');
+
+/**
+ * Drives an AddAttribute op through the real FixApplicator against a throwaway source file and
+ * returns the rewritten source plus the applicator outcome, so byte-exact output and the
+ * applied/skipped accounting can both be asserted. The class is addressed structurally (FQCN +
+ * member), and the synthesised attribute is emitted in fully-qualified form so the use block is
+ * never touched.
+ */
+function applyAddAttribute(string $source, AddAttribute $operation): array
+{
+    $file = tempnam(sys_get_temp_dir(), 'openapi-addattr-test-') ?: '';
+    file_put_contents($file, $source);
+
+    $result = new FixApplicator()->apply([new Fix($file, 'description', 'test.rule', $operation)]);
+
+    $after = file_get_contents($file) ?: '';
+    @unlink($file);
+
+    return ['after' => $after, 'result' => $result];
+}
+
+afterEach(function (): void {
+    foreach (glob(sys_get_temp_dir() . '/openapi-addattr-test-*') ?: [] as $leftover) {
+        @unlink($leftover);
+    }
+});
+
+function addAttributeTarget(): TargetSelector
+{
+    return new TargetSelector('AddAttr\\Fixture', TargetKind::Method, 'index');
+}
+
+it('prepends a synthesised attribute on a member that has none', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        class Fixture
+        {
+            public function index(): void {}
+        }
+
+        PHP;
+
+    ['after' => $after, 'result' => $result] = applyAddAttribute($source, new AddAttribute(
+        target: addAttributeTarget(),
+        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        arguments: ['operationId' => 'users.index'],
+    ));
+
+    expect($after)->toBe(<<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        class Fixture
+        {
+            #[\Radiergummi\OpenApi\Attributes\Operation(operationId: 'users.index')]
+            public function index(): void {}
+        }
+
+        PHP)
+        ->and($result->applied)->toHaveCount(1);
+});
+
+it('prepends above an existing unrelated attribute, leaving it byte-identical', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        use Radiergummi\OpenApi\Attributes\Tag;
+
+        class Fixture
+        {
+            #[Tag('users')]
+            public function index(): void {}
+        }
+
+        PHP;
+
+    ['after' => $after, 'result' => $result] = applyAddAttribute($source, new AddAttribute(
+        target: addAttributeTarget(),
+        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        arguments: ['operationId' => 'users.index'],
+    ));
+
+    expect($after)->toBe(<<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        use Radiergummi\OpenApi\Attributes\Tag;
+
+        class Fixture
+        {
+            #[\Radiergummi\OpenApi\Attributes\Operation(operationId: 'users.index')]
+            #[Tag('users')]
+            public function index(): void {}
+        }
+
+        PHP)
+        ->and($result->applied)->toHaveCount(1);
+});
+
+it('is a no-op writing nothing when the member already carries the attribute class', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        use Radiergummi\OpenApi\Attributes\Operation;
+
+        class Fixture
+        {
+            #[Operation(summary: 'List users')]
+            public function index(): void {}
+        }
+
+        PHP;
+
+    ['after' => $after, 'result' => $result] = applyAddAttribute($source, new AddAttribute(
+        target: addAttributeTarget(),
+        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        arguments: ['operationId' => 'users.index'],
+    ));
+
+    expect($after)
+        ->toBe($source)
+        ->and($result->applied)->toBe([])
+        ->and($result->skipped)->toHaveCount(1)
+        ->and($result->modifiedFiles)->toBe([]);
+});
+
+it('renders multiple named arguments in declared order', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        class Fixture
+        {
+            public function index(): void {}
+        }
+
+        PHP;
+
+    ['after' => $after] = applyAddAttribute($source, new AddAttribute(
+        target: addAttributeTarget(),
+        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        arguments: ['summary' => 'List users', 'operationId' => 'users.index'],
+    ));
+
+    expect($after)->toContain(
+        "#[\Radiergummi\OpenApi\Attributes\Operation(summary: 'List users', operationId: 'users.index')]",
+    );
+});
+
+it('is idempotent: re-running the same op against its own output changes nothing', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace AddAttr;
+
+        class Fixture
+        {
+            public function index(): void {}
+        }
+
+        PHP;
+
+    $operation = new AddAttribute(
+        target: addAttributeTarget(),
+        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        arguments: ['operationId' => 'users.index'],
+    );
+
+    ['after' => $once] = applyAddAttribute($source, $operation);
+    ['after' => $twice, 'result' => $secondResult] = applyAddAttribute($once, $operation);
+
+    expect($twice)
+        ->toBe($once)
+        ->and($secondResult->applied)->toBe([]);
+});

--- a/tests/Unit/Lint/Fix/AddAttributeOperationTest.php
+++ b/tests/Unit/Lint/Fix/AddAttributeOperationTest.php
@@ -56,7 +56,7 @@ it('prepends a synthesised attribute on a member that has none', function (): vo
 
     ['after' => $after, 'result' => $result] = applyAddAttribute($source, new AddAttribute(
         target: addAttributeTarget(),
-        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        attributeClass: Radiergummi\OpenApi\Attributes\Operation::class,
         arguments: ['operationId' => 'users.index'],
     ));
 
@@ -93,7 +93,7 @@ it('prepends above an existing unrelated attribute, leaving it byte-identical', 
 
     ['after' => $after, 'result' => $result] = applyAddAttribute($source, new AddAttribute(
         target: addAttributeTarget(),
-        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        attributeClass: Radiergummi\OpenApi\Attributes\Operation::class,
         arguments: ['operationId' => 'users.index'],
     ));
 
@@ -133,7 +133,7 @@ it('is a no-op writing nothing when the member already carries the attribute cla
 
     ['after' => $after, 'result' => $result] = applyAddAttribute($source, new AddAttribute(
         target: addAttributeTarget(),
-        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        attributeClass: Radiergummi\OpenApi\Attributes\Operation::class,
         arguments: ['operationId' => 'users.index'],
     ));
 
@@ -159,7 +159,7 @@ it('renders multiple named arguments in declared order', function (): void {
 
     ['after' => $after] = applyAddAttribute($source, new AddAttribute(
         target: addAttributeTarget(),
-        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        attributeClass: Radiergummi\OpenApi\Attributes\Operation::class,
         arguments: ['summary' => 'List users', 'operationId' => 'users.index'],
     ));
 
@@ -183,7 +183,7 @@ it('is idempotent: re-running the same op against its own output changes nothing
 
     $operation = new AddAttribute(
         target: addAttributeTarget(),
-        attributeClass: \Radiergummi\OpenApi\Attributes\Operation::class,
+        attributeClass: Radiergummi\OpenApi\Attributes\Operation::class,
         arguments: ['operationId' => 'users.index'],
     );
 

--- a/tests/Unit/Lint/Fix/AddOperationIdFixerTest.php
+++ b/tests/Unit/Lint/Fix/AddOperationIdFixerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\AddOperationIdFixer;
+use Radiergummi\OpenApi\Lint\Fix\FixContext;
+use Radiergummi\OpenApi\Lint\Rules\OperationIdMissing;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\MissingOperationIdFixtureController;
+use Radiergummi\OpenApi\Tests\Support\AttributeFixFixture;
+
+uses()->group('openapi', 'lint', 'fix');
+
+it('synthesises a new #[Operation] attribute on a method that has none', function (): void {
+    $result = AttributeFixFixture::run(
+        new OperationIdMissing(),
+        MissingOperationIdFixtureController::class,
+        'withoutAttribute',
+        extraContext: [AddOperationIdFixer::CONTEXT_OPERATION_ID => 'users.index'],
+    );
+
+    expect($result['fixes'])
+        ->toHaveCount(1)
+        ->and($result['after'])->toContain(
+            "#[\Radiergummi\OpenApi\Attributes\Operation(operationId: 'users.index')]",
+        )
+        ->and($result['after'])->toContain('public function withoutAttribute(): void {}');
+});
+
+it('adds the operationId argument to an existing #[Operation] without duplicating the attribute', function (): void {
+    $result = AttributeFixFixture::run(
+        new OperationIdMissing(),
+        MissingOperationIdFixtureController::class,
+        'withAttribute',
+        extraContext: [AddOperationIdFixer::CONTEXT_OPERATION_ID => 'users.show'],
+    );
+
+    expect($result['fixes'])
+        ->toHaveCount(1)
+        ->and($result['after'])->toContain(
+            "#[Operation(summary: 'List users', operationId: 'users.show')]",
+        )
+        // No second attribute was synthesised.
+        ->and(substr_count($result['after'], '#[Operation'))->toBe(1)
+        ->and($result['after'])->not->toContain('Attributes\Operation(operationId');
+});
+
+it('yields nothing when the stamped operationId is absent (degrade)', function (): void {
+    $finding = new Finding(
+        ruleId: 'operation.id-missing',
+        severity: (new OperationIdMissing())->severity(),
+        message: 'fixture',
+        context: [
+            Finding::CONTEXT_SOURCE_CLASS => MissingOperationIdFixtureController::class,
+            Finding::CONTEXT_SOURCE_MEMBER => 'withoutAttribute',
+        ],
+    );
+
+    $fixes = iterator_to_array(new AddOperationIdFixer()->fix($finding, new FixContext()));
+
+    expect($fixes)->toBe([]);
+});
+
+it('yields nothing when the source member is unknown (degrade)', function (): void {
+    $finding = new Finding(
+        ruleId: 'operation.id-missing',
+        severity: (new OperationIdMissing())->severity(),
+        message: 'fixture',
+        context: [AddOperationIdFixer::CONTEXT_OPERATION_ID => 'users.index'],
+    );
+
+    $fixes = iterator_to_array(new AddOperationIdFixer()->fix($finding, new FixContext()));
+
+    expect($fixes)->toBe([]);
+});
+
+it('emits AddAttribute when no #[Operation] exists and SetAttributeArgument when one does', function (): void {
+    $fixer = new AddOperationIdFixer();
+
+    $without = iterator_to_array($fixer->fix(
+        operationIdMissingFinding('withoutAttribute', 'users.index'),
+        new FixContext(),
+    ));
+    $with = iterator_to_array($fixer->fix(
+        operationIdMissingFinding('withAttribute', 'users.show'),
+        new FixContext(),
+    ));
+
+    expect($without[0]->operation)->toBeInstanceOf(Radiergummi\OpenApi\Lint\Fix\Ast\AddAttribute::class)
+        ->and($with[0]->operation)->toBeInstanceOf(Radiergummi\OpenApi\Lint\Fix\Ast\SetAttributeArgument::class);
+});
+
+function operationIdMissingFinding(string $member, string $operationId): Finding
+{
+    return new Finding(
+        ruleId: 'operation.id-missing',
+        severity: (new OperationIdMissing())->severity(),
+        message: 'fixture',
+        context: [
+            Finding::CONTEXT_SOURCE_CLASS => MissingOperationIdFixtureController::class,
+            Finding::CONTEXT_SOURCE_MEMBER => $member,
+            AddOperationIdFixer::CONTEXT_OPERATION_ID => $operationId,
+        ],
+    );
+}

--- a/tests/Unit/Lint/Fix/SanitizeOperationIdFixerTest.php
+++ b/tests/Unit/Lint/Fix/SanitizeOperationIdFixerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\FixContext;
+use Radiergummi\OpenApi\Lint\Fix\SanitizeOperationIdFixer;
+use Radiergummi\OpenApi\Lint\Rules\OperationIdInvalidChars;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\InvalidOperationIdFixtureController;
+use Radiergummi\OpenApi\Tests\Support\AttributeFixFixture;
+
+uses()->group('openapi', 'lint', 'fix');
+
+it('rewrites an operationId with spaces and illegal characters to the sanitised value', function (): void {
+    $result = AttributeFixFixture::run(
+        new OperationIdInvalidChars(),
+        InvalidOperationIdFixtureController::class,
+        'withSpaces',
+        extraContext: [SanitizeOperationIdFixer::CONTEXT_OPERATION_ID => 'list_users_'],
+    );
+
+    expect($result['fixes'])
+        ->toHaveCount(1)
+        ->and($result['after'])->toContain("#[Operation(operationId: 'list_users_')]")
+        ->and($result['after'])->not->toContain("'list users!'");
+});
+
+it('rewrites a leading-digit operationId to a letter-prefixed form', function (): void {
+    $result = AttributeFixFixture::run(
+        new OperationIdInvalidChars(),
+        InvalidOperationIdFixtureController::class,
+        'withLeadingDigits',
+        extraContext: [SanitizeOperationIdFixer::CONTEXT_OPERATION_ID => 'users'],
+    );
+
+    expect($result['fixes'])
+        ->toHaveCount(1)
+        ->and($result['after'])->toContain("#[Operation(operationId: 'users')]");
+});
+
+it('yields nothing when the stamped sanitised value is absent (degrade)', function (): void {
+    $finding = new Finding(
+        ruleId: 'operation.id-invalid-chars',
+        severity: (new OperationIdInvalidChars())->severity(),
+        message: 'fixture',
+        context: [
+            Finding::CONTEXT_SOURCE_CLASS => InvalidOperationIdFixtureController::class,
+            Finding::CONTEXT_SOURCE_MEMBER => 'withSpaces',
+        ],
+    );
+
+    $fixes = iterator_to_array(new SanitizeOperationIdFixer()->fix($finding, new FixContext()));
+
+    expect($fixes)->toBe([]);
+});
+
+it('yields nothing when the method carries no #[Operation] attribute (degrade)', function (): void {
+    $finding = new Finding(
+        ruleId: 'operation.id-invalid-chars',
+        severity: (new OperationIdInvalidChars())->severity(),
+        message: 'fixture',
+        context: [
+            Finding::CONTEXT_SOURCE_CLASS => Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\DuplicateTagFixtureController::class,
+            Finding::CONTEXT_SOURCE_MEMBER => 'index',
+            SanitizeOperationIdFixer::CONTEXT_OPERATION_ID => 'users',
+        ],
+    );
+
+    $fixes = iterator_to_array(new SanitizeOperationIdFixer()->fix($finding, new FixContext()));
+
+    expect($fixes)->toBe([]);
+});
+
+it('produces an operationId the invalid-chars rule no longer flags', function (): void {
+    $sanitised = (new OperationIdInvalidChars())->fixer();
+
+    // The sanitised value the rule stamps must itself match the codegen-safe pattern, so a second
+    // lint pass over the fixed source finds nothing (the fix converges in one pass).
+    expect(preg_match(OperationIdInvalidChars::PATTERN, 'list_users_'))->toBe(1)
+        ->and($sanitised)->toBeInstanceOf(SanitizeOperationIdFixer::class);
+});

--- a/tests/Unit/Lint/Rules/OperationIdInvalidCharsTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdInvalidCharsTest.php
@@ -3,7 +3,11 @@
 declare(strict_types=1);
 
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\SanitizeOperationIdFixer;
 use Radiergummi\OpenApi\Lint\Rules\OperationIdInvalidChars;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\InvalidOperationIdFixtureController;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
 uses()->group('openapi', 'lint');
@@ -51,6 +55,34 @@ it('emits no finding for a permitted operationId', function (string $operationId
     'dot-separated'              => ['projects.list'],
     'hyphens, underscores, digits' => ['projects-list_v2'],
 ]);
+
+it('stamps the sanitised operationId and source member onto the finding when a descriptor is present', function (): void {
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        InvalidOperationIdFixtureController::class,
+        'withSpaces',
+    );
+    $operation = OperationNodeFactory::forDescriptor($descriptor, operationId: 'list users!');
+
+    $findings = iterator_to_array(
+        (new OperationIdInvalidChars())->checkOperation($operation, OperationNodeFactory::emptyContext()),
+    );
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->context[Finding::CONTEXT_SOURCE_CLASS])->toBe(InvalidOperationIdFixtureController::class)
+        ->and($findings[0]->context[Finding::CONTEXT_SOURCE_MEMBER])->toBe('withSpaces')
+        ->and($findings[0]->context[SanitizeOperationIdFixer::CONTEXT_OPERATION_ID])->toBe('list_users_');
+});
+
+it('stamps no fix context when the operation has no descriptor', function (): void {
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/projects', operationId: 'list users!');
+
+    $findings = iterator_to_array(
+        (new OperationIdInvalidChars())->checkOperation($operation, OperationNodeFactory::emptyContext()),
+    );
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->context)->toBe([]);
+});
 
 it('emits no finding when operationId is null', function (): void {
     $rule = new OperationIdInvalidChars();

--- a/tests/Unit/Lint/Rules/OperationIdMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdMissingTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Enums\HttpMethod;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\AddOperationIdFixer;
 use Radiergummi\OpenApi\Lint\Rules\OperationIdMissing;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\MissingOperationIdFixtureController;
+use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
 use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
 
 uses()->group('openapi', 'lint');
@@ -80,4 +84,33 @@ it('does not flag operations that have an operationId alongside missing ones', f
     expect($findings)
         ->toHaveCount(1)
         ->and($findings[0]->message)->toContain('POST');
+});
+
+it('stamps the derived operationId and source member onto the finding when a descriptor is present', function (): void {
+    $descriptor = ActionDescriptorFactory::forControllerMethod(
+        MissingOperationIdFixtureController::class,
+        'withoutAttribute',
+    );
+    $operation = OperationNodeFactory::forDescriptor($descriptor, operationId: null);
+
+    $findings = iterator_to_array(
+        (new OperationIdMissing())->checkOperation($operation, OperationNodeFactory::emptyContext()),
+    );
+
+    // The factory's route is the unnamed GET /x, so the route-name strategy falls back to {method}_{path}.
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->context[Finding::CONTEXT_SOURCE_CLASS])->toBe(MissingOperationIdFixtureController::class)
+        ->and($findings[0]->context[Finding::CONTEXT_SOURCE_MEMBER])->toBe('withoutAttribute')
+        ->and($findings[0]->context[AddOperationIdFixer::CONTEXT_OPERATION_ID])->toBe('get_x');
+});
+
+it('stamps no fix context when the operation has no descriptor', function (): void {
+    $operation = OperationNodeFactory::makeOperation(pathUri: '/users', operationId: null);
+
+    $findings = iterator_to_array(
+        (new OperationIdMissing())->checkOperation($operation, OperationNodeFactory::emptyContext()),
+    );
+
+    expect($findings)->toHaveCount(1)
+        ->and($findings[0]->context)->toBe([]);
 });

--- a/tests/Unit/Support/Generator/OperationIdDeriverTest.php
+++ b/tests/Unit/Support/Generator/OperationIdDeriverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Routing\Route;
+use Radiergummi\OpenApi\Enums\HttpMethod;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Support\Generator\OperationIdDeriver;
+
+uses()->group('openapi', 'generator');
+
+function deriverDescriptor(Route $route): ActionDescriptor
+{
+    return new ActionDescriptor(
+        route: $route,
+        controller: null,
+        method: null,
+        summary: null,
+        description: null,
+    );
+}
+
+it('uses the route name under the default route-name strategy', function (): void {
+    $route = new Route(['GET'], '/users', [])->name('users.index');
+
+    $operationId = new OperationIdDeriver()->derive(deriverDescriptor($route), HttpMethod::Get);
+
+    expect($operationId)->toBe('users.index');
+});
+
+it('suffixes the route name with the verb for a multi-method route', function (): void {
+    $route = new Route(['GET', 'POST'], '/users', [])->name('users');
+
+    $operationId = new OperationIdDeriver()->derive(deriverDescriptor($route), HttpMethod::Post);
+
+    expect($operationId)->toBe('users.post');
+});
+
+it('falls back to {method}_{path} for an unnamed route under route-name', function (): void {
+    $route = new Route(['GET'], '/users/{user}', []);
+
+    $operationId = new OperationIdDeriver()->derive(deriverDescriptor($route), HttpMethod::Get);
+
+    expect($operationId)->toBe('get_users_user_');
+});
+
+it('falls back to {method}_{path} for a generated route name', function (): void {
+    $route = new Route(['GET'], '/users', [])->name('generated::abc123');
+
+    $operationId = new OperationIdDeriver()->derive(deriverDescriptor($route), HttpMethod::Get);
+
+    expect($operationId)->toBe('get_users');
+});
+
+it('always uses {method}_{path} under the method-path strategy', function (): void {
+    config()->set('openapi.operation_id_strategy', 'method-path');
+
+    $route = new Route(['POST'], '/users', [])->name('users.store');
+
+    $operationId = new OperationIdDeriver()->derive(deriverDescriptor($route), HttpMethod::Post);
+
+    expect($operationId)->toBe('post_users');
+});
+
+it('sanitises spaces and illegal characters to underscores', function (): void {
+    $sanitised = new OperationIdDeriver()->sanitise('Get Users! (all)');
+
+    expect($sanitised)->toBe('Get_Users_all_');
+});
+
+it('strips leading non-letters while preserving dots', function (): void {
+    $sanitised = new OperationIdDeriver()->sanitise('123.users.index');
+
+    expect($sanitised)->toBe('users.index');
+});
+
+it('preserves an already-valid operationId', function (): void {
+    $sanitised = new OperationIdDeriver()->sanitise('users.index');
+
+    expect($sanitised)->toBe('users.index');
+});


### PR DESCRIPTION
Closes #382

## Implementation plan — #382 additive/modification lint-fix catalog (slice 1)

`<type>=feat` · area:lint · **no tier label** (Fix-layer infra, not an inference measure).
Depends on #368 (merged: AST-mutation Fix backend).

### TL;DR

This issue is too large for one auto-mergeable PR (AddAttribute primitive + ~15 fixers + per-rule
triage + goldens + docs). This PR ships a **genuinely-mergeable first slice**: the missing
`AddAttribute` AST primitive plus the **two operation-level fixers that are cleanly
attribute-addressable today** — `operation.id-missing` and `operation.id-invalid-chars`. Every
remaining candidate from the issue is **dispositioned below** (built / deferred-with-reason /
human-only) so the catalog is provably exhaustive, not silently truncated.

### Why this slice, and not the example/parameter set

The exploration surfaced a hard architectural constraint that reshapes the issue's candidate list:

1. **A `Finding` carries no byte location; a fixer needs a *structural address* (FQCN + member).**
   The only tree node that exposes a source back-reference is `OperationNode`, via its
   `descriptor` (`ActionDescriptor` → controller + method reflection). This is exactly what the
   existing `RemoveAttributeFixer::contextForOperation()` consumes. So **operation-level rules are
   the only ones whose findings can be made attribute-addressable without new plumbing.**

2. **`ParameterNode`/`ResponseNode`/header/schema-property nodes have no descriptor and no path
   back to a source attribute.** They are reconstructed from the generated `OA\*` objects. A spec
   parameter may originate from a `#[QueryParam]`/`#[PathParameter]` attribute, from
   route-model-binding inference, or be synthesized from the route URI with **no attribute at all**
   (the common case for path params). A fixer cannot mutate an attribute that does not exist and
   that the node cannot point to. Making these fixable requires a separate, larger plumbing change
   (thread a source-member + attribute-index back-reference through `SpecTreeBuilder`), which is
   its own slice.

3. **`SetAttributeArgument` is scalar-only** (`string|int|float|bool|null`). Faker example
   synthesis (`FakerExampleSynthesiser::synthesise()`) and example values are frequently
   arrays/objects, which the current op cannot express. The `*.example-missing` set therefore needs
   *both* (2) the source back-reference *and* a structured-value op — out of scope here.

Building `operation.id-missing` first also exercises the new `AddAttribute` primitive end-to-end
(synthesize `#[Operation(operationId: ...)]` where no `#[Operation]` exists), which is the issue's
named prerequisite.

### What this PR builds

**0. Extract the operationId-derivation logic into a shared, callable surface** (REQUIRED by plan-review)
- Today `PathsStage::buildOperationId()` / `routeNameOperationId()` / `methodPathOperationId()` /
  `sanitiseOperationId()` are **all `private`** on `Support\Generator\Stages\PathsStage`
  (PathsStage.php:156-203) — not callable from the Fix layer. Both new fixers must produce *exactly*
  what the generator emits, so the logic must be shared, not reinvented.
- New `src/Support/Generator/OperationIdDeriver.php` — a stateless, plugin-agnostic `final` helper in
  `Support/` (correct home: it is config-driven, plugin-agnostic infrastructure):
  - `public function derive(ActionDescriptor $descriptor, HttpMethod $method): string` — the body of
    today's `buildOperationId()`, including the `config('openapi.operation_id_strategy')` read and
    the `route-name` / `method-path` branch (moves `routeNameOperationId()` + `methodPathOperationId()`
    in as private methods).
  - `public function sanitise(string $operationId): string` — the body of today's
    `sanitiseOperationId()` (`preg_replace('/[^A-Za-z0-9._-]+/', '_')` then strip leading non-letters,
    preserving dots). This is exactly what `operation.id-invalid-chars` needs.
- **Pure extraction, no behaviour change.** `PathsStage` keeps its current call sites but delegates to
  the helper (construct/inject it; it has no state). Stays in `Support/`, no `Contracts/` change, no
  config-key change — the config read moves verbatim. The existing PathsStage tests pin the
  no-behaviour-change guarantee; add a direct unit test for the helper (`OperationIdDeriverTest`)
  covering both strategies + sanitisation.
- The `AddOperationIdFixer` calls `derive(...)`; the `SanitizeOperationIdFixer` calls `sanitise(...)`.
  Both inputs (`ActionDescriptor`, `HttpMethod`) are available on the finding's `OperationNode`
  (`descriptor` + `method`), so the fixers can reconstruct them from the stamped context.

**1. `AddAttribute` AST primitive** (the issue's checklist prerequisite)
- `src/Lint/Fix/Ast/AddAttribute.php` — `final readonly class AddAttribute extends AstOperation`.
  Carries the attribute FQCN (`class-string`) and an ordered map of named arguments
  (`array<string, string|int|float|bool|null>` — scalar-only, matching `SetAttributeArgument`'s
  value domain). Targets a class/method/property/param via the inherited `TargetSelector`.
- Wire it into `src/Lint/Fix/Ast/FixOperationVisitor.php`: in `enterNode()`, add an
  `$this->operation instanceof AddAttribute` branch that synthesizes a new
  `PhpParser\Node\AttributeGroup` (one `Attribute` with a resolved `Name` + `Arg` list built from
  the scalar args, reusing the same scalar→expr construction `SetAttributeArgument` uses) and
  **prepends** it to the located member's `attrGroups`. Prepend (not append) gives a deterministic,
  byte-stable position and keeps the attribute above any existing ones.
- Edge handling: if the member already carries the target attribute class, `AddAttribute` is a
  no-op (yield/apply nothing) — the *fixer* decides add-vs-modify, the op just inserts. Name
  rendering uses the short class name with a `use` assumption only if already imported; otherwise
  emit the FQ name (leading `\`) to stay correct without touching the `use` block. **Decision:**
  emit FQCN form to avoid editing imports in slice 1; a later slice can add import management.
  (Record this as a PR comment if the reviewer pushes on aesthetics.)

**2. Fixer: `operation.id-missing`** (additive, uses `AddAttribute`)
- `OperationIdMissing` (`src/Lint/Rules/OperationIdMissing.php`) gains `implements FixableRule` +
  `fixer()`. In `checkOperation()`, stamp finding `context` with the source class/member via
  `RemoveAttributeFixer::contextForOperation($operation->descriptor)` (reuse the existing
  context-builder; no discriminator) plus the synthesized operationId value under a new context key.
- New `src/Lint/Fix/AddOperationIdFixer.php implements Fixer`: reads the source class/method from
  the finding context, synthesizes the operationId by calling
  `OperationIdDeriver::derive($descriptor, $method)` (the shared surface from step 0) so the fix
  equals exactly what inference would emit, then:
  - if a `#[Operation]` attribute exists on the method → emit `SetAttributeArgument(operationId: …)`;
  - else → emit `AddAttribute(Operation::class, ['operationId' => …])`.
  Degrade to nothing when the descriptor/reflection is unavailable.

**3. Fixer: `operation.id-invalid-chars`** (deterministic modification, uses `SetAttributeArgument`)
- `OperationIdInvalidChars` gains `FixableRule` + `fixer()`, stamping the same operation context.
- `src/Lint/Fix/SanitizeOperationIdFixer.php`: sanitize the existing id by calling
  `OperationIdDeriver::sanitise($operationId)` (the shared surface from step 0 — identical to the
  generator's `sanitiseOperationId`, which already maps to the allowed set `/^[A-Za-z][A-Za-z0-9._-]*$/`),
  then emit `SetAttributeArgument` setting `operationId` on the existing `#[Operation]` attribute.
  (An invalid id can only have come from an explicit attribute, so the attribute always exists →
  no `AddAttribute` branch needed here.)

### Disposition of every issue candidate (acceptance: exhaustive)

| Rule | Disposition | Reason |
|---|---|---|
| `operation.id-missing` | **BUILT** | `OperationNode.descriptor` is addressable; needs/exercises `AddAttribute`. |
| `operation.id-invalid-chars` | **BUILT** | Addressable; value sanitizable deterministically. |
| `parameter.path-must-be-required` | **DEFERRED** | `ParameterNode` has no descriptor/attribute back-ref; path params are often synthesized from the route URI with no attribute to set `required:` on. Needs source back-reference plumbing (separate slice). |
| `parameter.example-missing` | **DEFERRED** | No source back-ref **and** `SetAttributeArgument` is scalar-only (Faker values may be arrays). Needs both plumbing + a structured-value op. |
| `response.example-missing` | **DEFERRED** | Same as above; response media-type examples are typically structured. |
| `request-body.example-missing` | **DEFERRED** | Same as above. |
| `schema.example-missing` | **DEFERRED** | Schema property nodes have no source-attribute back-ref; scalar-only op also insufficient. |
| `parameter.example-conflict` | **DEFERRED** | No back-ref; reconciliation also needs to pick which of N attribute sites is canonical (not expressible without the back-ref). |
| `schema.nullable-via-deprecated-keyword` | **DEFERRED** | Operates on generated schema shape, not on a source attribute the node points to; the deprecated `nullable` keyword has no 1:1 attribute argument to rewrite. |
| `header.invalid-name` | **DEFERRED** | Header nodes have no source back-ref to the `#[ResponseHeader]` attribute/index. |
| `field.name-naming-inconsistent` | **DEFERRED** | Field name source is the property/`#[Field]` name; needs the field back-ref + a rename op (renaming a property name, not an attribute arg). Larger, distinct shape. |
| `parameter.name-naming-inconsistent` | **DEFERRED** | No source back-ref (as above). |
| `header.name-naming-inconsistent` | **DEFERRED** | No source back-ref (as above). |
| `tag.name-naming-inconsistent` | **DEFERRED** | Tag value is addressable in principle, but a *rename to the configured convention* must agree with the convention engine; bundle with the naming-convention slice for one consistent rename op. |
| `operation.id-naming-inconsistent` | **DEFERRED** | Operation id is addressable, but the rename target is convention-driven; group with the naming slice so all naming rewrites share one convention-rename path (avoids divergent per-rule logic). |
| `component.name-naming-inconsistent` | **DEFERRED (likely permanent)** | Class-name addressed; renaming a class touches every reference — out of reach of the attribute/docblock substrate. |
| `path.segment-naming-inconsistent` | **DEFERRED (likely permanent)** | Route-source addressed; the fix is a route definition change, not an attribute. |
| `path.trailing-slash-inconsistent` | **DEFERRED (likely permanent)** | Route-source addressed (as above). |
| `apifield.conflicting-type` (`FieldConflictingType`) | **DEFERRED** (slice 2) | Deterministic `SetAttributeArgument` set `type:` to the property's declared PHP type — passes the litmus — but needs the field/attribute back-ref (`FieldNode` has no descriptor). **ID-alignment flag:** the rule currently returns `field.conflicting-type`, not `apifield.conflicting-type`; the slice-2 PR must pick a direction (rename the rule ID vs. update the epic) — flagged here, not decided now. |
| `apifield.invalid-format` (`FieldInvalidFormat`) | **DEFERRED** (slice 2) | Remove the invalid `format:` arg (`SetAttributeArgument` remove) — passes the litmus — but same field back-ref dependency. Rule currently returns `field.invalid-format`; **same ID-alignment flag** as above. |
| `response.heuristic` / `request.heuristic` | **OUT OF SCOPE** | Neither rule exists on `main`. This catalog is *fixers for existing findings only* (issue non-goal: "New lint *rules* … not here"). Materialising an inferred heuristic as an explicit attribute is authoring-first work; triage whether it belongs to this cluster at all happens when/if the rules are authored. |
| Prose rows from #21: `summary.missing`, `field.description-missing`, `parameter.description-missing`, `queryparam.description-missing`, `meta.no-suppression-reason` | **HUMAN-ONLY** | #21 proposed hard-coded `'TODO'` stubs; per this issue's non-goals prose stays diagnostic — the value requires human judgement (fails the litmus test). |
| Prose (issue body): summaries/descriptions/sunset dates/deprecation replacements | **HUMAN-ONLY** | Per issue non-goals; value requires human judgement (fails the litmus test). |

**Follow-on slices the lead should surface to the user** (we cannot `gh issue create` here):
- *Slice 2 — source back-reference plumbing*: thread source-member + attribute-index identity
  through `SpecTreeBuilder` onto `ParameterNode`/`ResponseNode`/`FieldNode`/header/schema-property
  nodes, so parameter/header/field/example rules become addressable. Unblocks
  `parameter.path-must-be-required`, the example-conflict/header rows, and the `apifield.*` rows
  (`conflicting-type`, `invalid-format`) — the slice-2 PR also resolves the `field.*` vs `apifield.*`
  rule-ID-alignment question flagged above.
- *Slice 3 — structured-value AST op*: a `SetAttributeArgument` variant (or new op) accepting
  array/object values, to land the `*.example-missing` Faker-backed set.
- *Slice 4 — naming-convention rename op*: one convention-driven rename path shared by the
  `*.name-naming-inconsistent` family (field/parameter/header/tag/operation-id rows).

### Tests (TDD — failing tests first)

New unit tests under `tests/Unit/Lint/Fix/`, fixtures under `tests/Fixtures/Lint/Fix/`, using the
existing `AttributeFixFixture::run()` golden harness (copy fixture → synthetic Finding → apply →
assert exact `after` source).

- `AddAttributeOperationTest` (op-level, byte-stable golden):
  - inserts `#[Operation(operationId: 'x')]` on a method with **no** attributes → exact output.
  - inserts above an existing unrelated attribute (e.g. `#[Tag('users')]`) → ordering + byte-stable.
  - target already has the attribute class → no-op: the test asserts the output is **byte-identical
    to the input source** (source-unchanged), not merely that nothing throws, pinning the op contract
    independently of any fixer.
  - **idempotent**: re-running the produced op yields no further change.
- `AddOperationIdFixerTest`:
  - method with no `#[Operation]` → `AddAttribute` path, exact synthesized id, Pint-clean output.
  - method with existing `#[Operation(summary: …)]` but no `operationId` → `SetAttributeArgument`
    add-arg path (no duplicate attribute).
  - descriptor/reflection unavailable → yields nothing (degrade).
  - idempotent re-run.
- `SanitizeOperationIdFixerTest`:
  - id with spaces/illegal chars → sanitized to allowed set, starts with a letter.
  - id starting with a digit → letter-prefixed/repaired branch.
  - already-valid id (defensive) → yields nothing.
  - idempotent re-run.
- Every golden asserts the full `after` string (byte-stable) and the suite already runs in the
  `snapshot`-excluded path; ensure outputs are Pint-clean by construction (printer + format-preserve).

### Docs & changelog (observable surface)

- `docs/linting.md` — between the `lint-rule-catalog` markers, the catalog is severity-only and
  hand-maintained; add/adjust a "Fixable" indication for `operation.id-missing` and
  `operation.id-invalid-chars` consistent with how existing fixable rules (`tag.duplicate`, etc.)
  are shown. Confirm during coding whether the catalog encodes fixability; if not, note the two
  rules as `--fix`-able in the surrounding prose. `openapi:lint --list` is the live source and will
  reflect them automatically once they implement `FixableRule`.
- `CHANGELOG.md` `[Unreleased] → Added`: one line — `openapi:lint --fix` now repairs missing and
  codegen-unsafe operationIds (synthesizes/sanitizes the `#[Operation(operationId: …)]`), via the
  new `AddAttribute` fix primitive. (#382)

### Controversy flags for the lead (expect a human merge gate)

- **Touches the Fix-layer substrate**: new `AddAttribute` AST op + `FixOperationVisitor` branch.
  This is the same substrate #368 introduced; new primitive = architectural surface.
- **Likely > ~150 src/ LOC** across the op, visitor branch, two fixers, and the two rule
  `FixableRule` wirings (plus tests/fixtures). Above the fast-path mechanical threshold.
- **No `src/Contracts/**` change, no config key, no public-signature change** — confirmed: rules
  gain `FixableRule` (already a public-but-internal Fix contract from #368), fixers are new
  `Fixer` implementations, the op extends the existing internal `AstOperation`. Nothing in the
  documented stable extension surface moves.
- `area:lint` ⇒ **survey gate skipped** (non-generation-affecting).
- Several candidates are **deferred without a follow-up issue** (runtime can't `gh issue create`) —
  the lead must surface slices 2–4 to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
