### PR TITLE
feat(#22): AST-era fix-conflict semantics + frozen --check JSON fix-run schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project are documented here.
 - `openapi:lint --format=markdown` now renders a real GitHub-Flavored Markdown body (a coverage summary line and a `Severity | Rule | Location | Message` findings table) instead of aliasing the CLI tree dump, so the CI coverage-comment recipe can post it verbatim. (#389)
 - ApiResources: the return-expression reader now recognises the `X::collect(...)` static resource-collection factory, emitting the same collection response schema as `X::collection(...)`. (#390)
 - `openapi:lint --fix` now repairs missing and codegen-unsafe operationIds (synthesizes/sanitizes the `#[Operation(operationId: …)]`), via the new `AddAttribute` fix primitive. (#382)
+- `--fix`/`--check` now detect same-node fix conflicts (apply the safe subset, skip + report the rest with a typed reason) and emit a frozen `--check --format=json` fix-run envelope for CI. (#22)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -156,12 +156,13 @@ would have emitted.
 ### Conflicting fixes
 
 When two fixes would touch the **same** code node (for example two rules that
-both rewrite the same attribute argument, or a removal an edit on the same
-attribute depends on), applying them together is unsafe. The fixer keeps the
-first of the conflicting set and **skips** the rest, reporting them rather than
-guessing — a skip is recoverable, a wrong edit is not. Re-run `--fix`: the
-skipped fix is re-emitted on the next pass and, with its conflictor already
-resolved, applies cleanly. The summary line reports `N skipped (conflict: N)`.
+both rewrite the same attribute argument, or a removal alongside another edit on
+the same member, where removing one attribute shifts the others), applying them
+together is unsafe. The fixer keeps the first of the conflicting set and
+**skips** the rest, reporting them rather than guessing — a skip is recoverable,
+a wrong edit is not. Re-run `--fix`: the skipped fix is re-emitted on the next
+pass and, with its conflictor already resolved, applies cleanly. The summary
+line reports `N skipped (conflict: N)`.
 
 ### Machine-readable fix runs (`--check --format=json`)
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -153,6 +153,41 @@ exists) and `operation.id-invalid-chars` (rewrites the operationId to the
 codegen-safe character set). Both produce exactly the operationId inference
 would have emitted.
 
+### Conflicting fixes
+
+When two fixes would touch the **same** code node (for example two rules that
+both rewrite the same attribute argument, or a removal an edit on the same
+attribute depends on), applying them together is unsafe. The fixer keeps the
+first of the conflicting set and **skips** the rest, reporting them rather than
+guessing — a skip is recoverable, a wrong edit is not. Re-run `--fix`: the
+skipped fix is re-emitted on the next pass and, with its conflictor already
+resolved, applies cleanly. The summary line reports `N skipped (conflict: N)`.
+
+### Machine-readable fix runs (`--check --format=json`)
+
+`--fix` / `--check` with `--format=json` emit a **stable fix-run envelope** for
+CI, distinct from the lint JSON (note the top-level `remaining`, not
+`findings`, so existing lint-JSON consumers are unaffected):
+
+```json
+{
+  "schema_version": "1",
+  "mode": "check",
+  "applied": 3,
+  "skipped": [
+    { "rule_id": "operation.id-invalid-chars", "file": "app/Http/Controllers/UserController.php", "reason": "conflict" }
+  ],
+  "modified_files": ["app/Http/Controllers/UserController.php"],
+  "remaining": [],
+  "exit_code": 1
+}
+```
+
+`mode` is `check` (dry run) or `fix`; `applied` counts the fixes applied (or, in
+`check` mode, that would apply); each `skipped` entry carries a `reason`
+(`conflict`, `node-not-found`, or `print-failed`); `remaining` holds the lint
+findings still unresolved, in the same shape the lint JSON uses.
+
 ## Documentation-coverage gate
 
 `openapi:lint` derives a **documentation-coverage** metric from its findings: the share of API

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -44,6 +44,7 @@ use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use UnexpectedValueException;
 
 use function array_filter;
+use function array_keys;
 use function array_map;
 use function array_values;
 use function count;
@@ -51,11 +52,18 @@ use function explode;
 use function fclose;
 use function fopen;
 use function getenv;
+use function implode;
 use function is_array;
 use function is_numeric;
 use function is_resource;
 use function is_string;
+use function json_encode;
+use function ksort;
 use function sprintf;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
 
 /**
  * Lints OpenAPI documentation gaps across the API surface.
@@ -248,19 +256,59 @@ class LintCommand extends Command
 
         $outcome = $fixRunner->run($options, $dryRun);
 
-        $this->renderFixSummary($outcome, $dryRun);
-
-        if ($outcome->remainingFindings !== []) {
-            $this->renderToTargets(
-                new LintResult(
-                    findings: $outcome->remainingFindings,
-                    level: $outcome->level,
-                    exitCode: $outcome->exitCode(),
-                ),
-            );
-        }
+        $this->renderFixOutcome($outcome);
 
         return $outcome->exitCode();
+    }
+
+    /**
+     * Renders the fix run to every requested target. A JSON target emits the frozen fix-run envelope
+     * ({@see FixRunResult::toArray()}); the human formats emit a one-line fixed/remaining/skipped
+     * summary plus the remaining findings through their normal formatter.
+     *
+     * @throws BindingResolutionException
+     * @throws InvalidArgumentException
+     * @throws JsonException
+     * @throws RuntimeException
+     */
+    private function renderFixOutcome(FixRunResult $outcome): void
+    {
+        $remaining = new LintResult(
+            findings: $outcome->remainingFindings,
+            level: $outcome->level,
+            exitCode: $outcome->exitCode(),
+        );
+
+        foreach ($this->resolveTargets() as $target) {
+            $output = $this->openOutput($target->target);
+
+            try {
+                if ($target->format === LinterOutputFormat::Json) {
+                    $output->writeln($this->encodeFixRun($outcome));
+
+                    continue;
+                }
+
+                $this->renderFixSummary($outcome, $target->format, $output);
+
+                if ($outcome->remainingFindings !== []) {
+                    $this->formatterFor($target->format)->render($remaining, $output);
+                }
+            } finally {
+                $this->closeOutput($output);
+            }
+        }
+    }
+
+    /**
+     * @throws JsonException
+     */
+    private function encodeFixRun(FixRunResult $outcome): string
+    {
+        return json_encode(
+            value: $outcome->toArray(),
+            flags: JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+        );
     }
 
     /**
@@ -417,45 +465,47 @@ class LintCommand extends Command
         return (int) $raw;
     }
 
-    private function renderFixSummary(FixRunResult $outcome, bool $dryRun): void
+    /**
+     * Writes a one-line fixed/remaining/skipped summary in the target's format. GitHub emits a
+     * workflow notice, Markdown a bullet, CLI plain prose; the skipped count is surfaced (with the
+     * conflict reason) so a re-run hint is actionable.
+     */
+    private function renderFixSummary(FixRunResult $outcome, LinterOutputFormat $format, OutputInterface $output): void
     {
-        $files = $outcome->fixResult->modifiedFiles;
-        $count = count($outcome->fixResult->applied);
+        $applied = count($outcome->fixResult->applied);
+        $remaining = count($outcome->remainingFindings);
+        $skipped = count($outcome->fixResult->skipped);
+        $verb = $outcome->dryRun ? 'pending' : 'fixed';
 
-        if ($count === 0) {
-            $this->info('openapi:lint --fix: nothing to fix.');
+        $summary = sprintf('openapi:lint --fix: %d %s, %d remaining, %d skipped', $applied, $verb, $remaining, $skipped);
 
-            return;
+        if ($skipped > 0) {
+            $summary .= sprintf(' (%s); re-run --fix to resolve conflicting fixes', $this->skipReasonBreakdown($outcome));
         }
 
-        if ($dryRun) {
-            $this->warn(
-                sprintf(
-                    '%d fixable finding(s) pending across %d file(s). Run `php artisan openapi:lint --fix` to apply them.',
-                    $count,
-                    count($files),
-                ),
-            );
+        $output->writeln(match ($format) {
+            LinterOutputFormat::GitHub => '::notice title=OpenAPI fix::' . $summary,
+            LinterOutputFormat::Markdown => '- ' . $summary,
+            default => $summary,
+        });
+    }
 
-            return;
+    /** A compact `reason: count` breakdown of skipped fixes, e.g. `conflict: 2, node-not-found: 1`. */
+    private function skipReasonBreakdown(FixRunResult $outcome): string
+    {
+        $counts = [];
+
+        foreach ($outcome->fixResult->skipped as $skip) {
+            $counts[$skip->reason->value] = ($counts[$skip->reason->value] ?? 0) + 1;
         }
 
-        $this->info(sprintf('Fixed %d finding(s) across %d file(s):', $count, count($files)));
+        ksort($counts);
 
-        foreach ($files as $file) {
-            $this->line('  ' . $file);
-        }
-
-        if ($outcome->fixResult->skipped !== []) {
-            $this->warn(
-                sprintf(
-                    '%d fix(es) skipped due to overlapping edits; re-run --fix to resolve the rest.',
-                    count($outcome->fixResult->skipped),
-                ),
-            );
-        }
-
-        $this->line('Run your formatter on the changes, e.g., `vendor/bin/pint --dirty`.');
+        return implode(', ', array_map(
+            static fn(string $reason, int $count): string => sprintf('%s: %d', $reason, $count),
+            array_keys($counts),
+            array_values($counts),
+        ));
     }
 
     /**

--- a/src/Lint/Fix/Ast/FixConflictDetector.php
+++ b/src/Lint/Fix/Ast/FixConflictDetector.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix\Ast;
+
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixSkipReason;
+use Radiergummi\OpenApi\Lint\Fix\SkippedFix;
+
+use function array_intersect;
+use function in_array;
+
+/**
+ * Partitions a batch of {@see Fix}es into a safe subset to apply and a conflicting subset to skip.
+ *
+ * Every fix's visitor runs in a single pass over one shared cloned tree, so two operations on the
+ * *same* node mutate it in sequence with no guard (silent last-wins, or one op acting on an index
+ * another shifted). This detector finds those same-node conflicts up front and keeps only a subset
+ * whose effects are provably independent.
+ *
+ * Grouping is by {@see TargetSelector} identity (`className` + `kind` + `memberName`): two different
+ * selectors can never address the same attribute-bearing node, so fixes in different groups never
+ * conflict. Within a group the rule is **first-in-list wins**: a fix is kept only when it is provably
+ * independent of every already-kept fix; otherwise it is skipped with {@see FixSkipReason::Conflict}.
+ * First-wins is deterministic and lets a re-run converge, the skipped op is re-emitted on the next
+ * lint pass with no surviving conflictor.
+ *
+ * @internal
+ */
+final readonly class FixConflictDetector
+{
+    /**
+     * @param list<Fix> $fixes
+     *
+     * @return array{kept: list<Fix>, skipped: list<SkippedFix>}
+     */
+    public function partition(array $fixes): array
+    {
+        /** @var array<string, list<Fix>> $byTarget */
+        $byTarget = [];
+
+        foreach ($fixes as $fix) {
+            $byTarget[$this->targetKey($fix)][] = $fix;
+        }
+
+        $kept = [];
+        $skipped = [];
+
+        foreach ($byTarget as $group) {
+            /** @var list<Fix> $groupKept */
+            $groupKept = [];
+
+            foreach ($group as $fix) {
+                $conflicts = false;
+
+                foreach ($groupKept as $keptFix) {
+                    if ($this->conflicts($keptFix, $fix)) {
+                        $conflicts = true;
+
+                        break;
+                    }
+                }
+
+                if ($conflicts) {
+                    $skipped[] = new SkippedFix($fix, FixSkipReason::Conflict);
+
+                    continue;
+                }
+
+                $groupKept[] = $fix;
+                $kept[] = $fix;
+            }
+        }
+
+        return ['kept' => $kept, 'skipped' => $skipped];
+    }
+
+    private function targetKey(Fix $fix): string
+    {
+        $target = $fix->operation->target;
+
+        return $target->className . "\0" . $target->kind->name . "\0" . ($target->memberName ?? '');
+    }
+
+    /**
+     * Whether two fixes on the *same* node cannot be safely applied together in one traversal.
+     *
+     * The op set is small and finite, so the matrix is enumerated explicitly. Bias toward
+     * correctness: when independence is not provable, treat the pair as conflicting (a skip is
+     * recoverable by re-running; a wrong mutation is not).
+     */
+    private function conflicts(Fix $a, Fix $b): bool
+    {
+        $first = $a->operation;
+        $second = $b->operation;
+
+        // An insertion prepends a new attribute group, shifting the flat index space every other
+        // attribute op resolves against, so it is never provably independent of another op here.
+        if ($first instanceof AddAttribute || $second instanceof AddAttribute) {
+            return true;
+        }
+
+        // Doc-comment edits touch a different node aspect (comments, not attrGroups), so they are
+        // independent of attribute ops; two doc-comment edits on one node both rewrite it.
+        if ($first instanceof SetDocComment || $second instanceof SetDocComment) {
+            return $first instanceof SetDocComment && $second instanceof SetDocComment;
+        }
+
+        if ($first instanceof RemoveAttribute && $second instanceof RemoveAttribute) {
+            return array_intersect($first->attributeIndices, $second->attributeIndices) !== [];
+        }
+
+        if ($first instanceof SetAttributeArgument && $second instanceof SetAttributeArgument) {
+            // Distinct attributes never collide; the same attribute collides only on the same argument
+            // (last-wins), distinct arguments add independent named args to that attribute.
+            return $first->attributeIndex === $second->attributeIndex
+                && $first->argumentName === $second->argumentName;
+        }
+
+        // The remaining pairs mix RemoveAttribute with SetAttributeArgument: a conflict iff the set
+        // operates on an index the remove drops (the survivor would mutate a shifted/absent attribute).
+        [$remove, $set] = $first instanceof RemoveAttribute
+            ? [$first, $second]
+            : [$second, $first];
+
+        return $remove instanceof RemoveAttribute
+            && $set instanceof SetAttributeArgument
+            && in_array($set->attributeIndex, $remove->attributeIndices, true);
+    }
+}

--- a/src/Lint/Fix/Ast/FixConflictDetector.php
+++ b/src/Lint/Fix/Ast/FixConflictDetector.php
@@ -8,9 +8,6 @@ use Radiergummi\OpenApi\Lint\Fix\Fix;
 use Radiergummi\OpenApi\Lint\Fix\FixSkipReason;
 use Radiergummi\OpenApi\Lint\Fix\SkippedFix;
 
-use function array_intersect;
-use function in_array;
-
 /**
  * Partitions a batch of {@see Fix}es into a safe subset to apply and a conflicting subset to skip.
  *
@@ -89,15 +86,20 @@ final readonly class FixConflictDetector
      * The op set is small and finite, so the matrix is enumerated explicitly. Bias toward
      * correctness: when independence is not provable, treat the pair as conflicting (a skip is
      * recoverable by re-running; a wrong mutation is not).
+     *
+     * Every kept op runs against the *same* progressively-mutated tree in one traversal, so an op
+     * that changes the member's attribute layout, inserting or removing an attribute group (which
+     * re-indexes the flat attribute list), invalidates the indices every later op resolves against.
+     * Both {@see AddAttribute} and {@see RemoveAttribute} are therefore treated as conflicting with
+     * any other op on the same node; a re-run converges because the skipped op is re-emitted next
+     * pass with fresh indices and no surviving layout-changer.
      */
     private function conflicts(Fix $a, Fix $b): bool
     {
         $first = $a->operation;
         $second = $b->operation;
 
-        // An insertion prepends a new attribute group, shifting the flat index space every other
-        // attribute op resolves against, so it is never provably independent of another op here.
-        if ($first instanceof AddAttribute || $second instanceof AddAttribute) {
+        if ($this->changesLayout($first) || $this->changesLayout($second)) {
             return true;
         }
 
@@ -107,25 +109,18 @@ final readonly class FixConflictDetector
             return $first instanceof SetDocComment && $second instanceof SetDocComment;
         }
 
-        if ($first instanceof RemoveAttribute && $second instanceof RemoveAttribute) {
-            return array_intersect($first->attributeIndices, $second->attributeIndices) !== [];
-        }
+        // The only remaining pair is SetAttributeArgument vs SetAttributeArgument (neither changes
+        // the layout): distinct attributes never collide; the same attribute collides only on the
+        // same argument (last-wins), distinct arguments add independent named args to it.
+        return $first instanceof SetAttributeArgument
+            && $second instanceof SetAttributeArgument
+            && $first->attributeIndex === $second->attributeIndex
+            && $first->argumentName === $second->argumentName;
+    }
 
-        if ($first instanceof SetAttributeArgument && $second instanceof SetAttributeArgument) {
-            // Distinct attributes never collide; the same attribute collides only on the same argument
-            // (last-wins), distinct arguments add independent named args to that attribute.
-            return $first->attributeIndex === $second->attributeIndex
-                && $first->argumentName === $second->argumentName;
-        }
-
-        // The remaining pairs mix RemoveAttribute with SetAttributeArgument: a conflict iff the set
-        // operates on an index the remove drops (the survivor would mutate a shifted/absent attribute).
-        [$remove, $set] = $first instanceof RemoveAttribute
-            ? [$first, $second]
-            : [$second, $first];
-
-        return $remove instanceof RemoveAttribute
-            && $set instanceof SetAttributeArgument
-            && in_array($set->attributeIndex, $remove->attributeIndices, true);
+    /** Whether the op inserts or removes an attribute group, re-indexing the flat attribute list. */
+    private function changesLayout(AstOperation $operation): bool
+    {
+        return $operation instanceof AddAttribute || $operation instanceof RemoveAttribute;
     }
 }

--- a/src/Lint/Fix/FixApplicator.php
+++ b/src/Lint/Fix/FixApplicator.php
@@ -11,10 +11,12 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
+use Radiergummi\OpenApi\Lint\Fix\Ast\FixConflictDetector;
 use Radiergummi\OpenApi\Lint\Fix\Ast\FixOperationVisitor;
 use RuntimeException;
 use Throwable;
 
+use function array_map;
 use function dirname;
 use function file_get_contents;
 use function file_put_contents;
@@ -38,10 +40,13 @@ final readonly class FixApplicator
 
     private Standard $printer;
 
+    private FixConflictDetector $conflictDetector;
+
     public function __construct()
     {
         $this->parser = new ParserFactory()->createForNewestSupportedVersion();
         $this->printer = new Standard();
+        $this->conflictDetector = new FixConflictDetector();
     }
 
     /**
@@ -63,16 +68,24 @@ final readonly class FixApplicator
         $modifiedFiles = [];
 
         foreach ($byFile as $file => $fileFixes) {
+            // Keep only fixes whose effects on a shared node are provably independent; the rest are
+            // skipped as conflicts before any mutation so a same-node clash never lands silently.
+            ['kept' => $kept, 'skipped' => $conflicts] = $this->conflictDetector->partition($fileFixes);
+
+            foreach ($conflicts as $conflict) {
+                $skipped[] = $conflict;
+            }
+
             $source = file_get_contents($file) ?: '';
 
-            [$accepted, $rejected, $newSource] = $this->applyToFile($source, $fileFixes);
+            [$accepted, $rejected, $newSource] = $this->applyToFile($source, $kept);
 
             foreach ($accepted as $fix) {
                 $applied[] = $fix;
             }
 
-            foreach ($rejected as $fix) {
-                $skipped[] = $fix;
+            foreach ($rejected as $skip) {
+                $skipped[] = $skip;
             }
 
             if ($accepted !== [] && $newSource !== $source) {
@@ -90,14 +103,14 @@ final readonly class FixApplicator
     /**
      * @param list<Fix> $fileFixes
      *
-     * @return array{list<Fix>, list<Fix>, string}
+     * @return array{list<Fix>, list<SkippedFix>, string}
      */
     private function applyToFile(string $source, array $fileFixes): array
     {
         $oldStatements = $this->parser->parse($source);
 
         if ($oldStatements === null) {
-            return [[], $fileFixes, $source];
+            return [[], $this->skipAll($fileFixes, FixSkipReason::NodeNotFound), $source];
         }
 
         $oldTokens = $this->parser->getTokens();
@@ -130,7 +143,7 @@ final readonly class FixApplicator
             if ($visitor->applied) {
                 $accepted[] = $fix;
             } else {
-                $rejected[] = $fix;
+                $rejected[] = new SkippedFix($fix, FixSkipReason::NodeNotFound);
             }
         }
 
@@ -143,10 +156,20 @@ final readonly class FixApplicator
         } catch (Throwable) {
             // A format-preserving print failure would otherwise reformat the whole file and destroy
             // comments/style. Reject the fixes instead of shipping a mangled file.
-            return [[], [...$rejected, ...$accepted], $source];
+            return [[], [...$rejected, ...$this->skipAll($accepted, FixSkipReason::PrintFailed)], $source];
         }
 
         return [$accepted, $rejected, $newSource];
+    }
+
+    /**
+     * @param list<Fix> $fixes
+     *
+     * @return list<SkippedFix>
+     */
+    private function skipAll(array $fixes, FixSkipReason $reason): array
+    {
+        return array_map(static fn(Fix $fix): SkippedFix => new SkippedFix($fix, $reason), $fixes);
     }
 
     /**

--- a/src/Lint/Fix/FixResult.php
+++ b/src/Lint/Fix/FixResult.php
@@ -8,7 +8,8 @@ namespace Radiergummi\OpenApi\Lint\Fix;
 /**
  * Outcome of a {@see FixApplicator::apply()} run.
  *
- * `$skipped` fixes were dropped due to overlap with an already-applied edit in the same file.
+ * Each entry in `$skipped` carries the typed reason it was not applied: a same-node conflict with a
+ * kept fix, a target node that could not be located, or a format-preserving print failure.
  */
 final class FixResult
 {
@@ -17,9 +18,9 @@ final class FixResult
     }
 
     /**
-     * @param list<Fix>    $applied
-     * @param list<Fix>    $skipped
-     * @param list<string> $modifiedFiles
+     * @param list<Fix>        $applied
+     * @param list<SkippedFix> $skipped
+     * @param list<string>     $modifiedFiles
      */
     public function __construct(
         public readonly array $applied,

--- a/src/Lint/Fix/FixRunResult.php
+++ b/src/Lint/Fix/FixRunResult.php
@@ -6,6 +6,9 @@ namespace Radiergummi\OpenApi\Lint\Fix;
 
 use Radiergummi\OpenApi\Lint\Finding;
 
+use function array_map;
+use function count;
+
 /**
  * Outcome of one {@see FixRunner::run()}: applied fixes, unresolved findings, and scope metadata.
  *
@@ -14,6 +17,9 @@ use Radiergummi\OpenApi\Lint\Finding;
  */
 final readonly class FixRunResult
 {
+    /** The fix-run JSON envelope schema version, bumped only on a breaking shape change. */
+    public const string SCHEMA_VERSION = '1';
+
     /**
      * @param list<Finding> $remainingFindings
      */
@@ -34,5 +40,41 @@ final readonly class FixRunResult
         }
 
         return $this->remainingFindings === [] ? 0 : 1;
+    }
+
+    /**
+     * The frozen fix-run JSON envelope. Distinct from the lint payload: it uses a top-level
+     * `remaining` key (not `findings`), so existing lint-JSON consumers are unaffected. The
+     * `remaining` entries reuse {@see Finding}'s `JsonSerializable` shape verbatim. This is the
+     * stable CI-facing contract for `--fix`/`--check`.
+     *
+     * @return array{
+     *     schema_version: string,
+     *     mode: 'check'|'fix',
+     *     applied: int,
+     *     skipped: list<array{rule_id: string, file: string, reason: string}>,
+     *     modified_files: list<string>,
+     *     remaining: list<Finding>,
+     *     exit_code: int
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'mode' => $this->dryRun ? 'check' : 'fix',
+            'applied' => count($this->fixResult->applied),
+            'skipped' => array_map(
+                static fn(SkippedFix $skipped): array => [
+                    'rule_id' => $skipped->fix->ruleId,
+                    'file' => $skipped->fix->file,
+                    'reason' => $skipped->reason->value,
+                ],
+                $this->fixResult->skipped,
+            ),
+            'modified_files' => $this->fixResult->modifiedFiles,
+            'remaining' => $this->remainingFindings,
+            'exit_code' => $this->exitCode(),
+        ];
     }
 }

--- a/src/Lint/Fix/FixSkipReason.php
+++ b/src/Lint/Fix/FixSkipReason.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+/**
+ * Why a {@see Fix} was not applied during a {@see FixApplicator::apply()} run.
+ *
+ * @internal
+ */
+enum FixSkipReason: string
+{
+    /** The operation's target node was not found in the parsed source (reflection/AST mismatch). */
+    case NodeNotFound = 'node-not-found';
+
+    /** The format-preserving print threw, so the whole file's batch was rejected to avoid mangling. */
+    case PrintFailed = 'print-failed';
+
+    /** Another fix on the same node was kept; this one was skipped to avoid an unsafe combined edit. */
+    case Conflict = 'conflict';
+}

--- a/src/Lint/Fix/SkippedFix.php
+++ b/src/Lint/Fix/SkippedFix.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+/**
+ * A {@see Fix} that {@see FixApplicator} did not apply, paired with the typed reason it was skipped.
+ *
+ * @internal
+ */
+final readonly class SkippedFix
+{
+    public function __construct(
+        public Fix $fix,
+        public FixSkipReason $reason,
+    ) {}
+}

--- a/tests/Feature/Lint/LintFixCommandTest.php
+++ b/tests/Feature/Lint/LintFixCommandTest.php
@@ -49,3 +49,53 @@ it('--fix removes the duplicate attribute and exits 0', function (): void {
         file_put_contents($file, $before);
     }
 });
+
+it('--check --format=json emits the frozen fix-run envelope, not the lint findings shape', function (): void {
+    $path = tempnam(sys_get_temp_dir(), 'openapi-fixrun-') . '.json';
+
+    try {
+        $this->artisan('openapi:lint', [
+            '--check' => true,
+            '--only' => 'link.duplicate-name',
+            '--uri' => 'lint-fixtures/fix-link*',
+            '--format' => "json:{$path}",
+        ])->assertExitCode(1);
+
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+
+        expect(array_keys($decoded))->toBe([
+            'schema_version', 'mode', 'applied', 'skipped', 'modified_files', 'remaining', 'exit_code',
+        ])
+            ->and($decoded)->not->toHaveKey('findings')
+            ->and($decoded['mode'])->toBe('check')
+            ->and($decoded['applied'])->toBe(1)
+            ->and($decoded['skipped'])->toBe([])
+            ->and($decoded['exit_code'])->toBe(1);
+    } finally {
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+});
+
+it('--check --format=github surfaces the fix-run summary as a workflow notice', function (): void {
+    $this->artisan('openapi:lint', [
+        '--check' => true,
+        '--only' => 'link.duplicate-name',
+        '--uri' => 'lint-fixtures/fix-link*',
+        '--format' => 'github',
+    ])
+        ->expectsOutputToContain('::notice title=OpenAPI fix::openapi:lint --fix: 1 pending')
+        ->assertExitCode(1);
+});
+
+it('--check --format=markdown surfaces the fix-run summary as a bullet', function (): void {
+    $this->artisan('openapi:lint', [
+        '--check' => true,
+        '--only' => 'link.duplicate-name',
+        '--uri' => 'lint-fixtures/fix-link*',
+        '--format' => 'markdown',
+    ])
+        ->expectsOutputToContain('- openapi:lint --fix: 1 pending')
+        ->assertExitCode(1);
+});

--- a/tests/Unit/Lint/Fix/FixApplicatorConflictTest.php
+++ b/tests/Unit/Lint/Fix/FixApplicatorConflictTest.php
@@ -136,3 +136,149 @@ it('reports a mechanical node-not-found skip distinctly from a conflict skip', f
         ->and($result->skipped)->toHaveCount(1)
         ->and($result->skipped[0]->reason)->toBe(FixSkipReason::NodeNotFound);
 });
+
+function removeIndexFix(string $file, int $index): Fix
+{
+    return new Fix(
+        $file,
+        'description',
+        'tag.duplicate',
+        new RemoveAttribute(
+            new TargetSelector('Conflict\\Fixture', TargetKind::Method, 'index'),
+            [$index],
+        ),
+    );
+}
+
+it('skips a Set that follows a Remove on the same member, leaving the operationId untouched, then applies it on re-run', function (): void {
+    // The shipped-fixer-reachable case: a duplicate #[Tag] removal (flat 0) plus an operationId set
+    // (flat 1). Applying both in one traversal would compact the list and the set would address the
+    // wrong attribute. The set must be skipped, not silently mutate the wrong node.
+    $source = <<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Tag('dup')]
+            #[Operation(operationId: 'bad id')]
+            public function index(): void {}
+        }
+
+        PHP;
+    $file = conflictFixtureFile($source);
+
+    $remove = removeIndexFix($file, 0);
+    $set = new Fix(
+        $file,
+        'description',
+        'operation.id-invalid-chars',
+        new SetAttributeArgument(
+            new TargetSelector('Conflict\\Fixture', TargetKind::Method, 'index'),
+            attributeIndex: 1,
+            argumentName: 'operationId',
+            value: 'fixed',
+        ),
+    );
+
+    $result = new FixApplicator()->apply([$remove, $set]);
+
+    expect(file_get_contents($file))->toBe(<<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Operation(operationId: 'bad id')]
+            public function index(): void {}
+        }
+
+        PHP)
+        ->and($result->applied)->toBe([$remove])
+        ->and($result->skipped)->toHaveCount(1)
+        ->and($result->skipped[0]->fix)->toBe($set)
+        ->and($result->skipped[0]->reason)->toBe(FixSkipReason::Conflict);
+
+    // The re-emitted set now resolves against the compacted layout (Operation at flat 0) and lands.
+    $reRun = new FixApplicator()->apply([
+        new Fix(
+            $file,
+            'description',
+            'operation.id-invalid-chars',
+            new SetAttributeArgument(
+                new TargetSelector('Conflict\\Fixture', TargetKind::Method, 'index'),
+                attributeIndex: 0,
+                argumentName: 'operationId',
+                value: 'fixed',
+            ),
+        ),
+    ]);
+
+    expect($reRun->applied)->toHaveCount(1)
+        ->and(file_get_contents($file))->toContain("#[Operation(operationId: 'fixed')]");
+});
+
+it('applies only the first of two disjoint Removes on one member, skips the second, then finishes on re-run', function (): void {
+    // Intent: drop A (flat 0) and C (flat 2), keep B and D. Run together, the first removal compacts
+    // the list so the second op's index 2 no longer points at C. The second must be skipped.
+    $source = <<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Tag('a')]
+            #[Tag('b')]
+            #[Tag('c')]
+            #[Tag('d')]
+            public function index(): void {}
+        }
+
+        PHP;
+    $file = conflictFixtureFile($source);
+
+    $removeA = removeIndexFix($file, 0);
+    $removeC = removeIndexFix($file, 2);
+
+    $result = new FixApplicator()->apply([$removeA, $removeC]);
+
+    expect(file_get_contents($file))->toBe(<<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Tag('b')]
+            #[Tag('c')]
+            #[Tag('d')]
+            public function index(): void {}
+        }
+
+        PHP)
+        ->and($result->applied)->toBe([$removeA])
+        ->and($result->skipped)->toHaveCount(1)
+        ->and($result->skipped[0]->fix)->toBe($removeC)
+        ->and($result->skipped[0]->reason)->toBe(FixSkipReason::Conflict);
+
+    // On the next pass C is now at flat index 1 (b, c, d); re-emitting its removal lands cleanly.
+    $reRun = new FixApplicator()->apply([removeIndexFix($file, 1)]);
+
+    expect($reRun->applied)->toHaveCount(1)
+        ->and(file_get_contents($file))->toBe(<<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Tag('b')]
+            #[Tag('d')]
+            public function index(): void {}
+        }
+
+        PHP);
+});

