### PR TITLE
feat(#198): SchemaEquivalence follows $ref by name (cycle-guarded, conservative)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project are documented here.
 - `PaginatorKind` recognises Spatie's `PaginatedDataCollection`; `DataResponseResolver` handles union return types as `oneOf`.
 - The inline `response()->noContent($status)` body-scan reads an explicit literal/named 2xx status (body-less); a non-literal or non-2xx status degrades. (#328)
 - A typed `UploadedFile` property on a Spatie `Data` class (transitively, through nested Data classes) emits a `multipart/form-data` body with a `format: binary` field, matching the FormRequest file-rule path; the `multipart.file-without-multipart` lint rule is reframed as a contradiction guard that fires only when a `#[RequestBody]` override forces a non-multipart media type onto a file-carrying payload. (#333)
+- The `migration.*` redundancy oracle (`SchemaEquivalence`) now follows a component `$ref` by name to its target schema on each side when the author and convention named the same component differently, so a parent schema whose only difference is a divergent child `$ref` name is no longer under-reported as non-redundant; resolution is conservative (an unresolvable ref keeps the annotation) and cycle-guarded. (#198)
 
 ### Fixed
 - Lint now surfaces top-level and field-level bare `oneOf` / `anyOf` schemas across components, responses, and request bodies. (#294, #318)

--- a/src/Lint/InferenceView.php
+++ b/src/Lint/InferenceView.php
@@ -10,6 +10,7 @@ use Radiergummi\OpenApi\Support\Generator\InferenceOnlyGeneration;
 use function is_array;
 use function is_string;
 use function ltrim;
+use function Radiergummi\OpenApi\is_defined;
 use function strtolower;
 
 /**
@@ -25,10 +26,12 @@ final readonly class InferenceView
     /**
      * @param array<class-string, OA\Schema> $schemasByClass
      * @param array<string, OA\Operation>    $operationsByKey
+     * @param array<string, OA\Schema>       $schemasByName   Control components keyed by component name.
      */
     public function __construct(
         private array $schemasByClass = [],
         private array $operationsByKey = [],
+        private array $schemasByName = [],
     ) {}
 
     /**
@@ -48,7 +51,31 @@ final readonly class InferenceView
             }
         }
 
-        return new self($generation->schemasByClass, $operationsByKey);
+        return new self($generation->schemasByClass, $operationsByKey, self::schemasByName($generation));
+    }
+
+    /**
+     * The control document's component schemas keyed by component name (the `$ref` target name).
+     *
+     * @return array<string, OA\Schema>
+     */
+    private static function schemasByName(InferenceOnlyGeneration $generation): array
+    {
+        $components = $generation->document->components;
+
+        if (!$components instanceof OA\Components || !is_array($components->schemas)) {
+            return [];
+        }
+
+        $byName = [];
+
+        foreach ($components->schemas as $schema) {
+            if ($schema instanceof OA\Schema && is_defined($schema->schema) && is_string($schema->schema)) {
+                $byName[$schema->schema] = $schema;
+            }
+        }
+
+        return $byName;
     }
 
     /** Lookup key: lowercased method, space, URI without leading slash. */
@@ -71,5 +98,13 @@ final readonly class InferenceView
     public function operationForRoute(string $method, string $uri): ?OA\Operation
     {
         return $this->operationsByKey[self::operationKey($method, $uri)] ?? null;
+    }
+
+    /**
+     * The control component schema with the given component name (a `$ref` target), or null.
+     */
+    public function schemaForName(string $name): ?OA\Schema
+    {
+        return $this->schemasByName[$name] ?? null;
     }
 }

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantWithInference.php
@@ -18,6 +18,7 @@ use Radiergummi\OpenApi\Lint\Visitors\ComponentSchemaRule;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Fix\RedundantOaAnnotationFixer;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support\AuthoredAnnotationShape;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support\OaRedundancyEngine;
+use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support\ScannerInferenceRefResolver;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support\SchemaEquivalence;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support\SchemaSubsumption;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Stages\HarvestAuthoredAnnotationsStage;
@@ -43,14 +44,10 @@ final class OaRedundantWithInference implements Rule, ComponentSchemaRule, Fixab
 {
     private readonly OaRedundancyEngine $engine;
 
-    private readonly SchemaSubsumption $comparator;
-
     public function __construct(
         private readonly AuthoredAnnotationScanner $scanner,
-        SchemaEquivalence $equivalence,
     ) {
         $this->engine = new OaRedundancyEngine();
-        $this->comparator = new SchemaSubsumption($equivalence);
     }
 
     /**
@@ -75,6 +72,12 @@ final class OaRedundantWithInference implements Rule, ComponentSchemaRule, Fixab
 
         $inferred = $context->inference->schemaForClass($class);
 
+        // The oracle follows a $ref the author and convention named differently to its target schema
+        // on each side; built per run since the inference view is per spec run.
+        $comparator = new SchemaSubsumption(
+            new SchemaEquivalence(new ScannerInferenceRefResolver($this->scanner, $context->inference)),
+        );
+
         // Removing a schema still referenced by name by another authored annotation would dangle it.
         $isEssential = fn(): bool
             => is_defined($authored->schema)
@@ -83,7 +86,7 @@ final class OaRedundantWithInference implements Rule, ComponentSchemaRule, Fixab
         $finding = $this->engine->evaluate(
             $authored,
             $inferred,
-            $this->comparator,
+            $comparator,
             fn(): ReflectionClass => new ReflectionClass($class),
             fn(AuthoredAnnotationShape $shape): Finding => new Finding(
                 ruleId: $this->id(),

--- a/src/Plugins/SwaggerPhp/Lint/Support/ScannerInferenceRefResolver.php
+++ b/src/Plugins/SwaggerPhp/Lint/Support/ScannerInferenceRefResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support;
+
+use OpenApi\Annotations as OA;
+use Override;
+use Radiergummi\OpenApi\Lint\InferenceView;
+use Radiergummi\OpenApi\Plugins\SwaggerPhp\Support\AuthoredAnnotationScanner;
+
+/**
+ * Resolves `$ref` names against the two sides the redundancy oracle compares: the authored side via
+ * the harvested {@see AuthoredAnnotationScanner}, the inferred side via the per-run
+ * {@see InferenceView}. Built at lint time, since the inference view is per spec run.
+ *
+ * @internal
+ */
+final readonly class ScannerInferenceRefResolver implements SchemaRefResolver
+{
+    public function __construct(
+        private AuthoredAnnotationScanner $scanner,
+        private InferenceView $inference,
+    ) {}
+
+    #[Override]
+    public function resolveAuthored(string $name): ?OA\Schema
+    {
+        return $this->scanner->schemaForName($name);
+    }
+
+    #[Override]
+    public function resolveInferred(string $name): ?OA\Schema
+    {
+        return $this->inference->schemaForName($name);
+    }
+}

--- a/src/Plugins/SwaggerPhp/Lint/Support/SchemaEquivalence.php
+++ b/src/Plugins/SwaggerPhp/Lint/Support/SchemaEquivalence.php
@@ -10,8 +10,11 @@ use function array_is_list;
 use function array_key_exists;
 use function array_values;
 use function get_object_vars;
+use function is_string;
 use function Radiergummi\OpenApi\is_undefined;
 use function str_starts_with;
+use function strrpos;
+use function substr;
 
 /**
  * Tests whether one swagger-php annotation subtree is structurally contained in another.
@@ -21,22 +24,32 @@ use function str_starts_with;
  * (`additionalProperties: false`, etc.) fails containment and the annotation is kept.
  *
  * Canonical form drops `UNDEFINED` sentinels and `_`-prefixed internals; collections are
- * compared order-insensitively. `$ref` targets are compared by literal string (conservative).
+ * compared order-insensitively. Equal `$ref` strings match literally. When a {@see SchemaRefResolver}
+ * is injected, two *differing* `$ref` names are followed to their target schemas and those compared,
+ * so a component the author and convention named differently does not defeat the verdict; an
+ * unresolvable ref is conservatively treated as not contained (the annotation is kept).
  *
  * @internal
  */
 final readonly class SchemaEquivalence
 {
+    public function __construct(private ?SchemaRefResolver $refs = null) {}
+
     /**
      * Whether every value in `$narrower` is present and equal in `$broader` (which may carry more).
      */
     public function subsumes(?OA\AbstractAnnotation $broader, ?OA\AbstractAnnotation $narrower): bool
     {
-        return $this->contains($this->normalize($broader), $this->normalize($narrower));
+        return $this->contains($this->normalize($broader), $this->normalize($narrower), []);
     }
 
-    /** Recursive containment: maps check key-by-key, lists are order-insensitive, scalars use ==. */
-    private function contains(mixed $broader, mixed $narrower): bool
+    /**
+     * Recursive containment: maps check key-by-key, lists are order-insensitive, scalars use ==.
+     *
+     * @param array<string, string> $visited Ref-name pairs (`inferred => authored`) already being
+     *                                       compared up the stack, so a recursive graph terminates.
+     */
+    private function contains(mixed $broader, mixed $narrower, array $visited): bool
     {
         if (!is_array($narrower)) {
             return $broader == $narrower;
@@ -51,7 +64,7 @@ final readonly class SchemaEquivalence
         if (array_is_list($narrower) || array_is_list($broader)) {
             foreach ($narrower as $narrowerElement) {
                 foreach ($broader as $broaderElement) {
-                    if ($this->contains($broaderElement, $narrowerElement)) {
+                    if ($this->contains($broaderElement, $narrowerElement, $visited)) {
                         continue 2;
                     }
                 }
@@ -62,13 +75,67 @@ final readonly class SchemaEquivalence
             return true;
         }
 
+        if (($followed = $this->followDifferingRefs($broader, $narrower, $visited)) !== null) {
+            return $followed;
+        }
+
         foreach ($narrower as $key => $narrowerValue) {
-            if (!array_key_exists($key, $broader) || !$this->contains($broader[$key], $narrowerValue)) {
+            if (!array_key_exists($key, $broader) || !$this->contains($broader[$key], $narrowerValue, $visited)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * When both maps carry a *differing* `ref` name, resolves each side to its target schema and
+     * compares those instead. Equal refs already pass via `==` and never reach here. Returns null
+     * when the branch does not apply (no resolver, no/equal refs), so the caller falls back to the
+     * literal map comparison; a true/false result short-circuits it.
+     *
+     * @param array<array-key, mixed> $broader
+     * @param array<array-key, mixed> $narrower
+     * @param array<string, string>   $visited
+     */
+    private function followDifferingRefs(array $broader, array $narrower, array $visited): ?bool
+    {
+        $broaderRef = $broader['ref'] ?? null;
+        $narrowerRef = $narrower['ref'] ?? null;
+
+        if ($this->refs === null || !is_string($broaderRef) || !is_string($narrowerRef) || $broaderRef === $narrowerRef) {
+            return null;
+        }
+
+        $broaderName = self::refName($broaderRef);
+        $narrowerName = self::refName($narrowerRef);
+
+        // A cycle re-entering the same pair is established by the outer frame (coinductive).
+        if (($visited[$broaderName] ?? null) === $narrowerName) {
+            return true;
+        }
+
+        $broaderTarget = $this->refs->resolveInferred($broaderName);
+        $narrowerTarget = $this->refs->resolveAuthored($narrowerName);
+
+        // Conservative: an unresolvable target is never treated as contained.
+        if ($broaderTarget === null || $narrowerTarget === null) {
+            return false;
+        }
+
+        return $this->contains(
+            $this->normalize($broaderTarget),
+            $this->normalize($narrowerTarget),
+            [...$visited, $broaderName => $narrowerName],
+        );
+    }
+
+    /** The component name from a `#/components/schemas/Name` pointer (or the string as-is). */
+    private static function refName(string $ref): string
+    {
+        $position = strrpos($ref, '/');
+
+        return $position === false ? $ref : substr($ref, $position + 1);
     }
 
     /**

--- a/src/Plugins/SwaggerPhp/Lint/Support/SchemaRefResolver.php
+++ b/src/Plugins/SwaggerPhp/Lint/Support/SchemaRefResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * Resolves a component `$ref` name to its target schema, on each of the two sides the redundancy
+ * oracle compares.
+ *
+ * The authored and inferred documents name the same class differently (convention uses
+ * `class_basename`, the author may pin an explicit `#[OA\Schema(schema: '…')]`), so a `$ref` string
+ * carries a side-specific name: the narrower (authored) ref must resolve against the authored
+ * components, the broader (inferred) ref against the inference-only control. Keeping the two lookups
+ * distinct avoids conflating the namespaces. An unknown name yields null, which the comparator treats
+ * conservatively (not subsumed).
+ *
+ * @internal
+ */
+interface SchemaRefResolver
+{
+    public function resolveAuthored(string $name): ?OA\Schema;
+
+    public function resolveInferred(string $name): ?OA\Schema;
+}

--- a/tests/Feature/SwaggerPhpMigrationRuleTest.php
+++ b/tests/Feature/SwaggerPhpMigrationRuleTest.php
@@ -19,12 +19,14 @@ use Radiergummi\OpenApi\Support\Generator\OpenApiGenerationOrchestrator;
 use Radiergummi\OpenApi\Support\Generator\OpenApiGenerator;
 use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\AttributeServer;
+use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\DivergentRefParentData;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\EssentialAttributeData;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\PlainStructData;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\RedundantAnnotationController;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\RedundantAttributeData;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\RedundantDocblockData;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\RefChildData;
+use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\RefParentData;
 use Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp\ServerController;
 
 uses()->group('openapi', 'plugin:spatie-data');
@@ -195,6 +197,30 @@ it('does not flag a schema another authored annotation still references by name'
 
     expect(migrationFindingClasses($result))
         ->not->toContain(RefChildData::class);
+});
+
+it('flags a parent whose $ref the author named differently but whose target inference reproduces', function (): void {
+    // RefParentData's authored child $ref is `RefChild`; convention names the same class `RefChildData`.
+    // The oracle now follows both refs to their (equivalent) target schemas, so the parent is flagged.
+    Route::get('/ref-parent', [RedundantAnnotationController::class, 'refParent']);
+    migrationRuleSetup();
+
+    $result = app(LintRunner::class)->run(new LintOptions(only: ['migration.*']));
+
+    expect(migrationFindingClasses($result))
+        ->toContain(RefParentData::class);
+});
+
+it('does not flag a parent whose divergently-named $ref target genuinely differs', function (): void {
+    // The authored child target (`DivergentChild`) carries a description inference cannot reproduce,
+    // so following the parent's $ref fails subsumption and the parent is kept.
+    Route::get('/divergent-ref-parent', [RedundantAnnotationController::class, 'divergentRefParent']);
+    migrationRuleSetup();
+
+    $result = app(LintRunner::class)->run(new LintOptions(only: ['migration.*']));
+
+    expect(migrationFindingClasses($result))
+        ->not->toContain(DivergentRefParentData::class);
 });
 
 it('expands a family glob configured in openapi.lint.enabled_rules', function (): void {

--- a/tests/Fixtures/SwaggerPhp/DivergentRefChildData.php
+++ b/tests/Fixtures/SwaggerPhp/DivergentRefChildData.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp;
+
+use OpenApi\Attributes as OA;
+use Spatie\LaravelData\Data;
+
+// Named `DivergentChild` (the author's name), but its authored schema carries a description
+// inference cannot derive, so following the parent's $ref to this target fails subsumption: the
+// parent stays flagged-NOT.
+#[OA\Schema(schema: 'DivergentChild', description: 'A hand-written description inference omits.')]
+final class DivergentRefChildData extends Data
+{
+    public function __construct(
+        public string $label,
+    ) {}
+}

--- a/tests/Fixtures/SwaggerPhp/DivergentRefParentData.php
+++ b/tests/Fixtures/SwaggerPhp/DivergentRefParentData.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\SwaggerPhp;
+
+use OpenApi\Attributes as OA;
+use Spatie\LaravelData\Data;
+
+// Its authored schema references the child by the author's divergent name (`DivergentChild` vs the
+// convention's `DivergentRefChildData`). The oracle follows both refs, but the authored child target
+// carries a description inference cannot reproduce, so the parent is NOT flagged redundant.
+#[OA\Schema(
+    schema: 'DivergentParent',
+    properties: [new OA\Property(property: 'child', ref: '#/components/schemas/DivergentChild')],
+)]
+final class DivergentRefParentData extends Data
+{
+    public function __construct(
+        public DivergentRefChildData $child,
+    ) {}
+}

--- a/tests/Fixtures/SwaggerPhp/RedundantAnnotationController.php
+++ b/tests/Fixtures/SwaggerPhp/RedundantAnnotationController.php
@@ -36,4 +36,9 @@ class RedundantAnnotationController
     {
         throw new LogicException('Signature-only fixture; never invoked.');
     }
+
+    public function divergentRefParent(): DivergentRefParentData
+    {
+        throw new LogicException('Signature-only fixture; never invoked.');
+    }
 }

--- a/tests/Unit/Lint/InferenceViewTest.php
+++ b/tests/Unit/Lint/InferenceViewTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenApi\Annotations as OA;
+use Radiergummi\OpenApi\Lint\InferenceView;
+use Radiergummi\OpenApi\Support\Generator\InferenceOnlyGeneration;
+
+uses()->group('openapi', 'lint');
+
+function inferenceViewFrom(OA\OpenApi $document): InferenceView
+{
+    return InferenceView::from(new InferenceOnlyGeneration($document, []));
+}
+
+it('resolves a control component schema by its component name', function (): void {
+    $child = new OA\Schema(['schema' => 'RefChildData', 'type' => 'object']);
+    $document = new OA\OpenApi([
+        'components' => new OA\Components(['schemas' => [$child]]),
+    ]);
+
+    expect(inferenceViewFrom($document)->schemaForName('RefChildData'))->toBe($child);
+});
+
+it('returns null for an unknown component name', function (): void {
+    $document = new OA\OpenApi([
+        'components' => new OA\Components(['schemas' => [
+            new OA\Schema(['schema' => 'Known', 'type' => 'object']),
+        ]]),
+    ]);
+
+    expect(inferenceViewFrom($document)->schemaForName('Unknown'))->toBeNull();
+});
+
+it('returns null by name when the document has no components', function (): void {
+    expect(inferenceViewFrom(new OA\OpenApi([]))->schemaForName('Anything'))->toBeNull();
+});

--- a/tests/Unit/Plugins/SwaggerPhp/SchemaEquivalenceTest.php
+++ b/tests/Unit/Plugins/SwaggerPhp/SchemaEquivalenceTest.php
@@ -243,4 +243,50 @@ it('does not subsume a recursive graph whose non-ref content differs', function 
     expect(new SchemaEquivalence($resolver)->subsumes($inferredA, $authoredA))->toBeFalse();
 });
 
+it('terminates on a mutual (A↔B) cyclic $ref graph and subsumes', function (): void {
+    // A.b -> B, B.a -> A on both sides; the visited-pair set accumulates two pairs before catching
+    // the loop, so this exercises a different traversal than the self-reference case.
+    $inferredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'b', 'ref' => '#/components/schemas/BData']),
+    ]]);
+    $inferredB = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'a', 'ref' => '#/components/schemas/AData']),
+    ]]);
+    $authoredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'b', 'ref' => '#/components/schemas/B']),
+    ]]);
+    $authoredB = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'a', 'ref' => '#/components/schemas/A']),
+    ]]);
+    $resolver = refResolver(
+        inferred: ['AData' => $inferredA, 'BData' => $inferredB],
+        authored: ['A' => $authoredA, 'B' => $authoredB],
+    );
+
+    expect(new SchemaEquivalence($resolver)->subsumes($inferredA, $authoredA))->toBeTrue();
+});
+
+it('does not subsume a mutual cyclic graph whose content differs on one node', function (): void {
+    $inferredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'b', 'ref' => '#/components/schemas/BData']),
+    ]]);
+    $inferredB = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'a', 'ref' => '#/components/schemas/AData']),
+    ]]);
+    $authoredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'b', 'ref' => '#/components/schemas/B']),
+    ]]);
+    // B's authored target carries an extra property inference does not reproduce.
+    $authoredB = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'a', 'ref' => '#/components/schemas/A']),
+        new OA\Property(['property' => 'extra', 'type' => 'string']),
+    ]]);
+    $resolver = refResolver(
+        inferred: ['AData' => $inferredA, 'BData' => $inferredB],
+        authored: ['A' => $authoredA, 'B' => $authoredB],
+    );
+
+    expect(new SchemaEquivalence($resolver)->subsumes($inferredA, $authoredA))->toBeFalse();
+});
+
 // endregion

