### PR TITLE
feat(#383): --fix=safe|dangerous gate + FixSafety + clean-tree rail (mechanism only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project are documented here.
 - ApiResources: the return-expression reader now recognises the `X::collect(...)` static resource-collection factory, emitting the same collection response schema as `X::collection(...)`. (#390)
 - `openapi:lint --fix` now repairs missing and codegen-unsafe operationIds (synthesizes/sanitizes the `#[Operation(operationId: …)]`), via the new `AddAttribute` fix primitive. (#382)
 - `--fix`/`--check` now detect same-node fix conflicts (apply the safe subset, skip + report the rest with a typed reason) and emit a frozen `--check --format=json` fix-run envelope for CI. (#22)
+- `--fix`/`--check` now take an optional `safe|dangerous` level; destructive fixes are withheld from the default `--fix`, counted (`withheld_destructive` in the JSON envelope), and gated behind `--fix=dangerous` plus a clean working tree (`--allow-dirty` overrides). (#383)
 
 ### Changed
 - `spatie/laravel-data` is now a soft dependency (moved from `require` to `require-dev`); Fractal and query-builder packages are opt-in.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -164,6 +164,33 @@ a wrong edit is not. Re-run `--fix`: the skipped fix is re-emitted on the next
 pass and, with its conflictor already resolved, applies cleanly. The summary
 line reports `N skipped (conflict: N)`.
 
+### Safe vs destructive fixes (`--fix=safe|dangerous`)
+
+`--fix` and `--check` take an optional level, defaulting to `safe`:
+
+```bash
+php artisan openapi:lint --fix              # safe fixes only (default)
+php artisan openapi:lint --fix=safe         # same, explicit
+php artisan openapi:lint --fix=dangerous    # also apply destructive fixes
+```
+
+Most fixes are **safe**: they edit the source at, or tightly bound to, the
+finding site and are easy to eyeball. A **destructive** fix rewrites a file the
+developer hand-curates or writes far from the finding (for example regenerating
+`config/openapi.php`). Destructive fixes are **withheld** from a plain `--fix`,
+counted, and reported (`N finding(s) have potentially destructive fixes. Re-run
+with --fix=dangerous to apply them.`); the finding stays unresolved until you
+opt in. `--fix=dangerous` applies them too.
+
+Because a destructive write is harder to undo, `--fix=dangerous` first checks
+that its target files are clean and git-tracked, so an unwanted change reverts
+with `git checkout`. If a target file has uncommitted changes, is not in a git
+repository, or git is unavailable, the run **refuses** and names the files. Pass
+`--allow-dirty` to override the check.
+
+> No bundled rule emits destructive fixes yet; the level and the rail are the
+> mechanism that future config-writing fixers build on.
+
 ### Machine-readable fix runs (`--check --format=json`)
 
 `--fix` / `--check` with `--format=json` emit a **stable fix-run envelope** for
@@ -178,6 +205,7 @@ CI, distinct from the lint JSON (note the top-level `remaining`, not
   "skipped": [
     { "rule_id": "operation.id-invalid-chars", "file": "app/Http/Controllers/UserController.php", "reason": "conflict" }
   ],
+  "withheld_destructive": 0,
   "modified_files": ["app/Http/Controllers/UserController.php"],
   "remaining": [],
   "exit_code": 1
@@ -186,8 +214,9 @@ CI, distinct from the lint JSON (note the top-level `remaining`, not
 
 `mode` is `check` (dry run) or `fix`; `applied` counts the fixes applied (or, in
 `check` mode, that would apply); each `skipped` entry carries a `reason`
-(`conflict`, `node-not-found`, or `print-failed`); `remaining` holds the lint
-findings still unresolved, in the same shape the lint JSON uses.
+(`conflict`, `node-not-found`, or `print-failed`); `withheld_destructive` counts
+destructive fixes held back when running without `--fix=dangerous`; `remaining`
+holds the lint findings still unresolved, in the same shape the lint JSON uses.
 
 ## Documentation-coverage gate
 

--- a/src/Console/LintCommand.php
+++ b/src/Console/LintCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use InvalidArgumentException;
 use JsonException;
+use Override;
 use Radiergummi\OpenApi\Lint\DiffMode;
 use Radiergummi\OpenApi\Lint\DiffScope;
 use Radiergummi\OpenApi\Lint\Fix\FixRunner;
@@ -32,6 +33,8 @@ use Radiergummi\OpenApi\Lint\RuleRegistry;
 use ReflectionException;
 use RuntimeException;
 use Symfony\Component\Console\Exception\InvalidArgumentException as ConsoleInvalidArgumentException;
+use Symfony\Component\Console\Exception\LogicException as ConsoleLogicException;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -87,13 +90,44 @@ class LintCommand extends Command
         {--no-suppress : Ignore #[IgnoreLint] attributes}
         {--no-validate : Skip the OAS 3.1 meta-schema validation (the spec.invalid rule); faster on large specs}
         {--list : Print the rule catalog instead of linting}
-        {--fix : Apply fixable findings to the source, then report the rest}
-        {--check : Report whether --fix would change anything, without writing (CI-safe)}
+        {--allow-dirty : Allow destructive fixes (--fix=dangerous) to write to an unclean working tree}
         {--spec= : Restrict per-spec rules to this spec; pre-build rules still run}
         {--min-coverage= : Fail when documentation coverage % falls below this threshold (gate-driven exit)}
         {--max-findings= : Fail when the in-scope finding count exceeds this budget}';
 
     protected $description = 'Lint OpenAPI documentation gaps across the API surface';
+
+    /**
+     * Registers `--fix` / `--check` as value-optional options after the string signature is parsed.
+     *
+     * The Laravel string signature can only express `VALUE_NONE` or `VALUE_REQUIRED`; these need
+     * `VALUE_OPTIONAL` so bare `--fix` (level `safe`) and `--fix=dangerous` both parse. Done here,
+     * not via Laravel-13-only attributes, to stay portable across Laravel 12 and 13.
+     *
+     * @throws ConsoleInvalidArgumentException
+     * @throws ConsoleLogicException
+     */
+    #[Override]
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $definition = $this->getDefinition();
+        $definition->addOption(new InputOption(
+            'fix',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Apply fixable findings to the source, then report the rest (safe|dangerous)',
+            'safe',
+        ));
+        $definition->addOption(new InputOption(
+            'check',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Report whether --fix would change anything, without writing (safe|dangerous; CI-safe)',
+            'safe',
+        ));
+    }
 
     /**
      * @throws \LogicException
@@ -116,7 +150,9 @@ class LintCommand extends Command
             return $this->renderCatalog($registry);
         }
 
-        if ($this->option('fix') || $this->option('check')) {
+        // Detect fix-mode by option *presence*, not value: --fix/--check default to 'safe', so
+        // $this->option() is non-null even when the flag is absent.
+        if ($this->input->hasParameterOption('--fix') || $this->input->hasParameterOption('--check')) {
             return $this->runFix($fixRunner);
         }
 
@@ -244,7 +280,8 @@ class LintCommand extends Command
      */
     private function runFix(FixRunner $fixRunner): int
     {
-        $dryRun = (bool) $this->option('check');
+        $dryRun = $this->input->hasParameterOption('--check');
+        $applyDestructive = $this->resolveFixLevelIsDangerous($dryRun ? 'check' : 'fix');
         $options = $this->buildOptions();
 
         if ($options->minCoverage !== null || $options->maxFindings !== null) {
@@ -254,11 +291,37 @@ class LintCommand extends Command
             );
         }
 
-        $outcome = $fixRunner->run($options, $dryRun);
+        $outcome = $fixRunner->run(
+            $options,
+            $dryRun,
+            applyDestructive: $applyDestructive,
+            allowDirty: (bool) $this->option('allow-dirty'),
+        );
 
         $this->renderFixOutcome($outcome);
 
         return $outcome->exitCode();
+    }
+
+    /**
+     * Resolves the `--fix`/`--check` level to whether destructive fixes apply. Bare flag or `=safe`
+     * is safe; `=dangerous` opts in; anything else is a usage error.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function resolveFixLevelIsDangerous(string $option): bool
+    {
+        $value = $this->option($option);
+
+        return match ($value) {
+            'safe', null, true => false,
+            'dangerous' => true,
+            default => throw new InvalidArgumentException(sprintf(
+                "Unknown --%s level '%s'. Expected 'safe' or 'dangerous'.",
+                $option,
+                is_string($value) ? $value : '',
+            )),
+        };
     }
 
     /**
@@ -483,11 +546,26 @@ class LintCommand extends Command
             $summary .= sprintf(' (%s); re-run --fix to resolve conflicting fixes', $this->skipReasonBreakdown($outcome));
         }
 
-        $output->writeln(match ($format) {
+        $output->writeln($this->formatSummaryLine($summary, $format));
+
+        if ($outcome->withheldDestructiveCount > 0) {
+            $output->writeln($this->formatSummaryLine(
+                sprintf(
+                    '%d finding(s) have potentially destructive fixes. Re-run with --fix=dangerous to apply them.',
+                    $outcome->withheldDestructiveCount,
+                ),
+                $format,
+            ));
+        }
+    }
+
+    private function formatSummaryLine(string $summary, LinterOutputFormat $format): string
+    {
+        return match ($format) {
             LinterOutputFormat::GitHub => '::notice title=OpenAPI fix::' . $summary,
             LinterOutputFormat::Markdown => '- ' . $summary,
             default => $summary,
-        });
+        };
     }
 
     /** A compact `reason: count` breakdown of skipped fixes, e.g. `conflict: 2, node-not-found: 1`. */

--- a/src/Lint/Fix/DirtyWorkingTreeException.php
+++ b/src/Lint/Fix/DirtyWorkingTreeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+use RuntimeException;
+
+/**
+ * Thrown when destructive fixes would write to files that are not in a clean, git-tracked state, so
+ * the changes could not be trivially reverted. Pass `--allow-dirty` to override.
+ *
+ * @internal
+ */
+final class DirtyWorkingTreeException extends RuntimeException {}

--- a/src/Lint/Fix/Fix.php
+++ b/src/Lint/Fix/Fix.php
@@ -12,6 +12,11 @@ use Radiergummi\OpenApi\Lint\Fix\Ast\AstOperation;
  * rule, and the mechanical change as an {@see AstOperation} (a node mutation reprinted with the
  * format-preserving printer). A fixer may emit several `Fix`es per finding; {@see FixApplicator}
  * groups them by file and applies them.
+ *
+ * `$safety` defaults to {@see FixSafety::Safe}: every fixer constructs `Fix` positionally without
+ * it, so all current behaviour is unchanged. A fixer marks a `Fix` {@see FixSafety::Destructive}
+ * when it rewrites hand-curated files or writes far from the finding; such fixes are withheld from
+ * a plain `--fix`.
  */
 final readonly class Fix
 {
@@ -20,5 +25,6 @@ final readonly class Fix
         public string $description,
         public string $ruleId,
         public AstOperation $operation,
+        public FixSafety $safety = FixSafety::Safe,
     ) {}
 }

--- a/src/Lint/Fix/FixRunResult.php
+++ b/src/Lint/Fix/FixRunResult.php
@@ -22,12 +22,16 @@ final readonly class FixRunResult
 
     /**
      * @param list<Finding> $remainingFindings
+     * @param int           $withheldDestructiveCount Fixes gated behind `--fix=dangerous` that were
+     *                                                not applied this run (their findings stay in
+     *                                                `$remainingFindings`).
      */
     public function __construct(
         public FixResult $fixResult,
         public array $remainingFindings,
         public int $level,
         public bool $dryRun,
+        public int $withheldDestructiveCount = 0,
     ) {}
 
     /**
@@ -53,6 +57,7 @@ final readonly class FixRunResult
      *     mode: 'check'|'fix',
      *     applied: int,
      *     skipped: list<array{rule_id: string, file: string, reason: string}>,
+     *     withheld_destructive: int,
      *     modified_files: list<string>,
      *     remaining: list<Finding>,
      *     exit_code: int
@@ -72,6 +77,7 @@ final readonly class FixRunResult
                 ],
                 $this->fixResult->skipped,
             ),
+            'withheld_destructive' => $this->withheldDestructiveCount,
             'modified_files' => $this->fixResult->modifiedFiles,
             'remaining' => $this->remainingFindings,
             'exit_code' => $this->exitCode(),

--- a/src/Lint/Fix/FixRunner.php
+++ b/src/Lint/Fix/FixRunner.php
@@ -15,6 +15,7 @@ use Radiergummi\OpenApi\Lint\RuleRegistry;
 use ReflectionException;
 use RuntimeException;
 
+use function array_keys;
 use function spl_object_id;
 
 /**
@@ -32,24 +33,37 @@ final readonly class FixRunner
         private LintRunner $linter,
         private RuleRegistry $registry,
         private FixApplicator $applicator,
+        private WorkingTreeGuard $workingTreeGuard = new WorkingTreeGuard(),
     ) {}
 
     /**
+     * @param bool $applyDestructive Apply {@see FixSafety::Destructive} fixes too (`--fix=dangerous`);
+     *                               when false they are withheld and counted.
+     * @param bool $allowDirty       Skip the clean-working-tree rail that otherwise gates destructive
+     *                               writes (`--allow-dirty`).
+     *
      * @throws BindingResolutionException
+     * @throws DirtyWorkingTreeException  When destructive fixes would write to a dirty/non-git tree
+     *                                    and `--allow-dirty` was not given.
      * @throws InvalidArgumentException
      * @throws LogicException
      * @throws ReflectionException
      * @throws RuntimeException
      */
-    public function run(LintOptions $options, bool $dryRun): FixRunResult
-    {
+    public function run(
+        LintOptions $options,
+        bool $dryRun,
+        bool $applyDestructive = false,
+        bool $allowDirty = false,
+    ): FixRunResult {
         $lint = $this->linter->run($options);
         $fixers = $this->fixers();
         $context = new FixContext();
 
         /** @var list<array{finding: Finding, fixes: list<Fix>}> $planned */
         $planned = [];
-        $allFixes = [];
+        $applicable = [];
+        $withheldDestructiveCount = 0;
 
         foreach ($lint->findings as $finding) {
             $fixes = [];
@@ -58,14 +72,26 @@ final readonly class FixRunner
             if ($fixer !== null) {
                 foreach ($fixer->fix($finding, $context) as $fix) {
                     $fixes[] = $fix;
-                    $allFixes[] = $fix;
+
+                    if ($fix->safety === FixSafety::Destructive && !$applyDestructive) {
+                        $withheldDestructiveCount++;
+
+                        continue;
+                    }
+
+                    $applicable[] = $fix;
                 }
             }
 
             $planned[] = ['finding' => $finding, 'fixes' => $fixes];
         }
 
-        $fixResult = $this->applicator->apply($allFixes, $dryRun);
+        // The clean-tree rail only guards destructive writes; a safe-only run never touches git.
+        if (!$dryRun && $applyDestructive) {
+            $this->workingTreeGuard->assertClean($this->destructiveTargetFiles($applicable), $allowDirty);
+        }
+
+        $fixResult = $this->applicator->apply($applicable, $dryRun);
 
         $appliedIds = [];
 
@@ -75,13 +101,33 @@ final readonly class FixRunner
 
         $remaining = [];
 
+        // A finding whose only fix was withheld stays here: the source is genuinely unchanged, so it
+        // is both an unresolved gap and counted as withheld, never dropped from the remaining set.
         foreach ($planned as $entry) {
             if (!$this->wasFixed($entry['fixes'], $appliedIds)) {
                 $remaining[] = $entry['finding'];
             }
         }
 
-        return new FixRunResult($fixResult, $remaining, $lint->level, $dryRun);
+        return new FixRunResult($fixResult, $remaining, $lint->level, $dryRun, $withheldDestructiveCount);
+    }
+
+    /**
+     * @param list<Fix> $applicable
+     *
+     * @return list<string>
+     */
+    private function destructiveTargetFiles(array $applicable): array
+    {
+        $files = [];
+
+        foreach ($applicable as $fix) {
+            if ($fix->safety === FixSafety::Destructive) {
+                $files[$fix->file] = true;
+            }
+        }
+
+        return array_keys($files);
     }
 
     /**

--- a/src/Lint/Fix/FixSafety.php
+++ b/src/Lint/Fix/FixSafety.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+/**
+ * How risky applying a {@see Fix} is.
+ *
+ * `Safe` fixes mutate the source at, or tightly bound to, the finding site and are easy to eyeball
+ * (the default for every fixer). `Destructive` fixes touch files a developer hand-curates or write
+ * far from the finding (e.g. rewriting `config/openapi.php`); they are withheld from a plain
+ * `--fix` and only applied under `--fix=dangerous` against a clean working tree.
+ *
+ * @internal
+ */
+enum FixSafety
+{
+    case Safe;
+
+    case Destructive;
+}

--- a/src/Lint/Fix/WorkingTreeGuard.php
+++ b/src/Lint/Fix/WorkingTreeGuard.php
@@ -12,10 +12,8 @@ use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
 
 use function dirname;
-use function explode;
 use function implode;
 use function sprintf;
-use function substr;
 use function trim;
 
 /**
@@ -27,6 +25,11 @@ use function trim;
  */
 final readonly class WorkingTreeGuard
 {
+    /** @param string $gitBinary The git executable; overridable so tests can force a launch failure. */
+    public function __construct(
+        private string $gitBinary = 'git',
+    ) {}
+
     /**
      * Asserts every target file is clean in git, or throws {@see DirtyWorkingTreeException}.
      *
@@ -48,53 +51,38 @@ final readonly class WorkingTreeGuard
             return;
         }
 
-        $process = new Process(['git', 'status', '--porcelain', '--', ...$files], dirname($files[0]));
+        $process = new Process([$this->gitBinary, 'status', '--porcelain', '--', ...$files], dirname($files[0]));
 
         try {
             $process->run();
         } catch (ProcessStartFailedException) {
-            throw new DirtyWorkingTreeException(
-                'Cannot verify a clean working tree because git is unavailable. Re-run with '
-                . '--allow-dirty to apply destructive fixes anyway.',
-            );
+            // Some platforms surface a launch failure as a thrown exception rather than a non-zero
+            // exit; both mean git could not verify the tree, so both refuse.
+            throw $this->cannotVerify();
         }
 
+        // git absent (exit 127, run via a shell) and not-a-repo (exit 128) both arrive here as a
+        // non-zero exit. Neither can promise a trivial revert, so refuse with one honest message.
         if (!$process->isSuccessful()) {
-            throw new DirtyWorkingTreeException(
-                'Cannot verify a clean working tree because the target files are not in a git '
-                . 'repository. Re-run with --allow-dirty to apply destructive fixes anyway.',
-            );
+            throw $this->cannotVerify();
         }
 
-        $dirty = $this->dirtyPaths($process->getOutput());
-
-        if ($dirty !== []) {
+        // Any porcelain output for the explicitly-scoped paths means at least one is dirty. Report
+        // the files we checked rather than parsing porcelain paths (quoting/rename rules vary).
+        if (trim($process->getOutput()) !== '') {
             throw new DirtyWorkingTreeException(sprintf(
                 'Refusing to apply destructive fixes: uncommitted changes in %s. Commit or stash '
                 . 'them, or re-run with --allow-dirty.',
-                implode(', ', $dirty),
+                implode(', ', $files),
             ));
         }
     }
 
-    /**
-     * The paths reported dirty by `git status --porcelain` (each line is `XY <path>`).
-     *
-     * @return list<string>
-     */
-    private function dirtyPaths(string $output): array
+    private function cannotVerify(): DirtyWorkingTreeException
     {
-        $paths = [];
-
-        foreach (explode("\n", trim($output)) as $line) {
-            if ($line === '') {
-                continue;
-            }
-
-            // Porcelain v1: two status columns, a space, then the path; drop the 3-char prefix.
-            $paths[] = trim(substr($line, 3));
-        }
-
-        return $paths;
+        return new DirtyWorkingTreeException(
+            'Cannot verify a clean working tree (git is unavailable or the target files are not in '
+            . 'a git repository). Re-run with --allow-dirty to apply destructive fixes anyway.',
+        );
     }
 }

--- a/src/Lint/Fix/WorkingTreeGuard.php
+++ b/src/Lint/Fix/WorkingTreeGuard.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Fix;
+
+use Symfony\Component\Process\Exception\LogicException;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Exception\ProcessStartFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+use function dirname;
+use function explode;
+use function implode;
+use function sprintf;
+use function substr;
+use function trim;
+
+/**
+ * Refuses to apply destructive fixes unless their target files are clean and git-tracked, so an
+ * unwanted change can be reverted with `git checkout`. The safe-only path never calls this, so the
+ * common run carries no git dependency or overhead.
+ *
+ * @internal
+ */
+final readonly class WorkingTreeGuard
+{
+    /**
+     * Asserts every target file is clean in git, or throws {@see DirtyWorkingTreeException}.
+     *
+     * `$allowDirty` (the `--allow-dirty` flag) skips the check entirely. With no target files there
+     * is nothing destructive to guard. Two git failure modes both refuse, since neither can promise
+     * a trivial revert: git is unavailable (the binary cannot launch) or the path is not a repo.
+     *
+     * @param list<string> $files
+     *
+     * @throws DirtyWorkingTreeException
+     * @throws LogicException
+     * @throws ProcessSignaledException
+     * @throws ProcessTimedOutException
+     * @throws RuntimeException
+     */
+    public function assertClean(array $files, bool $allowDirty): void
+    {
+        if ($allowDirty || $files === []) {
+            return;
+        }
+
+        $process = new Process(['git', 'status', '--porcelain', '--', ...$files], dirname($files[0]));
+
+        try {
+            $process->run();
+        } catch (ProcessStartFailedException) {
+            throw new DirtyWorkingTreeException(
+                'Cannot verify a clean working tree because git is unavailable. Re-run with '
+                . '--allow-dirty to apply destructive fixes anyway.',
+            );
+        }
+
+        if (!$process->isSuccessful()) {
+            throw new DirtyWorkingTreeException(
+                'Cannot verify a clean working tree because the target files are not in a git '
+                . 'repository. Re-run with --allow-dirty to apply destructive fixes anyway.',
+            );
+        }
+
+        $dirty = $this->dirtyPaths($process->getOutput());
+
+        if ($dirty !== []) {
+            throw new DirtyWorkingTreeException(sprintf(
+                'Refusing to apply destructive fixes: uncommitted changes in %s. Commit or stash '
+                . 'them, or re-run with --allow-dirty.',
+                implode(', ', $dirty),
+            ));
+        }
+    }
+
+    /**
+     * The paths reported dirty by `git status --porcelain` (each line is `XY <path>`).
+     *
+     * @return list<string>
+     */
+    private function dirtyPaths(string $output): array
+    {
+        $paths = [];
+
+        foreach (explode("\n", trim($output)) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            // Porcelain v1: two status columns, a space, then the path; drop the 3-char prefix.
+            $paths[] = trim(substr($line, 3));
+        }
+
+        return $paths;
+    }
+}

--- a/tests/Feature/Lint/FixRunnerPartitionTest.php
+++ b/tests/Feature/Lint/FixRunnerPartitionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Contracts\Lint\Severity;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\Fix\Ast\RemoveAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixableRule;
+use Radiergummi\OpenApi\Lint\Fix\FixContext;
+use Radiergummi\OpenApi\Lint\Fix\Fixer;
+use Radiergummi\OpenApi\Lint\Fix\FixRunner;
+use Radiergummi\OpenApi\Lint\Fix\FixSafety;
+use Radiergummi\OpenApi\Lint\LintContext;
+use Radiergummi\OpenApi\Lint\LintOptions;
+use Radiergummi\OpenApi\Lint\RuleRegistry;
+use Radiergummi\OpenApi\Lint\Tree\OperationNode;
+use Radiergummi\OpenApi\Lint\Visitors\OperationRule;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\FixCommandLinkController;
+
+uses()->group('openapi', 'lint', 'fix');
+
+/**
+ * The Destructive tier has no production producers yet (#199 ships the first), so the runner's
+ * partition is exercised by binding a synthetic rule that emits one FixSafety::Destructive fix.
+ * The fix targets an absent member, so the applicator never mutates a real file: this test is about
+ * partition accounting, not file IO.
+ */
+function bindSyntheticDestructiveRule(): void
+{
+    $rule = new class () implements FixableRule, OperationRule {
+        public function checkOperation(OperationNode $operation, LintContext $context): iterable
+        {
+            yield new Finding(ruleId: $this->id(), severity: Severity::Degraded, message: 'synthetic');
+        }
+
+        public function id(): string
+        {
+            return 'synthetic.destructive';
+        }
+
+        public function severity(): Severity
+        {
+            return Severity::Degraded;
+        }
+
+        public function description(): string
+        {
+            return 'synthetic destructive rule';
+        }
+
+        public function fixer(): Fixer
+        {
+            // Target a real, readable file but an absent member, so even when this destructive fix
+            // reaches the applicator it is a node-not-found no-op (never mutates the fixture).
+            $file = new ReflectionClass(FixCommandLinkController::class)->getFileName() ?: '';
+
+            return new class ($file) implements Fixer {
+                public function __construct(private string $file) {}
+
+                public function fix(Finding $finding, FixContext $context): iterable
+                {
+                    yield new Fix(
+                        $this->file,
+                        'synthetic destructive',
+                        $finding->ruleId,
+                        new RemoveAttribute(
+                            new TargetSelector(FixCommandLinkController::class, TargetKind::Method, 'absent'),
+                            [0],
+                        ),
+                        FixSafety::Destructive,
+                    );
+                }
+            };
+        }
+    };
+
+    app()->instance(RuleRegistry::class, new RuleRegistry([$rule]));
+}
+
+beforeEach(function (): void {
+    Route::get('partition/route', [FixCommandLinkController::class, 'index']);
+    bindSyntheticDestructiveRule();
+});
+
+it('withholds a destructive fix under --fix=safe and keeps its finding in remaining', function (): void {
+    $outcome = app(FixRunner::class)->run(new LintOptions(level: 2), dryRun: false, applyDestructive: false);
+
+    expect($outcome->withheldDestructiveCount)->toBeGreaterThan(0)
+        ->and($outcome->fixResult->applied)->toBe([])
+        // Tightening 3: a withheld-only finding is counted AND remains an unresolved gap.
+        ->and($outcome->remainingFindings)->not->toBeEmpty()
+        ->and($outcome->remainingFindings[0]->ruleId)->toBe('synthetic.destructive');
+});
+
+it('routes destructive fixes to the applicator under --fix=dangerous (none withheld)', function (): void {
+    // dryRun avoids the working-tree guard and any real write; we assert only the partition routing.
+    $outcome = app(FixRunner::class)->run(new LintOptions(level: 2), dryRun: true, applyDestructive: true);
+
+    expect($outcome->withheldDestructiveCount)->toBe(0);
+});

--- a/tests/Feature/Lint/LintFixCommandTest.php
+++ b/tests/Feature/Lint/LintFixCommandTest.php
@@ -64,12 +64,13 @@ it('--check --format=json emits the frozen fix-run envelope, not the lint findin
         $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
 
         expect(array_keys($decoded))->toBe([
-            'schema_version', 'mode', 'applied', 'skipped', 'modified_files', 'remaining', 'exit_code',
+            'schema_version', 'mode', 'applied', 'skipped', 'withheld_destructive', 'modified_files', 'remaining', 'exit_code',
         ])
             ->and($decoded)->not->toHaveKey('findings')
             ->and($decoded['mode'])->toBe('check')
             ->and($decoded['applied'])->toBe(1)
             ->and($decoded['skipped'])->toBe([])
+            ->and($decoded['withheld_destructive'])->toBe(0)
             ->and($decoded['exit_code'])->toBe(1);
     } finally {
         if (file_exists($path)) {

--- a/tests/Feature/Lint/LintFixCommandTest.php
+++ b/tests/Feature/Lint/LintFixCommandTest.php
@@ -100,3 +100,48 @@ it('--check --format=markdown surfaces the fix-run summary as a bullet', functio
         ->expectsOutputToContain('- openapi:lint --fix: 1 pending')
         ->assertExitCode(1);
 });
+
+it('treats a bare --check as the safe level (no error, fix-mode runs)', function (): void {
+    // VALUE_OPTIONAL regression guard: a bare flag resolves to the default 'safe' and must not error.
+    $this->artisan('openapi:lint', [
+        '--check' => true,
+        '--only' => 'link.duplicate-name',
+        '--uri' => 'lint-fixtures/fix-link*',
+        '--format' => 'markdown',
+    ])
+        ->expectsOutputToContain('- openapi:lint --fix: 1 pending')
+        ->assertExitCode(1);
+});
+
+it('does not enter fix-mode when neither --fix nor --check is present', function (): void {
+    // The OPTIONAL default ('safe') must not be mistaken for the flag being set: a plain lint runs
+    // (the finding is reported normally, exit 1), with no fix-run summary line emitted.
+    $this->artisan('openapi:lint', [
+        '--only' => 'link.duplicate-name',
+        '--uri' => 'lint-fixtures/fix-link*',
+        '--format' => 'markdown',
+    ])
+        ->doesntExpectOutputToContain('openapi:lint --fix:')
+        ->assertExitCode(1);
+});
+
+it('accepts --check=dangerous without error', function (): void {
+    $this->artisan('openapi:lint', [
+        '--check' => 'dangerous',
+        '--only' => 'link.duplicate-name',
+        '--uri' => 'lint-fixtures/fix-link*',
+        '--format' => 'markdown',
+    ])
+        ->expectsOutputToContain('- openapi:lint --fix: 1 pending')
+        ->assertExitCode(1);
+});
+
+it('errors clearly on an unknown --check level', function (): void {
+    // The artisan harness propagates the thrown InvalidArgumentException rather than converting it
+    // to an exit code, so assert on the throw directly (mirrors the --min-coverage validation test).
+    expect(fn(): int => $this->artisan('openapi:lint', [
+        '--check' => 'bogus',
+        '--only' => 'link.duplicate-name',
+        '--uri' => 'lint-fixtures/fix-link*',
+    ])->run())->toThrow(InvalidArgumentException::class, "Unknown --check level 'bogus'. Expected 'safe' or 'dangerous'.");
+});

--- a/tests/Unit/Lint/Fix/FixRunResultTest.php
+++ b/tests/Unit/Lint/Fix/FixRunResultTest.php
@@ -45,10 +45,10 @@ it('serializes the frozen fix-run envelope with the exact key set', function ():
     $array = $outcome->toArray();
 
     expect($array)->toHaveKeys([
-        'schema_version', 'mode', 'applied', 'skipped', 'modified_files', 'remaining', 'exit_code',
+        'schema_version', 'mode', 'applied', 'skipped', 'withheld_destructive', 'modified_files', 'remaining', 'exit_code',
     ])
         ->and(array_keys($array))->toBe([
-            'schema_version', 'mode', 'applied', 'skipped', 'modified_files', 'remaining', 'exit_code',
+            'schema_version', 'mode', 'applied', 'skipped', 'withheld_destructive', 'modified_files', 'remaining', 'exit_code',
         ])
         ->and($array['schema_version'])->toBe('1')
         ->and($array['mode'])->toBe('fix')
@@ -56,6 +56,7 @@ it('serializes the frozen fix-run envelope with the exact key set', function ():
         ->and($array['skipped'])->toBe([
             ['rule_id' => 'b.skipped', 'file' => '/app/B.php', 'reason' => 'conflict'],
         ])
+        ->and($array['withheld_destructive'])->toBe(0)
         ->and($array['modified_files'])->toBe(['/app/A.php'])
         ->and($array['remaining'])->toBe($remaining)
         ->and($array['exit_code'])->toBe(1);

--- a/tests/Unit/Lint/Fix/FixRunResultTest.php
+++ b/tests/Unit/Lint/Fix/FixRunResultTest.php
@@ -114,3 +114,20 @@ it('is JSON-encodable to a stable shape (remaining reuses Finding json shape, no
     expect($decoded)->not->toHaveKey('findings')
         ->and($decoded['remaining'][0])->toHaveKeys(['rule_id', 'level', 'message']);
 });
+
+it('surfaces a non-zero withheld_destructive count alongside the withheld finding in remaining', function (): void {
+    // A destructive-only finding under --check=dangerous-off: counted as withheld AND still remaining.
+    $outcome = new FixRunResult(
+        fixResult: new FixResult([], [], []),
+        remainingFindings: [runResultFinding('config.write')],
+        level: 2,
+        dryRun: true,
+        withheldDestructiveCount: 1,
+    );
+
+    $array = $outcome->toArray();
+
+    expect($array['withheld_destructive'])->toBe(1)
+        ->and($array['applied'])->toBe(0)
+        ->and($array['remaining'])->toHaveCount(1);
+});

--- a/tests/Unit/Lint/Fix/FixSafetyDefaultTest.php
+++ b/tests/Unit/Lint/Fix/FixSafetyDefaultTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Fix\Ast\RemoveAttribute;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetKind;
+use Radiergummi\OpenApi\Lint\Fix\Ast\TargetSelector;
+use Radiergummi\OpenApi\Lint\Fix\Fix;
+use Radiergummi\OpenApi\Lint\Fix\FixSafety;
+
+uses()->group('openapi', 'lint', 'fix');
+
+function safetyFix(?FixSafety $safety = null): Fix
+{
+    $operation = new RemoveAttribute(new TargetSelector('App\\C', TargetKind::Method, 'index'), [0]);
+
+    return $safety === null
+        ? new Fix('/app/C.php', 'desc', 'rule.id', $operation)
+        : new Fix('/app/C.php', 'desc', 'rule.id', $operation, $safety);
+}
+
+it('defaults a Fix built without the safety argument to Safe', function (): void {
+    // This default keeps every existing fixer (which constructs Fix positionally) unchanged.
+    expect(safetyFix()->safety)->toBe(FixSafety::Safe);
+});
+
+it('carries an explicit Destructive safety when given', function (): void {
+    expect(safetyFix(FixSafety::Destructive)->safety)->toBe(FixSafety::Destructive);
+});

--- a/tests/Unit/Lint/Fix/WorkingTreeGuardTest.php
+++ b/tests/Unit/Lint/Fix/WorkingTreeGuardTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Lint\Fix\DirtyWorkingTreeException;
+use Radiergummi\OpenApi\Lint\Fix\WorkingTreeGuard;
+use Symfony\Component\Process\Process;
+
+uses()->group('openapi', 'lint', 'fix');
+
+function gitAvailable(): bool
+{
+    $process = new Process(['git', '--version']);
+
+    try {
+        $process->run();
+    } catch (Throwable) {
+        return false;
+    }
+
+    return $process->isSuccessful();
+}
+
+function makeTempGitRepo(): string
+{
+    $dir = sys_get_temp_dir() . '/openapi-wtg-' . uniqid();
+    mkdir($dir);
+
+    foreach ([['git', 'init', '-q'], ['git', 'config', 'user.email', 't@t'], ['git', 'config', 'user.name', 't']] as $cmd) {
+        new Process($cmd, $dir)->run();
+    }
+
+    return $dir;
+}
+
+function commit(string $dir): void
+{
+    new Process(['git', 'add', '-A'], $dir)->run();
+    new Process(['git', 'commit', '-q', '-m', 'x'], $dir)->run();
+}
+
+afterEach(function (): void {
+    foreach (glob(sys_get_temp_dir() . '/openapi-wtg-*') ?: [] as $leftover) {
+        new Process(['rm', '-rf', $leftover])->run();
+    }
+});
+
+it('allows when the target file is clean and tracked', function (): void {
+    $dir = makeTempGitRepo();
+    file_put_contents("{$dir}/a.php", "<?php\n");
+    commit($dir);
+
+    expect(fn() => new WorkingTreeGuard()->assertClean(["{$dir}/a.php"], allowDirty: false))
+        ->not->toThrow(DirtyWorkingTreeException::class);
+})->skip(fn() => !gitAvailable(), 'git is unavailable on this runner');
+
+it('refuses naming the path when the target file has uncommitted changes', function (): void {
+    $dir = makeTempGitRepo();
+    file_put_contents("{$dir}/a.php", "<?php\n");
+    commit($dir);
+    file_put_contents("{$dir}/a.php", "<?php // dirty\n");
+
+    expect(fn() => new WorkingTreeGuard()->assertClean(["{$dir}/a.php"], allowDirty: false))
+        ->toThrow(DirtyWorkingTreeException::class, 'a.php');
+})->skip(fn() => !gitAvailable(), 'git is unavailable on this runner');
+
+it('allows a dirty tree when --allow-dirty is set', function (): void {
+    $dir = makeTempGitRepo();
+    file_put_contents("{$dir}/a.php", "<?php\n");
+    commit($dir);
+    file_put_contents("{$dir}/a.php", "<?php // dirty\n");
+
+    expect(fn() => new WorkingTreeGuard()->assertClean(["{$dir}/a.php"], allowDirty: true))
+        ->not->toThrow(DirtyWorkingTreeException::class);
+})->skip(fn() => !gitAvailable(), 'git is unavailable on this runner');
+
+it('refuses a file that is not in a git repository (not-a-repo failure mode)', function (): void {
+    $dir = sys_get_temp_dir() . '/openapi-wtg-norepo-' . uniqid();
+    mkdir($dir);
+    file_put_contents("{$dir}/a.php", "<?php\n");
+
+    expect(fn() => new WorkingTreeGuard()->assertClean(["{$dir}/a.php"], allowDirty: false))
+        ->toThrow(DirtyWorkingTreeException::class, 'Cannot verify a clean working tree');
+
+    new Process(['rm', '-rf', $dir])->run();
+})->skip(fn() => !gitAvailable(), 'git is unavailable on this runner');
+
+it('allows a non-repo file when --allow-dirty is set', function (): void {
+    $dir = sys_get_temp_dir() . '/openapi-wtg-norepo-' . uniqid();
+    mkdir($dir);
+    file_put_contents("{$dir}/a.php", "<?php\n");
+
+    expect(fn() => new WorkingTreeGuard()->assertClean(["{$dir}/a.php"], allowDirty: true))
+        ->not->toThrow(DirtyWorkingTreeException::class);
+
+    new Process(['rm', '-rf', $dir])->run();
+});
+
+it('is a no-op with no target files (nothing destructive to guard)', function (): void {
+    expect(fn() => new WorkingTreeGuard()->assertClean([], allowDirty: false))
+        ->not->toThrow(DirtyWorkingTreeException::class);
+});
+
+it('refuses when git is unavailable (binary cannot launch)', function (): void {
+    // The git-absent failure mode: Process throws ProcessStartFailedException when the binary cannot
+    // launch, distinct from the not-a-repo branch (non-zero exit, no throw). Force it deterministically
+    // with a guaranteed-missing executable rather than mutating PATH on the runner.
+    $dir = sys_get_temp_dir() . '/openapi-wtg-nogit-' . uniqid();
+    mkdir($dir);
+    file_put_contents("{$dir}/a.php", "<?php\n");
+
+    $guard = new WorkingTreeGuard('git-does-not-exist-' . uniqid());
+
+    try {
+        expect(fn() => $guard->assertClean(["{$dir}/a.php"], allowDirty: false))
+            ->toThrow(DirtyWorkingTreeException::class, 'Cannot verify a clean working tree');
+    } finally {
+        new Process(['rm', '-rf', $dir])->run();
+    }
+});


### PR DESCRIPTION
Closes #383

## Implementation plan — #383 `--fix=safe|dangerous` opt-in level for destructive fixes (MECHANISM only)

`<type>=feat` · area:lint + area:cli · **no tier label** (Fix-layer + CLI mechanism, not an inference
measure). Depends on #382 + #22/#396 (merged; `main` @ `6836623c`). **Blocks #199.**

> Read the issue THROUGH its 2026-06-17 reconciliation comment: the mechanism is backend-agnostic and
> accurate against post-#368 `main`. **Build the gate only.** The `Destructive` tier stays **empty**
> until #199 ships the first destructive producer (config auto-write into `config/openapi.php`); under
> this PR `--fix=dangerous` applies nothing extra. Do **not** build #199's fixers here.

### Verified current state (grounds the plan; avoids re-cutting merged seams)

- `Fix` VO is `file`, `description`, `ruleId`, `operation: AstOperation` (Fix.php) — `FixSafety` is an
  additive field with a default.
- `FixRunner::run(LintOptions, bool $dryRun)` collects every fixer's `Fix`es into `$allFixes`, applies
  them in one batch, maps applied → resolved findings (FixRunner.php:44-85). **The partition belongs
  here**, before `$this->applicator->apply()`.
- `FixApplicator::apply(array $fixes, bool $dryRun)` writes via an atomic temp-file+rename `write()`
  (FixApplicator.php:57, 178). The clean-tree rail gates this write path.
- `FixRunResult::toArray()` is the **frozen `--fix`/`--check` JSON envelope** that #396 just merged
  (FixRunResult.php:45-79), with `SCHEMA_VERSION = '1'`, keys `schema_version, mode, applied, skipped,
  modified_files, remaining, exit_code`. **Extend THIS — do not re-cut the seam.** The safe/dangerous
  dimension is additive (new keys), so the version bumps only if we decide the addition is breaking
  (it is not — additive keys keep existing consumers valid; **keep `SCHEMA_VERSION = '1'`**, confirm
  at review).
- `--fix`/`--check` are declared in the Laravel **string `$signature`** as `VALUE_NONE`
  (LintCommand.php:90-91); `runFix()` reads them as booleans (LintCommand.php:247). The `--diff` flag
  already demonstrates the value-optional idiom this repo uses: it stays catchable via
  `$this->input->hasParameterOption('--diff')` + `$this->option('diff')` (LintCommand.php:330-346,
  resolveDiffScope).
- Git is already invoked via `Symfony\Component\Process\Process` with `['git', …]` arg arrays in
  `LintRouteFilter` (LintRouteFilter.php:138-154) — the clean-tree rail reuses this exact mechanism and
  the Process exceptions the command already declares.

### Design (five parts, all additive)

**1. `FixSafety` enum + `Fix` field.**
- `src/Lint/Fix/FixSafety.php` — `enum FixSafety { case Safe; case Destructive; }` (`@internal`,
  docblock: what "destructive" means — mutates files the developer hand-curates or far from the
  finding site). A `public string $value`-style backing is **not** needed unless it appears in the
  JSON envelope; we will surface counts, so a **pure (unbacked) enum** suffices — confirm when wiring
  the envelope (if a per-fix safety string is emitted, make it `string`-backed `safe|dangerous`).
- `Fix` gains a trailing `public FixSafety $safety = FixSafety::Safe` constructor param. **Default
  `Safe` is load-bearing:** every existing fixer constructs `Fix` without it, so all current goldens
  stay byte-identical and behaviour is unchanged. (Decision per the issue: granularity is **Fix-level**,
  not fixer/rule-level — a single rule can emit both tiers; #199's scaffold is `Safe`, its config write
  is `Destructive`.)

**2. Runner partition.**
- `FixRunner::run()` gains a level parameter (`FixApplyLevel` / reuse `FixSafety` as the threshold —
  **decision:** pass a `bool $applyDestructive` derived from the CLI level; simplest, no second enum).
  After collecting `$allFixes`, partition into `$applicable` (always the `Safe` fixes; plus the
  `Destructive` ones **iff** `$applyDestructive`) and `$withheldDestructive` (the `Destructive` fixes
  when not applying them). Only `$applicable` goes to `apply()`. `$withheldDestructive` is **counted**
  and surfaced (not applied, not in `remaining` as "unfixable" — they have a fix, just gated; keep
  them associated with their findings so the message count is correct).
- `FixRunResult` gains `withheldDestructiveCount: int` (and, if `--check` lists rule IDs per the open
  decision, a `list<string> $withheldDestructiveRuleIds`). Wire into `toArray()` additively:
  `"withheld_destructive": <int>` (+ optional `"withheld_destructive_rules": [...]`).

**3. `--fix` / `--check` become `VALUE_OPTIONAL` (`safe|dangerous`, default `safe`).**
- The Laravel string signature cannot express an optional-value option (`{--fix=}` is
  `VALUE_REQUIRED`, breaking bare `--fix`). **Remove `--fix`/`--check` from the `$signature` string**
  and register them as Symfony `InputOption`s with `VALUE_OPTIONAL` in the command — either by
  overriding `configure()` after `parent::configure()` (`$this->getDefinition()->addOption(new
  InputOption('fix', null, InputOption::VALUE_OPTIONAL, '…', false))`) or adding them in the
  constructor. Pattern to confirm during coding against this repo's Laravel-12/13 portability note
  (the class already avoids 13-only attributes).
- Parse: bare `--fix` → Symfony yields the option's *default when present without value*. Resolve the
  level with a small helper: present-without-value or `=safe` → `safe`; `=dangerous` → `dangerous`;
  any other value → **throw `InvalidArgumentException`** ("Unknown --fix level 'x'. Expected 'safe' or
  'dangerous'."), which the command surfaces as a clear input error. Use
  `$this->input->hasParameterOption('--fix' / '--check')` to detect presence (mirrors `--diff`).
- `--check` symmetric: bare/`=safe` previews the split, `=dangerous` previews destructive too.

**4. Reporting.**
- Withheld message (when `Destructive` fixes exist but were not applied):
  `"<n> additional finding(s) have potentially destructive fixes. Re-run with --fix=dangerous to apply them."`
  Emit through the same per-format summary path #396 added (`renderFixOutcome` /
  the one-line summary at LintCommand.php:469-500) — cli line, github `::notice`, markdown bullet —
  reusing that machinery, not a parallel one.
- `--check` split: extend the existing summary to report "would apply X safe fix(es); Y destructive
  held back" and the JSON envelope's new `withheld_destructive` key.

**5. Clean-tree safety rail (only for `Destructive` writes).**
- New `src/Lint/Fix/WorkingTreeGuard.php` (`@internal`): given the set of target files of the
  `Destructive` fixes about to be written, run `git status --porcelain -- <files>` via
  `Symfony\Component\Process\Process` (same mechanism as `LintRouteFilter`). Dirty (any output for
  those paths) → **refuse**, naming the offending paths, unless `--allow-dirty`.
- Gate placement: the guard runs in `FixRunner` (or the command) **before** `apply()` is called with
  destructive fixes included — never inside the atomic `write()` (keep `FixApplicator` git-agnostic).
  Safe-only runs never touch git (zero overhead, no git dependency for the common path).
- **Non-git / git-absent behaviour (open decision — RECOMMENDED: warn-and-require-`--allow-dirty`).**
  If the target file is not in a git repo or `git` is unavailable, the trivial-revert rationale
  (`git checkout`) does not hold, so we cannot claim safety. **Recommend: refuse destructive writes and
  require `--allow-dirty`** (with a one-line warning explaining why), rather than silently proceeding.
  This keeps the safety guarantee honest and the package's no-hard-git-dependency intact (git absence
  is handled, not crashed on). **Flagged for the lead** — the alternative (warn-and-proceed) is laxer.
- `--allow-dirty`: new `VALUE_NONE` flag in the signature; only consulted on the destructive path.

### Open design decisions — recommended dispositions (flag for lead)

| Decision | Recommendation |
|---|---|
| Safety granularity | **`FixSafety` enum on `Fix`** (issue-recommended; a single rule emits both tiers). |
| CLI vocab `dangerous` vs `destructive` | **`dangerous`** for the CLI value (issue-decided); enum case stays `Destructive` (internal precision). |
| Non-git-repo clean-tree behaviour | **Refuse + require `--allow-dirty`** (honest safety; flagged). |
| `--check` lists destructive rule IDs vs counts only | **Count only** in the human line; add `withheld_destructive` count to JSON. Listing rule IDs is cheap to add if the lead prefers — include `withheld_destructive_rules` in JSON, omit from the human one-liner to keep it terse. |

### Tests (TDD — failing tests first)

Under `tests/Unit/Lint/Fix/` and the existing console-test home:

- **`FixSafetyDefaultTest`** — a `Fix` built without the safety arg is `FixSafety::Safe`; pins the
  default that keeps every existing fixer/goldens unchanged.
- **`FixRunnerPartitionTest`** — given a synthetic fixer set emitting one `Safe` + one `Destructive`
  fix: `applyDestructive=false` → only the safe fix reaches `apply()`, withheld count = 1; 
  `applyDestructive=true` → both applied, withheld = 0. Findings whose only fix is withheld are
  reported as withheld, not silently "remaining-unfixable".
- **`LintCommand` option-parsing tests** (feature): bare `--fix` → level `safe`; `--fix=safe` → safe;
  `--fix=dangerous` → dangerous; `--fix=bogus` → non-zero exit + clear error message; same matrix for
  `--check`. Assert bare `--fix` does **not** error (the VALUE_OPTIONAL regression guard).
- **`WorkingTreeGuardTest`** — clean tree → allows; dirty target file → refuses naming the path;
  `--allow-dirty` → allows despite dirt; non-git path → refuses without `--allow-dirty`, allows with
  it (per the recommended decision). Use a temp git repo fixture; skip/guard gracefully if `git` is
  unavailable on the runner.
- **JSON envelope shape** — `--check=dangerous --format=json` includes `withheld_destructive`
  (and `withheld_destructive_rules` if adopted); `SCHEMA_VERSION` unchanged; existing keys intact
  (extends the #396 envelope test, does not fork it).
- Edge cases: zero destructive fixes (withheld = 0, no message, no git call); all-destructive under
  `--fix=safe` (nothing applied, withheld message shown); destructive under `--fix=dangerous` on a
  dirty tree without `--allow-dirty` (refused).

> Note: with **no `Destructive` producer in the tree yet**, the runner/guard tests use a synthetic
> fixer/`Fix` emitting `FixSafety::Destructive` (the mechanism is exercisable without #199). State this
> in the test so the next reader knows the tier is intentionally empty in production until #199.

### Docs & changelog

- `docs/linting.md` — extend the existing `--fix`/`--check` section (it already exists): document the
  `safe|dangerous` level, the default-safe behaviour, the withheld-destructive message, the
  clean-tree rail + `--allow-dirty`, and the destructive-fix concept (forward-reference #199 as the
  first producer, without documenting #199's fixers). Add `withheld_destructive` to the documented
  `--check --format=json` schema block (also added in #22/#396).
- `CHANGELOG.md` `[Unreleased]`: one line — `--fix`/`--check` now take an optional `safe|dangerous`
  level; destructive fixes are withheld from the default `--fix`, counted, and gated behind
  `--fix=dangerous` + a clean working tree (`--allow-dirty` overrides). (#383)

### Controversy flags for the lead (expect reviewer attention; likely human gate)

- **area:lint + area:cli ⇒ no survey** (non-generation-affecting).
- **CLI surface change:** `--fix`/`--check` migrate from `VALUE_NONE` → `VALUE_OPTIONAL`, plus a new
  `--allow-dirty` flag. No flag is *removed* and bare `--fix` keeps working (regression-tested), but
  this touches the command definition and the Laravel-12/13 portability seam — reviewer should verify
  the `configure()`/`InputOption` route works on both.
- **New git side-effect at write time** (`WorkingTreeGuard` shells out to `git status`). Confirmed it
  reuses the existing `Process`-based pattern and degrades when git is absent (no hard dependency) —
  but a shell-out in the fix path warrants reviewer eyes. **The non-git-repo decision is a judgement
  call flagged above.**
- **`FixSafety` is a near-public enum** (lives in the Fix layer that plugin/fixer authors touch); mark
  `@internal` for now, but note it becomes the surface #199 (and any third-party destructive fixer)
  builds against. **No `src/Contracts/**` change, no config key, no rule-severity change** — confirmed
  against the issue non-goals.
- **Size:** `FixSafety` + `Fix` field + runner partition + 2 new flags + parsing/validation + the
  `WorkingTreeGuard` + envelope/reporting wiring is **likely > ~150 src/ LOC** → expect a human merge
  gate.
- **Follow-ups to surface (cannot `gh issue create` here):** this PR is the gate; **#199 is the first
  `Destructive` producer** and the real exercise of `--fix=dangerous` — confirm #199 is unblocked once
  this merges. If the lead wants `openapi:lint --list` to surface which rules *can* emit destructive
  fixes (the issue's "alternative considered" aside), that is a separate, optional enhancement — not
  built here.

---

### Reviewer addendum (plan-review, reviewer1)

Verified every load-bearing claim against `main` @ `6836623c`; the design is sound, surgical, and
correctly extends the merged #396 seam. Three **precision tightenings** to honour during coding
(none change the design):

1. **`--diff` is `VALUE_REQUIRED`, not a bare-flag (value-optional) precedent — only its *presence
   detection* transfers.** The plan cites `--diff` as "the value-optional idiom this repo uses," but
   `{--diff=}` (LintCommand.php:86) is `VALUE_REQUIRED`: bare `--diff` would error ("option requires a
   value"). What `--diff` *does* establish is the presence/value split: `hasParameterOption('--diff')`
   for presence + `$this->option('diff')` for the value (`resolveDiffScope`, LintCommand.php:378-389).
   That half transfers; the **bare-flag-resolves-to-default** half genuinely requires the
   `VALUE_OPTIONAL` migration the plan calls out — copying `--diff`'s declaration is **not** sufficient.
   Coding check: with `VALUE_OPTIONAL` + a default, **absent `--fix` and bare `--fix` both yield the
   default**, so presence MUST be `hasParameterOption('--fix')` (the plan does this) and the resolver
   must treat present-without-value as `safe`. Assert bare `--fix` does not error (the regression guard
   the plan lists) AND that `--fix` *absent* still runs a plain lint (no accidental fix-mode trigger
   from the default value).

2. **`WorkingTreeGuard` must distinguish two git failure modes — different detection, same
   destination.** `LintRouteFilter` uses `new Process(['git', …])->run()` (not `mustRun()`,
   LintRouteFilter.php:138-139) and reads `getOutput()` without `isSuccessful()`. Reusing that pattern,
   note: **git absent** → `Process::run()` throws `ProcessStartFailedException` (binary can't launch);
   **present but not a repo** → exits non-zero with empty/stderr output, no throw. The plan's "degrades
   when git is absent" is right, but the guard must catch the launch exception for the absent case
   *and* check exit status (or stderr) for the not-a-repo case — both route to "refuse + require
   `--allow-dirty`", via different detection. Pin both in `WorkingTreeGuardTest` (the test already plans
   a non-git path; add an explicit git-unavailable simulation, or document why only one is feasible on
   the runner). Use `git status --porcelain -- <files>` and treat **any** porcelain output for the
   target paths as dirty.

3. **A finding whose only fix is a withheld `Destructive` one genuinely stays in `remaining` — it is
   *both* unresolved AND withheld-counted; do not exclude it from `remaining`.** `FixRunner::wasFixed()`
   keys resolution off `spl_object_id` of *applied* fixes (FixRunner.php), so a withheld fix's finding
   correctly is not "fixed" and lands in `remaining` (the source really is unchanged). The plan's
   phrase "not in `remaining` as 'unfixable'" must not be read as "remove it from `remaining`" — that
   would under-report unresolved findings to CI. Correct behaviour: it appears in `remaining` (still a
   real gap) **and** increments `withheld_destructive`; the message explains the gap has a gated fix.
   Add a test asserting exactly this (destructive-only finding under `--fix=safe` → in `remaining` AND
   `withheld_destructive == 1`).

Affirmations on the lead's other questions: **(2)** the `bool $applyDestructive` threshold is
sufficient — a binary safe-vs-also-dangerous decision; a second enum would be over-engineering.
**(5)** `withheld_destructive` is genuinely additive to the frozen envelope (existing consumers read
the current keys and stay valid), so `SCHEMA_VERSION = '1'` is correct — just extend the `@return`
shape annotation on `toArray()` too. **(1)** the `Safe` default is a true no-op: every existing fixer
constructs `Fix` positionally without the new trailing param, so goldens are byte-stable. **(4)**
refuse-and-require-`--allow-dirty` for the non-git path is the right honest-safety default. The
`Destructive` tier correctly has **no producers** (synthetic fixer in tests only; #199 is the first
real producer and is unblocked by this).

**Verdict: approved** with tightenings 1–3 honoured during coding (small accuracy/precision points,
not design changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