--- a/tests/Unit/Lint/Fix/FixApplicatorConflictTest.php
+++ b/tests/Unit/Lint/Fix/FixApplicatorConflictTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Fix\Ast\RemoveAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\SetAttributeArgument;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixApplicator;
+use Radiergummi\OpenApi\Lint\Fix\FixSkipReason;
+
+uses()->group('openapi', 'lint', 'fix');
+
+function conflictFixtureFile(string $contents): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'openapi-conflict-test-') ?: '';
+    file_put_contents($path, $contents);
+
+    return $path;
+}
+
+function setOperationIdFix(string $file, string $value): Fix
+{
+    return new Fix(
+        $file,
+        'description',
+        'operation.id-invalid-chars',
+        new SetAttributeArgument(
+            new TargetSelector('Conflict\\Fixture', TargetKind::Method, 'index'),
+            attributeIndex: 0,
+            argumentName: 'operationId',
+            value: $value,
+        ),
+    );
+}
+
+afterEach(function (): void {
+    foreach (glob(sys_get_temp_dir() . '/openapi-conflict-test-*') ?: [] as $leftover) {
+        @unlink($leftover);
+    }
+});
+
+it('applies the safe subset, skips the conflicting fix with a reason, and stays byte-stable', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Operation(operationId: 'bad id')]
+            public function index(): void {}
+        }
+
+        PHP;
+    $file = conflictFixtureFile($source);
+
+    $first = setOperationIdFix($file, 'first');
+    $second = setOperationIdFix($file, 'second');
+
+    $result = new FixApplicator()->apply([$first, $second]);
+
+    expect(file_get_contents($file))->toBe(<<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Operation(operationId: 'first')]
+            public function index(): void {}
+        }
+
+        PHP)
+        ->and($result->applied)->toBe([$first])
+        ->and($result->skipped)->toHaveCount(1)
+        ->and($result->skipped[0]->fix)->toBe($second)
+        ->and($result->skipped[0]->reason)->toBe(FixSkipReason::Conflict)
+        ->and($result->modifiedFiles)->toBe([$file]);
+});
+
+it('applies the previously-skipped fix on a subsequent run (progress on re-run)', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Operation(operationId: 'bad id')]
+            public function index(): void {}
+        }
+
+        PHP;
+    $file = conflictFixtureFile($source);
+
+    new FixApplicator()->apply([setOperationIdFix($file, 'first'), setOperationIdFix($file, 'second')]);
+
+    // The next lint pass re-emits only the still-needed fix; it now has no surviving conflictor.
+    $reRun = new FixApplicator()->apply([setOperationIdFix($file, 'second')]);
+
+    expect($reRun->applied)->toHaveCount(1)
+        ->and($reRun->skipped)->toBe([])
+        ->and(file_get_contents($file))->toContain("#[Operation(operationId: 'second')]");
+});
+
+it('reports a mechanical node-not-found skip distinctly from a conflict skip', function (): void {
+    $source = <<<'PHP'
+        <?php
+
+        namespace Conflict;
+
+        class Fixture
+        {
+            #[Operation(operationId: 'bad id')]
+            public function index(): void {}
+        }
+
+        PHP;
+    $file = conflictFixtureFile($source);
+
+    $missing = new Fix(
+        $file,
+        'description',
+        'operation.id-invalid-chars',
+        new RemoveAttribute(
+            new TargetSelector('Conflict\\Fixture', TargetKind::Method, 'absentMethod'),
+            [0],
+        ),
+    );
+
+    $result = new FixApplicator()->apply([$missing]);
+
+    expect($result->applied)->toBe([])
+        ->and($result->skipped)->toHaveCount(1)
+        ->and($result->skipped[0]->reason)->toBe(FixSkipReason::NodeNotFound);
+});