--- a/tests/Unit/Plugins/SwaggerPhp/SchemaEquivalenceTest.php
+++ b/tests/Unit/Plugins/SwaggerPhp/SchemaEquivalenceTest.php
@@ -108,3 +108,139 @@ it('drops UNDEFINED elements inside a list before comparing', function (): void 
 
     expect(schemaEquivalence()->subsumes($broader, $narrower))->toBeTrue();
 });
+
+// region $ref-by-name following
+
+use Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint\Support\SchemaRefResolver;
+
+/**
+ * A schema with one property referencing `$refName`, mirroring a convention/authored component graph.
+ */
+function refParentSchema(string $refName): OA\Schema
+{
+    return new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'child', 'ref' => "#/components/schemas/{$refName}"]),
+    ]]);
+}
+
+/**
+ * @param array<string, ?OA\Schema> $inferred
+ * @param array<string, ?OA\Schema> $authored
+ */
+function refResolver(array $inferred, array $authored): SchemaRefResolver
+{
+    return new class ($inferred, $authored) implements SchemaRefResolver {
+        /**
+         * @param array<string, ?OA\Schema> $inferred
+         * @param array<string, ?OA\Schema> $authored
+         */
+        public function __construct(private array $inferred, private array $authored) {}
+
+        public function resolveInferred(string $name): ?OA\Schema
+        {
+            return $this->inferred[$name] ?? null;
+        }
+
+        public function resolveAuthored(string $name): ?OA\Schema
+        {
+            return $this->authored[$name] ?? null;
+        }
+    };
+}
+
+it('subsumes a differing $ref name whose target graphs are equivalent', function (): void {
+    $broader = refParentSchema('RefChildData');
+    $narrower = refParentSchema('RefChild');
+    $resolver = refResolver(
+        inferred: ['RefChildData' => new OA\Schema(['type' => 'object', 'properties' => [
+            new OA\Property(['property' => 'label', 'type' => 'string']),
+        ]])],
+        authored: ['RefChild' => new OA\Schema(['type' => 'object', 'properties' => [
+            new OA\Property(['property' => 'label', 'type' => 'string']),
+        ]])],
+    );
+
+    expect(new SchemaEquivalence($resolver)->subsumes($broader, $narrower))->toBeTrue();
+});
+
+it('does not subsume when the referenced target genuinely differs', function (): void {
+    $resolver = refResolver(
+        inferred: ['RefChildData' => new OA\Schema(['type' => 'object', 'properties' => [
+            new OA\Property(['property' => 'label', 'type' => 'string']),
+        ]])],
+        authored: ['RefChild' => new OA\Schema(['type' => 'object', 'properties' => [
+            new OA\Property(['property' => 'label', 'type' => 'integer']),
+        ]])],
+    );
+
+    expect(new SchemaEquivalence($resolver)->subsumes(refParentSchema('RefChildData'), refParentSchema('RefChild')))
+        ->toBeFalse();
+});
+
+it('does not subsume when either side ref is unresolvable (conservative)', function (): void {
+    $onlyInferred = refResolver(
+        inferred: ['RefChildData' => new OA\Schema(['type' => 'object'])],
+        authored: [],
+    );
+
+    expect(new SchemaEquivalence($onlyInferred)->subsumes(refParentSchema('RefChildData'), refParentSchema('RefChild')))
+        ->toBeFalse();
+});
+
+it('does not subsume a differing $ref with no resolver at all (today path unchanged)', function (): void {
+    expect(schemaEquivalence()->subsumes(refParentSchema('RefChildData'), refParentSchema('RefChild')))
+        ->toBeFalse();
+});
+
+it('does not consult the resolver when the $ref names are equal (short-circuit)', function (): void {
+    $spy = new class () implements SchemaRefResolver {
+        public function resolveInferred(string $name): ?OA\Schema
+        {
+            throw new RuntimeException('resolver consulted on equal-ref short-circuit');
+        }
+
+        public function resolveAuthored(string $name): ?OA\Schema
+        {
+            throw new RuntimeException('resolver consulted on equal-ref short-circuit');
+        }
+    };
+
+    expect(new SchemaEquivalence($spy)->subsumes(refParentSchema('Same'), refParentSchema('Same')))
+        ->toBeTrue();
+});
+
+it('terminates on a recursive (self-referential) $ref graph and subsumes', function (): void {
+    // A.self -> $ref A on both sides; the cycle's content matches, so it subsumes without looping.
+    $inferredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'self', 'ref' => '#/components/schemas/NodeData']),
+    ]]);
+    $authoredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'self', 'ref' => '#/components/schemas/Node']),
+    ]]);
+    $resolver = refResolver(
+        inferred: ['NodeData' => $inferredA],
+        authored: ['Node' => $authoredA],
+    );
+
+    expect(new SchemaEquivalence($resolver)->subsumes($inferredA, $authoredA))->toBeTrue();
+});
+
+it('does not subsume a recursive graph whose non-ref content differs', function (): void {
+    $inferredA = new OA\Schema(['type' => 'object', 'title' => 'Node', 'properties' => [
+        new OA\Property(['property' => 'self', 'ref' => '#/components/schemas/NodeData']),
+    ]]);
+    // The authored side adds a property inference does not carry, so containment fails despite the
+    // cycle resolving.
+    $authoredA = new OA\Schema(['type' => 'object', 'properties' => [
+        new OA\Property(['property' => 'self', 'ref' => '#/components/schemas/Node']),
+        new OA\Property(['property' => 'extra', 'type' => 'string']),
+    ]]);
+    $resolver = refResolver(
+        inferred: ['NodeData' => $inferredA],
+        authored: ['Node' => $authoredA],
+    );
+
+    expect(new SchemaEquivalence($resolver)->subsumes($inferredA, $authoredA))->toBeFalse();
+});
+
+// endregion