--- a/tests/Unit/Lint/Fix/FixConflictDetectorTest.php
+++ b/tests/Unit/Lint/Fix/FixConflictDetectorTest.php
@@ -57,29 +57,24 @@ it('skips a SetAttributeArgument that depends on an index a kept RemoveAttribute
         ->and($result['skipped'][0]->reason)->toBe(FixSkipReason::Conflict);
 });
 
-it('keeps a SetAttributeArgument on an index a RemoveAttribute does not touch', function (): void {
+it('skips a SetAttributeArgument even on an index a kept RemoveAttribute does not name', function (): void {
+    // A removal re-indexes the member's flat attribute list mid-traversal, so a later op's index is
+    // no longer trustworthy regardless of which indices the removal named. The set is skipped.
     $remove = detectorFix(new RemoveAttribute(methodTarget(), [1]));
     $set = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
 
     $result = new FixConflictDetector()->partition([$remove, $set]);
 
-    expect($result['kept'])->toBe([$remove, $set])
-        ->and($result['skipped'])->toBe([]);
+    expect($result['kept'])->toBe([$remove])
+        ->and($result['skipped'][0]->fix)->toBe($set)
+        ->and($result['skipped'][0]->reason)->toBe(FixSkipReason::Conflict);
 });
 
-it('keeps two RemoveAttribute with disjoint indices on one member', function (): void {
+it('skips the second of two RemoveAttribute on one member even with disjoint indices', function (): void {
+    // Disjoint indices are not independent across separate ops: the first removal compacts the list,
+    // so the second op's original indices then address shifted attributes. Keep first, skip the rest.
     $first = detectorFix(new RemoveAttribute(methodTarget(), [0, 1]));
     $second = detectorFix(new RemoveAttribute(methodTarget(), [2, 3]));
-
-    $result = new FixConflictDetector()->partition([$first, $second]);
-
-    expect($result['kept'])->toBe([$first, $second])
-        ->and($result['skipped'])->toBe([]);
-});
-
-it('skips the second of two RemoveAttribute with an overlapping index', function (): void {
-    $first = detectorFix(new RemoveAttribute(methodTarget(), [0, 1]));
-    $second = detectorFix(new RemoveAttribute(methodTarget(), [1, 2]));
 
     $result = new FixConflictDetector()->partition([$first, $second]);
 

--- a/tests/Unit/Lint/Fix/FixConflictDetectorTest.php
+++ b/tests/Unit/Lint/Fix/FixConflictDetectorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Fix\Ast\AddAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\AstOperation;
+use Radiergummi\OpenApi\Lint\Fix\Ast\FixConflictDetector;
+use Radiergummi\OpenApi\Lint\Fix\Ast\RemoveAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\SetAttributeArgument;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixSkipReason;
+
+uses()->group('openapi', 'lint', 'fix');
+
+function detectorFix(AstOperation $operation, string $file = '/app/Controller.php'): Fix
+{
+    return new Fix($file, 'desc', 'rule.id', $operation);
+}
+
+function methodTarget(string $member = 'index', string $class = 'App\\Controller'): TargetSelector
+{
+    return new TargetSelector($class, TargetKind::Method, $member);
+}
+
+it('keeps the first and skips the second of two SetAttributeArgument on the same attribute+argument', function (): void {
+    $first = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
+    $second = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'b'));
+
+    $result = new FixConflictDetector()->partition([$first, $second]);
+
+    expect($result['kept'])->toBe([$first])
+        ->and($result['skipped'])->toHaveCount(1)
+        ->and($result['skipped'][0]->fix)->toBe($second)
+        ->and($result['skipped'][0]->reason)->toBe(FixSkipReason::Conflict);
+});
+
+it('keeps two SetAttributeArgument on the same attribute but different arguments', function (): void {
+    $first = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
+    $second = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'summary', 'b'));
+
+    $result = new FixConflictDetector()->partition([$first, $second]);
+
+    expect($result['kept'])->toBe([$first, $second])
+        ->and($result['skipped'])->toBe([]);
+});
+
+it('skips a SetAttributeArgument that depends on an index a kept RemoveAttribute drops', function (): void {
+    $remove = detectorFix(new RemoveAttribute(methodTarget(), [0]));
+    $set = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
+
+    $result = new FixConflictDetector()->partition([$remove, $set]);
+
+    expect($result['kept'])->toBe([$remove])
+        ->and($result['skipped'][0]->fix)->toBe($set)
+        ->and($result['skipped'][0]->reason)->toBe(FixSkipReason::Conflict);
+});
+
+it('keeps a SetAttributeArgument on an index a RemoveAttribute does not touch', function (): void {
+    $remove = detectorFix(new RemoveAttribute(methodTarget(), [1]));
+    $set = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
+
+    $result = new FixConflictDetector()->partition([$remove, $set]);
+
+    expect($result['kept'])->toBe([$remove, $set])
+        ->and($result['skipped'])->toBe([]);
+});
+
+it('keeps two RemoveAttribute with disjoint indices on one member', function (): void {
+    $first = detectorFix(new RemoveAttribute(methodTarget(), [0, 1]));
+    $second = detectorFix(new RemoveAttribute(methodTarget(), [2, 3]));
+
+    $result = new FixConflictDetector()->partition([$first, $second]);
+
+    expect($result['kept'])->toBe([$first, $second])
+        ->and($result['skipped'])->toBe([]);
+});
+
+it('skips the second of two RemoveAttribute with an overlapping index', function (): void {
+    $first = detectorFix(new RemoveAttribute(methodTarget(), [0, 1]));
+    $second = detectorFix(new RemoveAttribute(methodTarget(), [1, 2]));
+
+    $result = new FixConflictDetector()->partition([$first, $second]);
+
+    expect($result['kept'])->toBe([$first])
+        ->and($result['skipped'][0]->fix)->toBe($second)
+        ->and($result['skipped'][0]->reason)->toBe(FixSkipReason::Conflict);
+});
+
+it('treats an AddAttribute as conflicting with any other op on the same node', function (): void {
+    $add = detectorFix(new AddAttribute(methodTarget(), 'App\\Attr', ['x' => 'y']));
+    $set = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
+
+    $result = new FixConflictDetector()->partition([$add, $set]);
+
+    expect($result['kept'])->toBe([$add])
+        ->and($result['skipped'][0]->fix)->toBe($set);
+});
+
+it('keeps ops on different members of the same class', function (): void {
+    $a = detectorFix(new SetAttributeArgument(methodTarget('show'), 0, 'operationId', 'a'));
+    $b = detectorFix(new SetAttributeArgument(methodTarget('store'), 0, 'operationId', 'b'));
+
+    $result = new FixConflictDetector()->partition([$a, $b]);
+
+    expect($result['kept'])->toBe([$a, $b])
+        ->and($result['skipped'])->toBe([]);
+});
+
+it('keeps ops on the same member name but different classes', function (): void {
+    $a = detectorFix(new SetAttributeArgument(methodTarget('index', 'App\\A'), 0, 'operationId', 'a'));
+    $b = detectorFix(new SetAttributeArgument(methodTarget('index', 'App\\B'), 0, 'operationId', 'b'));
+
+    $result = new FixConflictDetector()->partition([$a, $b]);
+
+    expect($result['kept'])->toBe([$a, $b]);
+});
+
+it('partitions deterministically: first-in-list always wins', function (): void {
+    $first = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'a'));
+    $second = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'b'));
+    $third = detectorFix(new SetAttributeArgument(methodTarget(), 0, 'operationId', 'c'));
+
+    $result = new FixConflictDetector()->partition([$first, $second, $third]);
+
+    expect($result['kept'])->toBe([$first])
+        ->and($result['skipped'])->toHaveCount(2)
+        ->and($result['skipped'][0]->fix)->toBe($second)
+        ->and($result['skipped'][1]->fix)->toBe($third);
+});

--- a/tests/Unit/Lint/Fix/FixRunResultTest.php
+++ b/tests/Unit/Lint/Fix/FixRunResultTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Contracts\Lint\Severity;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\Ast\RemoveAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixResult;
+use Radiergummi\OpenApi\Lint\Fix\FixRunResult;
+use Radiergummi\OpenApi\Lint\Fix\FixSkipReason;
+use Radiergummi\OpenApi\Lint\Fix\SkippedFix;
+
+uses()->group('openapi', 'lint', 'fix');
+
+function runResultFix(string $ruleId, string $file): Fix
+{
+    return new Fix(
+        $file,
+        'desc',
+        $ruleId,
+        new RemoveAttribute(new TargetSelector('App\\C', TargetKind::Method, 'index'), [0]),
+    );
+}
+
+function runResultFinding(string $ruleId): Finding
+{
+    return new Finding(ruleId: $ruleId, severity: Severity::Degraded, message: 'msg');
+}
+
+it('serializes the frozen fix-run envelope with the exact key set', function (): void {
+    $applied = [runResultFix('a.applied', '/app/A.php')];
+    $skipped = [new SkippedFix(runResultFix('b.skipped', '/app/B.php'), FixSkipReason::Conflict)];
+    $remaining = [runResultFinding('c.remaining')];
+
+    $outcome = new FixRunResult(
+        fixResult: new FixResult($applied, $skipped, ['/app/A.php']),
+        remainingFindings: $remaining,
+        level: 2,
+        dryRun: false,
+    );
+
+    $array = $outcome->toArray();
+
+    expect($array)->toHaveKeys([
+        'schema_version', 'mode', 'applied', 'skipped', 'modified_files', 'remaining', 'exit_code',
+    ])
+        ->and(array_keys($array))->toBe([
+            'schema_version', 'mode', 'applied', 'skipped', 'modified_files', 'remaining', 'exit_code',
+        ])
+        ->and($array['schema_version'])->toBe('1')
+        ->and($array['mode'])->toBe('fix')
+        ->and($array['applied'])->toBe(1)
+        ->and($array['skipped'])->toBe([
+            ['rule_id' => 'b.skipped', 'file' => '/app/B.php', 'reason' => 'conflict'],
+        ])
+        ->and($array['modified_files'])->toBe(['/app/A.php'])
+        ->and($array['remaining'])->toBe($remaining)
+        ->and($array['exit_code'])->toBe(1);
+});
+
+it('reports mode=check and a clean exit when nothing would be fixed', function (): void {
+    $outcome = new FixRunResult(
+        fixResult: new FixResult([], [], []),
+        remainingFindings: [],
+        level: 2,
+        dryRun: true,
+    );
+
+    $array = $outcome->toArray();
+
+    expect($array['mode'])->toBe('check')
+        ->and($array['applied'])->toBe(0)
+        ->and($array['skipped'])->toBe([])
+        ->and($array['modified_files'])->toBe([])
+        ->and($array['remaining'])->toBe([])
+        ->and($array['exit_code'])->toBe(0);
+});
+
+it('reports an all-skipped run: zero applied, skipped entries, finding stays remaining', function (): void {
+    $skipped = [
+        new SkippedFix(runResultFix('x', '/app/X.php'), FixSkipReason::Conflict),
+        new SkippedFix(runResultFix('x', '/app/X.php'), FixSkipReason::NodeNotFound),
+    ];
+
+    $outcome = new FixRunResult(
+        fixResult: new FixResult([], $skipped, []),
+        remainingFindings: [runResultFinding('x')],
+        level: 2,
+        dryRun: false,
+    );
+
+    $array = $outcome->toArray();
+
+    expect($array['applied'])->toBe(0)
+        ->and($array['skipped'])->toHaveCount(2)
+        ->and($array['skipped'][1]['reason'])->toBe('node-not-found')
+        ->and($array['exit_code'])->toBe(1);
+});
+
+it('is JSON-encodable to a stable shape (remaining reuses Finding json shape, not the lint findings key)', function (): void {
+    $outcome = new FixRunResult(
+        fixResult: new FixResult([], [], []),
+        remainingFindings: [runResultFinding('c.remaining')],
+        level: 2,
+        dryRun: false,
+    );
+
+    $decoded = json_decode(json_encode($outcome->toArray(), JSON_THROW_ON_ERROR), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($decoded)->not->toHaveKey('findings')
+        ->and($decoded['remaining'][0])->toHaveKeys(['rule_id', 'level', 'message']);
+});


### PR DESCRIPTION
Closes #22

## Implementation plan — #22 `lint --fix` Phase 3: AST-era conflict semantics + fix-run reporting

`<type>=feat` · area:lint + area:cli · tier-1 label on the issue, but this is **Fix-layer polish**,
not an inference measure — no body-scanning. Depends on #382 (merged @ `f13d1abd`: `AddAttribute` +
the two operationId fixers now exist).