### PR DESCRIPTION
## Plan — follow `$ref` by name in `SchemaEquivalence` subsumption (#198)

Closes #198

### Feasibility probe (done first, per the #197 lesson) — scenario holds ✅

`SchemaEquivalence` compares `$ref` strings **literally** (`contains()` falls through to `==`). The
divergent-name scenario is **real and already present in the fixtures**:

- Convention names a component by `class_basename` — so inference emits
  `RefParentData.child → $ref: #/components/schemas/RefChildData`.
- The author chose a different name (`#[OA\Schema(schema: 'RefChild')]`) — so the authored
  `RefParentData.child → $ref: #/components/schemas/RefChild`.

Both point at the **same class** (`RefChildData`), whose schema inference and the author each
reproduce. But the ref strings differ, so subsumption fails today and `RefParentData` is kept even
though it is genuinely redundant. The fix lets the comparator follow both refs to their target
schemas and compare *those*. Acceptance is **unit tests on `SchemaEquivalence`** — self-contained,
exactly as the issue states. Not a #197-style empty premise. Proceeding.

### Tier

**Not a new rule — an algorithm refinement to the redundancy oracle.** Tier-0/1 territory (it reads
already-parsed annotation graphs; no body parsing). No `migration.*` ID added; the existing
`migration.oa-redundant-with-inference` simply stops under-reporting once the oracle can follow refs.

### Design

`SchemaEquivalence` must stay a **pure, independently-unit-testable comparator** — today every call
site is `new SchemaEquivalence()`. So ref-resolution is an **optional injected resolver**, defaulting
to "no resolution" (literal compare) so all existing call sites and the existing
`SchemaEquivalenceTest` cases are byte-for-byte unchanged.

- Introduce a tiny resolver seam, e.g. `SchemaEquivalence::__construct(?SchemaRefResolver $refs = null)`
  where `SchemaRefResolver::resolve(string $refName): ?OA\Schema`. **Two sides, two names:** the
  authored ref name resolves against the authored side, the broader ref name against the control
  side. Cleanest is a single resolver carrying both lookups, or pass a side-tagged resolver — pick
  one and keep it `@internal`. (Decision: one `SchemaRefResolver` with `resolveAuthored()` /
  `resolveInferred()`, since the two namespaces are distinct and must not be conflated.)
- In `contains()`, when **both** sides are schema-maps carrying a differing `$ref` (literal `==`
  already handles the equal-name case for free), resolve each name to its target schema and recurse
  into `contains(resolvedBroader, resolvedNarrower)`. Resolution applies only when literal compare
  fails, so the common path is untouched and cheap.
- **Cycle guard:** carry a visited-pair set (`{authoredName ⇒ inferredName}` already seen) down the
  recursion; on re-entry of a pair, return `true` (the cycle's equivalence is being established by the
  outer frame — standard coinductive bisimulation). A recursive schema graph must not loop.