> **Read the issue THROUGH its 2026-06-17 lead-reconciliation comment.** The body's central mechanic
> — "group fixes per file, apply **bottom-to-top** so earlier edits don't drift later line numbers" —
> is **DEAD** under #368's AST-mutation + `printFormatPreserving()` backend. There is no shared mutable
> offset space; each file is parsed once, cloned, mutated, and reprinted once. **No line arithmetic is
> planned.** Surviving, backend-agnostic scope only.

### What the code already does (verified on `main` @ f13d1abd)

So the plan targets real gaps, not work already shipped by #368/#382:

- `FixApplicator::apply()` already groups fixes by file, applies one `FixOperationVisitor` per fix on
  a cloned tree, reprints once, and writes atomically (FixApplicator.php:52-88).
- `FixResult` already carries `applied` / `skipped` / `modifiedFiles` (FixResult.php). Today a fix
  lands in `skipped` **only** when its visitor never matched a node (`$visitor->applied === false`) or
  the FP-print threw — i.e. *mechanical* failure, **not** a detected same-node conflict.
- `FixRunResult` already carries `fixResult` + `remainingFindings` + the `--check` dry-run exit-code
  logic (FixRunResult.php). `FixRunner` already maps applied fixes → resolved findings (FixRunner.php).
- `LintCommand::renderFixSummary()` already prints a human "N fix(es) skipped due to overlapping
  edits" line — but **only on the human `info`/`warn` channel**, never through the four formatters,
  and the remaining findings are rendered through formatters with **no fix-run envelope** at all
  (LintCommand.php:420-459, 253-261).
- A `--fix`/`--check` section **already exists** in `docs/linting.md` (lines 124-226).

### The two real gaps this PR closes

**Gap 1 — same-node conflict is not detected (the correctness gap).** `applyToFile()` registers every
fix's visitor on one traverser and runs them in registration order against the same cloned nodes
(FixApplicator.php:113-124). Two ops on the *same* node therefore mutate it in sequence with no guard:
- two `SetAttributeArgument` on the same `attributeIndex`+`argumentName` → silent last-wins;
- a `RemoveAttribute` dropping an index that a `SetAttributeArgument`/`AddAttribute`-modify on the same
  member depends on → the surviving op mutates a shifted/absent attribute.
Both are reported as `applied` today. Per the reconciliation comment: **detect, apply the safe subset,
skip the conflicting remainder, surface the skip.**

**Gap 2 — fix-run reporting/JSON schema.** The skipped dimension and the applied/remaining/skipped
envelope never reach the formatters; `--check --format=json` emits only the remaining `LintResult`
(JsonFormatter.php:42-57), so CI cannot read "what would be fixed / what was skipped" as data.

### Design

**1. Conflict detector — `src/Lint/Fix/Ast/FixConflictDetector.php` (new, `@internal`).**
A pure pre-apply pass, run by `FixApplicator::apply()` before `applyToFile()` (or inside it, per
file — confirm placement during coding; per-file is enough since cross-file ops never share a node).
- Group the file's fixes by their op's `TargetSelector` identity (`className` + `kind` + `memberName`
  — `TargetSelector.php`). Different nodes never conflict.