- **Conservative fallback (load-bearing):** if **either** side's ref is unresolvable (no resolver, or
  the name isn't found), `contains` returns **false** for that branch (not subsumed → keep). Never a
  false redundancy verdict. This preserves today's behaviour exactly when no resolver is wired.

### Wiring the resolver where the rule runs

The rule (`OaRedundantWithInference`) constructs `SchemaSubsumption(new SchemaEquivalence(...))`.
Feed it a resolver backed by:
- **authored side:** `AuthoredAnnotationScanner::schemaForName($name)` (already exists).
- **inferred/control side:** a **by-name** component lookup the control document already contains but
  `InferenceView` does not yet expose. `InferenceOnlyGeneration.document->components->schemas` is keyed
  by component name; add `InferenceView::schemaForName(string $name): ?OA\Schema` (and thread the
  by-name map through `InferenceView::from()`), mirroring the existing `schemaForClass()`. Small,
  internal, additive.

`SchemaEquivalence` and the resolver are constructed in the rule/DI seam, not inside the comparator,
so the comparator stays dependency-light and unit-testable with a hand-built resolver stub.

### Files

**Create**
- `src/Plugins/SwaggerPhp/Lint/Support/SchemaRefResolver.php` — `@internal` interface (or small final
  class) with `resolveAuthored(string $name): ?OA\Schema` / `resolveInferred(string $name): ?OA\Schema`.