- Within a target group, partition into a **kept (safe)** subset and a **skipped (conflicting)** subset
  with a **deterministic, stable rule** (first-in-list wins, so re-running `--fix` makes progress):
  - Provably independent (all KEPT): multiple `RemoveAttribute` whose `attributeIndices` are pairwise
    disjoint (the visitor already removes descending and order-independently). A single op of any kind.
  - Conflicting (KEEP first, SKIP rest): two ops whose effects on the same node are not provably
    independent — same `attributeIndex` touched by more than one of {`SetAttributeArgument`,
    `RemoveAttribute`}; two `SetAttributeArgument` on the same `(attributeIndex, argumentName)`;
    an `AddAttribute` on a target another op also mutates (index space changes under insertion).
  - **The exact pair matrix is small and finite (4 op types); enumerate it explicitly in the detector
    with a comment, and pin it with unit tests.** Bias toward *correctness over coverage*: when in
    doubt, skip rather than risk a wrong mutation (skips are recoverable by re-running; corruption is
    not). Flag any pair the coder finds ambiguous for the reviewer rather than guessing.
- Return kept + skipped(with a reason string). `applyToFile()` then only registers kept visitors; the
  skipped fixes join `FixResult::$skipped`. **The `skipped` set thus gains a second source (detected
  conflict) alongside the existing mechanical one** — both already flow to the same field, so
  `FixRunner`'s remaining-findings logic needs no change (a finding whose fix was skipped stays
  unresolved, which is already the behaviour via `wasFixed()`).

**2. Carry a skip *reason*.** Today `skipped` is `list<Fix>` with no reason. Add a lightweight
`list<SkippedFix>` (`Fix` + `string $reason` enum/const: `node-not-found`, `print-failed`, `conflict`)
on `FixResult`, or keep `list<Fix>` and add a parallel reasons map — **decision:** introduce a small
`SkippedFix` readonly VO (`Fix $fix`, `FixSkipReason $reason` enum) for a typed, testable surface;
update the three existing skip sites in `FixApplicator` to tag their reason. Confirm this is the only
`FixResult` shape change. *(This is an internal `@internal` Fix-layer VO, not a public contract.)*

**3. Reporting across formatters.**
- **JSON (`--check`/`--fix --format=json`) — freeze the schema.** The fix run must emit a stable
  object, not just the remaining findings. Add a fix-run payload to `JsonFormatter` (the surgical
  route: `JsonFormatter` gains an optional fix-run section, or — cleaner — the command builds a
  dedicated fix-run JSON when `--fix/--check` + json, reusing `Finding`'s existing `JsonSerializable`).
  Frozen shape (bump `JsonFormatter::SCHEMA_VERSION` only if the lint shape itself changes; the fix
  envelope is additive):
  ```json
  {
    "schema_version": "1",
    "mode": "check" | "fix",
    "applied": <int>,
    "skipped": [ { "rule_id": "...", "file": "...", "reason": "conflict|node-not-found|print-failed" } ],
    "modified_files": [ "..." ],
    "remaining": [ <Finding>, ... ],
    "exit_code": <int>
  }
  ```
  Exact key names/casing to match the existing JSON formatter's snake_case convention (it uses
  `schema_version`, `exit_code`). **Decision to flag:** whether the fix-run JSON lives in
  `JsonFormatter` (fix-aware) or is assembled in the command. Recommend a small
  `FixRunResult::toArray()` / dedicated serializer so the shape is owned in one place and unit-testable
  without the console — flag for the reviewer.