- (if the rule's concrete resolver needs a home) a small adapter wiring scanner + `InferenceView` to
  that interface — likely a private/anonymous impl in the rule or a one-file class under `Lint/Support/`.

**Modify**
- `src/Plugins/SwaggerPhp/Lint/Support/SchemaEquivalence.php` — optional resolver ctor arg; ref-follow
  branch in `contains()` with cycle guard + conservative fallback. Keep `@internal`. **This is the
  only behavioural change to the oracle.**
- `src/Lint/InferenceView.php` — add `schemaForName()` + thread the by-name component map through
  `from()`.
- `src/Support/Generator/InferenceOnlyGeneration.php` — if the by-name map isn't already derivable
  from `document->components->schemas` at `InferenceView::from()` time, expose it (prefer deriving in
  `InferenceView::from()` from `document` to avoid widening this VO).
- `src/Plugins/SwaggerPhp/Lint/OaRedundantWithInference.php` — construct `SchemaEquivalence` with the
  resolver. (Constructor already receives `SchemaEquivalence`; check whether to build the resolver here
  or in the DI factory — keep the rule's public constructor signature unchanged if possible; if the
  resolver must be injected, that's an `@internal` ctor change — flag it.)
- `CHANGELOG.md` `[Unreleased]` — Added/Changed entry (oracle now follows `$ref` by name).

**No `docs/linting.md` row** — internal oracle change, no new rule ID. Confirm with the reviewer but I
believe none is warranted; the existing `migration.oa-redundant-with-inference` row still describes it.

### Tests (TDD — failing first)

**Unit — extend `tests/Unit/Plugins/SwaggerPhp/SchemaEquivalenceTest.php`** (the issue's acceptance is
here). Build small `OA\Schema` graphs + a hand-written `SchemaRefResolver` stub:
- **(i) differing ref name, equivalent target → subsumed.** broader has `child → $ref: ChildA`,
  narrower has `child → $ref: ChildB`; resolver maps `ChildA`/`ChildB` to structurally equal schemas.
  `subsumes(broader, narrower)` is **true**. (This fails before the change.)
- **(ii) referenced target genuinely differs → not subsumed.** Same refs, but resolver maps them to
  schemas that differ (`type: string` vs `type: integer`). **false**.
- **(iii) unresolvable ref → not subsumed.** Resolver returns null for one side. **false** (and with
  **no** resolver at all, the pre-existing literal-mismatch behaviour: **false**).
- **(iv) equal ref names short-circuit** without consulting the resolver (assert via a resolver spy
  that throws if called) — the cheap common path stays cheap.
- **(v) cycle.** `A.self → $ref: A` on both sides (or `A→B→A`); resolver returns those schemas;
  `subsumes` **terminates** and returns **true**. A second cycle case where the cycle's non-ref
  content differs → **false**.
- Keep all existing `SchemaEquivalenceTest` cases green untouched (proves the default-no-resolver path
  is unchanged).

**Unit — `tests/Unit/Lint/InferenceViewTest.php`** (or extend an existing one): `schemaForName()`
returns the control component by name; null for an unknown name.

**Feature — extend `tests/Feature/SwaggerPhpMigrationRuleTest.php`**: with the resolver wired, the
existing divergent-name fixture pair (`RefParentData` → `RefChild`/`RefChildData`) is now **flagged
redundant** end-to-end (previously kept). Guard the inverse: a fixture whose referenced target
genuinely differs is **not** flagged. Reuse `RefParentData`/`RefChildData` if their current shape
already exhibits the divergence (it does: author `RefChild` vs convention `RefChildData`); confirm,
and add a "genuinely-differs" sibling fixture if none exists.
**Watch:** `RefParentData`/`RefChildData` currently back the *dangling-$ref guard* test ("does not
flag a schema another authored annotation still references by name"). Verify this change doesn't flip
that test's expectation — the guard is about RefChild being *kept* because RefParent still refs it;
RefParent itself becoming flaggable is orthogonal, but re-run that test and reconcile if it moves.

### Controversy / human-gate notes

- **`@internal` infra only.** `SchemaEquivalence`, `InferenceView`, `SchemaRefResolver`,
  `InferenceOnlyGeneration` are all `@internal`. No public/`Contracts\` surface, no new config key, no
  stage-order change, no new lint rule/severity.
- **Constructor-signature watch:** the change adds an optional ctor arg to `SchemaEquivalence`
  (default null = today's behaviour) and possibly threads a resolver into `OaRedundantWithInference`.
  Both `@internal`; the optional-arg default keeps every existing call site compiling unchanged. Call
  it out so the reviewer confirms no external constructor relies on the old arity.
- **Soundness is the whole point:** the conservative-fallback + cycle-guard cases are the
  acceptance-critical tests; the reviewer should weight those. If the resolver wiring balloons past
  ~150 LOC of `src/`, stop and flag for Moritz's gate (the #399 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 🤖 [reviewer1] plan-review amendments (verified empirically against `src/`)

**Approved.** I re-ran the feasibility probe end-to-end (throwaway generates, now deleted) and the scenario holds with one important nuance that *confirms* the side-tagged-resolver decision. Tier-0/1, surgical, `@internal`-only. Apply the precision note below.

**Empirical confirmation of the seam shape (pressure-test #1) — the side-tagged resolver is necessary, not speculative DI.** Verified for the `RefParentData` fixture:
- Inference-only doc: `RefParentData.child.ref = #/components/schemas/RefChildData` (class basename). `InferenceView::schemaForName('RefChildData')` will resolve; `scanner->schemaForName('RefChildData')` returns **null**.
- Authored (scanner): `RefParentData.child.ref = #/components/schemas/RefChild`. `scanner->schemaForName('RefChild')` resolves; the inferred side does **not** know `RefChild`.

So the broader-side ref and narrower-side ref live in **two genuinely distinct namespaces** — a single conflated lookup fails both ways. `resolveInferred()` (broader) + `resolveAuthored()` (narrower) is the correct, data-justified design. An **interface** seam is warranted here (not over-abstraction): the unit tests need a hand-built stub to keep `SchemaEquivalence` a pure, independently-testable comparator, which is the legitimate second implementation. Default-`null` preserves arity for all current call sites — verified: `new SchemaEquivalence()` (zero args) in `SchemaEquivalenceTest`, `SchemaSubsumptionTest`, `OperationSubsumptionTest`, plus the rule's wrappers — all keep compiling unchanged.

**[PRECISION — fix in code] The ref-follow branch must `normalize()` the resolved schemas before recursing.** `contains()` operates on **normalized** values (maps with `_`-internals + `UNDEFINED` + the `schema` name key already stripped), but the resolver returns raw `OA\Schema`. The plan's "recurse into `contains(resolvedBroader, resolvedNarrower)`" is imprecise — it must be `contains(normalize(resolvedBroader), normalize(resolvedNarrower))` (or route back through `subsumes()`), or the comparison will mis-handle raw annotation objects. Thread the cycle-visited set through whichever entry you choose.

**[PRECISION — trigger condition] The ref-follow branch fires inside the map-compare, keyed on the `ref` key.** There is no dedicated `$ref` handling in `contains()` today: a differing `ref` is just a map key whose two string values fail `==` (SchemaEquivalence.php:42,65-69). The new branch should trigger when, comparing two maps, **both** carry a `ref` key with differing string values — resolve each (broader via `resolveInferred`, narrower via `resolveAuthored`) and recurse. Equal `ref` strings already pass via `==` and must **not** consult the resolver (the spy-throws test pins this).

**Pressure-tests #2 / #3 — both satisfied.**
- Tests pin all four acceptance-critical cases (divergent-name-equivalent → subsumed; genuine-diff → not; conservative-unresolvable → keep; cycle terminates) plus the equal-name short-circuit spy and the unchanged existing cases. Add one explicit assertion: **no resolver at all** (default null) still returns the pre-existing literal-mismatch `false` for the divergent-ref pair — proves the zero-arg path is untouched.
- Fixture reconciliation is fine: the dangling-`$ref` guard test asserts the **child** (`RefChildData`) stays unflagged via `isSchemaReferencedByOtherAuthored('RefChild', …)`, which is independent of the **parent** (`RefParentData`) becoming flaggable. Orthogonal; re-run it but the expectation won't move.

**Controversy: none.** Optional ctor arg on an `@internal` comparator does not trip the public-signature gate (not `Contracts\`, not a documented extension point). No config key, no stage-order change, no new rule/severity. No `docs/linting.md` row (the existing `migration.oa-redundant-with-inference` row still describes it accurately — it just stops under-reporting). CHANGELOG entry is the only bookkeeping needed.