- **Human formats (cli / github / markdown).** Extend the existing summary so all three surface
  fixed / remaining / **skipped(+reason)** consistently. The remaining findings already render through
  each formatter; add a one-line fix-run summary line per format (CLI already has the prose at
  LintCommand.php:443-456 — move/share it so github + markdown get the same line; github should emit
  the skip as a workflow notice/warning, markdown as a bullet). Keep it minimal — no per-format
  redesign.

### Tests (TDD — failing tests first)

Under `tests/Unit/Lint/Fix/` (fixtures under `tests/Fixtures/Lint/Fix/`):

- **`FixConflictDetectorTest`** (the heart):
  - two `SetAttributeArgument` on the same `(attributeIndex, argumentName)` on one node → first KEPT,
    second SKIPPED(`conflict`).
  - `RemoveAttribute[0]` + `SetAttributeArgument` on index 0, same member → the dependent op SKIPPED.
  - two `RemoveAttribute` with **disjoint** indices on one member → both KEPT (no false positive).
  - ops on **different** members of the same class → both KEPT.
  - ops in **different** files → untouched (detector is per-target).
  - determinism: the kept/skipped partition is stable across runs (first-wins).
- **`FixApplicatorConflictTest`** (golden, byte-stable): a fixture file with two findings that produce
  a same-node conflict → after `apply()`, the safe subset is written, output is **byte-stable** and
  Pint-clean, the skipped fix is returned with `reason: conflict`, and a **re-run applies the
  previously-skipped fix** (idempotent progress).
- **`--check --format=json` shape assertion** (`tests/Feature/Console/` or the existing lint-command
  test home — locate it): run `openapi:lint --check --format=json` against a fixture app with a mix of
  applied + skipped + remaining, assert the **exact** decoded array shape (all keys present, types,
  `skipped[].reason`, `exit_code`). Edge cases as separate assertions: **zero fixes** (empty applied,
  empty skipped, `exit_code` 0), **all-skipped** (applied 0, skipped non-empty), **mixed**.
- **Per-format summary**: assert cli/github/markdown each emit the fixed/remaining/skipped line
  (expectsOutput-style), including the github notice form and markdown bullet form.

### Docs & changelog

- `docs/linting.md` — the `--fix`/`--check` section already exists (lines 124-226). **Extend it**
  (do not add a new page): document the skipped-conflict behaviour ("conflicting fixes on the same
  node are skipped and reported; re-run `--fix` to apply them") and add the frozen
  `--check --format=json` schema as a fenced block. `docs/README.md` already indexes linting — no new
  index row needed (confirm during coding; add one only if a new page is created, which it should not
  be).
- `CHANGELOG.md` `[Unreleased]`: one line — `--fix`/`--check` now detect same-node fix conflicts
  (apply the safe subset, skip + report the rest) and emit a frozen `--check --format=json` fix-run
  schema. (#22)

### Controversy flags for the lead

- **area:lint + area:cli ⇒ no survey** (non-generation-affecting).
- **No `src/Contracts/**` change, no config key, no public CLI-signature change** — confirmed: the
  `--fix`/`--check`/`--format` flags already exist; new code is the `@internal` `FixConflictDetector`,
  an `@internal` `SkippedFix`/`FixSkipReason` VO, a `FixResult` field-shape change (internal), and a
  formatter/JSON additive section. **One judgement call to confirm at review:** the
  `--check --format=json` shape is a *de facto public contract for CI consumers* once frozen — that is
  the point of the issue, but it means the JSON key set is now load-bearing. Flag so the lead/reviewer
  treats the schema block + its test as the stable surface.
- **Size risk:** the conflict detector + skip-reason VO + per-formatter wiring + JSON envelope is
  likely **> ~150 src/ LOC**, above the fast-path mechanical threshold → expect a human merge gate.
  If the conflict pair-matrix turns out larger than the four-op enumeration suggests, it grows further.
- **Out-of-scope discoveries to surface (cannot `gh issue create` here):**
  - The github/markdown summary-line sharing may want a small shared "fix-run summary" renderer; if it
    becomes more than a few lines, that is a candidate refactor, not part of this issue.
  - `FixRunResult::toArray()` (if chosen) is the natural seam the next cluster item **#383**
    (`--fix=safe|dangerous`) will extend; note the boundary so #383 doesn't re-cut it.

---

### Reviewer addendum (plan-review, reviewer1)

Verified every load-bearing claim against `main` @ `f13d1abd`; all hold. Three tightenings folded in
(none change the design):

1. **Grouping key is provably correct — affirmed, not just flagged.** The lead's question "can two
   *different* `TargetSelector`s alias the same node?" → **no.** A `Method` target resolves to the
   `ClassMethod` (its own `attrGroups`); a `Property` target resolves to the `Property` statement
   **or** a promoted constructor `Param` (`FixOperationVisitor::findProperty`, properties-first, so it
   is deterministic). The promoted-param node is reachable **only** via `(class, Property, name)`,
   never via a `Method` selector — so *same attribute-bearing node ⟺ same `(className, kind,
   memberName)` identity*. Grouping by `TargetSelector` identity is sound; no aliasing gap. (Existing
   emitters confirm only `ClassNode`/`Method`/`Property` selectors are ever produced.)

2. **Reword the existing skip message — it still describes the dead byte-overlap model.**
   `LintCommand::renderFixSummary()` (LintCommand.php:449-456) prints *"N fix(es) skipped due to
   **overlapping edits**"* and `FixResult`'s docblock says *"dropped due to overlap with an
   already-applied edit"* (FixResult.php:11). Both predate the rescope and are now inaccurate under the
   AST-reprint backend. The reporting work **must** reword these to AST-era "same-node conflict"
   semantics (and the `FixResult` docblock once `SkippedFix`/`FixSkipReason` lands), so the message
   matches what actually happened. Add this to the per-formatter summary task.

3. **Pin the fix-run JSON as a distinct envelope; the lint `findings`/`summary` shape stays
   untouched.** Today `JsonFormatter` emits `{schema_version, level, exit_code, findings, summary
   (+coverage?)}` (JsonFormatter.php:42-57). The frozen fix-run object uses a top-level `remaining`
   key (not `findings`) — so it is a **separate envelope**, not the lint payload plus keys. State
   explicitly that existing lint-JSON consumers (reading `findings`/`summary`/`exit_code`) are
   unaffected, and that the fix-run `remaining[]` entries reuse `Finding`'s existing
   `JsonSerializable` shape verbatim. This resolves the planner's "lives in JsonFormatter vs assembled
   in command" decision in favour of the recommended one-place serializer (`FixRunResult::toArray()`),
   which is also the #383 seam.

**Gap 1 (correctness) confirmed at the code:** `applyToFile()` registers every fix's visitor on one
`NodeTraverser` and runs them in a single pass over the shared cloned tree (FixApplicator.php:113-124);
two ops on the same node both set `$visitor->applied = true` and both land in `accepted` (lines
129-135) with no guard. The detector is the minimal correct fix; there is no existing seam to reuse
(the per-fix visitor isolation that would otherwise catch this does not exist — they share one
traversal). First-wins is deterministic and a re-run converges because the skipped op is re-emitted by
its rule on the next lint pass and now has no surviving conflictor.

**Verdict: approved** with tightenings 2 and 3 to be honoured during coding (both are small, in-scope
wording/seam clarifications, not design changes). Proving tests, docs-extension (not a new page),
CHANGELOG, and the #383 seam note are all correctly specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
