### PR TITLE
chore(#379): migrate Rule metadata contract from getter methods to property requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project are documented here.
 - The inline `response()->noContent($status)` body-scan reads an explicit literal/named 2xx status (body-less); a non-literal or non-2xx status degrades. (#328)
 - A typed `UploadedFile` property on a Spatie `Data` class (transitively, through nested Data classes) emits a `multipart/form-data` body with a `format: binary` field, matching the FormRequest file-rule path; the `multipart.file-without-multipart` lint rule is reframed as a contradiction guard that fires only when a `#[RequestBody]` override forces a non-multipart media type onto a file-carrying payload. (#333)
 - The `migration.*` redundancy oracle (`SchemaEquivalence`) now follows a component `$ref` by name to its target schema on each side when the author and convention named the same component differently, so a parent schema whose only difference is a divergent child `$ref` name is no longer under-reported as non-redundant; resolution is conservative (an unresolvable ref keeps the annotation) and cycle-guarded. (#198)
+- Lint `Rule` contract now declares `id`, `severity`, and `description` as readable property requirements instead of getter methods; rule implementations declare them as plain typed properties with initializers. (#379)
 
 ### Fixed
 - Lint now surfaces top-level and field-level bare `oneOf` / `anyOf` schemas across components, responses, and request bodies. (#294, #318)

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -203,7 +203,29 @@ listing it imposes no runtime dependency.
    mirror `DataClassRequestSchemaResolver` for a `RequestSchemaResolver`, or
    `DataRefSchemaResolver` for a `RefSchemaResolver`).
 2. Optionally write lint rules under `Lint/Rules/`, implementing
-   `Contracts\Lint\Rule` plus the visitor interfaces they need.
+   `Contracts\Lint\Rule` plus the visitor interfaces they need. The `Rule`
+   contract declares its metadata as readable properties, so a rule supplies
+   them as plain typed properties with initializers:
+
+   ```php
+   use Override;
+   use Radiergummi\OpenApi\Contracts\Lint\Rule;
+   use Radiergummi\OpenApi\Contracts\Lint\Severity;
+   use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
+
+   final class OperationSummaryMissing implements Rule, OperationRuleVisitor
+   {
+       public string $id = 'operation.summary-missing';
+       public Severity $severity = Severity::Underspecified;
+       public string $description = 'Operation has no summary.';
+
+       #[Override]
+       public function checkOperation(OperationNode $operation, LintContext $context): iterable
+       {
+           // yield Finding instances for any violations
+       }
+   }
+   ```
 3. Write a `Plugin` class whose `register()` calls the matching
    `OpenApiRegistry` `add*` methods.
 4. Bind any services your resolvers need in a service provider (the bundled

--- a/src/Contracts/Lint/Rule.php
+++ b/src/Contracts/Lint/Rule.php
@@ -8,22 +8,22 @@ namespace Radiergummi\OpenApi\Contracts\Lint;
  * A lint rule registered with {@see RuleRegistry} and run by the lint pipeline.
  *
  * Implement one or more visitor interfaces (e.g. {@see OperationRule}) to receive tree-walk
- * callbacks. Every rule must declare a stable `id()` for config overrides and `#[IgnoreLint]`.
+ * callbacks. Every rule must declare a stable `$id` for config overrides and `#[IgnoreLint]`.
  */
 interface Rule
 {
     /**
      * Stable, dot-namespaced identifier (e.g. `operation.id-missing`); must be unique.
      */
-    public function id(): string;
+    public string $id { get; }
 
     /**
      * Severity of the findings this rule emits. Lower is more severe.
      */
-    public function severity(): Severity;
+    public Severity $severity { get; }
 
     /**
      * One-line description of what the rule checks; shown by `openapi:lint --list`.
      */
-    public function description(): string;
+    public string $description { get; }
 }

--- a/src/Lint/Fix/FixRunner.php
+++ b/src/Lint/Fix/FixRunner.php
@@ -139,7 +139,7 @@ final readonly class FixRunner
 
         foreach ($this->registry->all() as $rule) {
             if ($rule instanceof FixableRule) {
-                $fixers[$rule->id()] = $rule->fixer();
+                $fixers[$rule->id] = $rule->fixer();
             }
         }
 

--- a/src/Lint/LintRunner.php
+++ b/src/Lint/LintRunner.php
@@ -180,7 +180,7 @@ final readonly class LintRunner
             $rules = array_values(
                 array_filter(
                     $rules,
-                    static fn(Rule $rule): bool => $rule->id() !== RuleRegistry::EXEMPT_RULE_ID,
+                    static fn(Rule $rule): bool => $rule->id !== RuleRegistry::EXEMPT_RULE_ID,
                 ),
             );
         }
@@ -713,11 +713,11 @@ final readonly class LintRunner
      */
     private function metaRuleEnabled(Rule $rule, int $level, array $only, array $skip): bool
     {
-        $effectiveLevel = $this->registry->effectiveLevelFor($rule->id(), $rule->severity());
+        $effectiveLevel = $this->registry->effectiveLevelFor($rule->id, $rule->severity);
 
         return $effectiveLevel->value <= $level
-            && ($only === [] || in_array($rule->id(), $only, true))
-            && !in_array($rule->id(), $skip, true);
+            && ($only === [] || in_array($rule->id, $only, true))
+            && !in_array($rule->id, $skip, true);
     }
 
     /**

--- a/src/Lint/RuleCatalogRenderer.php
+++ b/src/Lint/RuleCatalogRenderer.php
@@ -54,9 +54,9 @@ final readonly class RuleCatalogRenderer
         $rows = array_map(
             static fn(Rule $rule): array
                 => [
-                    'id' => $rule->id(),
-                    'level' => $rule->severity()->value,
-                    'description' => $rule->description(),
+                    'id' => $rule->id,
+                    'level' => $rule->severity->value,
+                    'description' => $rule->description,
                 ],
             $registry->all(),
         );

--- a/src/Lint/RuleRegistry.php
+++ b/src/Lint/RuleRegistry.php
@@ -73,11 +73,11 @@ final class RuleRegistry
                 continue;
             }
 
-            if ($only !== [] && !in_array($rule->id(), $only, true)) {
+            if ($only !== [] && !in_array($rule->id, $only, true)) {
                 continue;
             }
 
-            if (in_array($rule->id(), $skip, true)) {
+            if (in_array($rule->id, $skip, true)) {
                 continue;
             }
 
@@ -89,7 +89,7 @@ final class RuleRegistry
 
     private function effectiveLevel(Rule $rule): Severity
     {
-        return $this->effectiveLevelFor($rule->id(), $rule->severity());
+        return $this->effectiveLevelFor($rule->id, $rule->severity);
     }
 
     /**
@@ -121,7 +121,7 @@ final class RuleRegistry
         $ids = [];
 
         foreach ($this->rules as $rule) {
-            $ids[] = $rule->id();
+            $ids[] = $rule->id;
         }
 
         return $ids;

--- a/src/Lint/Rules/AbstractNamingRule.php
+++ b/src/Lint/Rules/AbstractNamingRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\IdentifierCase;
@@ -20,9 +19,13 @@ use function sprintf;
  * Accepts either an {@see IdentifierCase} enum or the raw config string from
  * `openapi.lint.style.*`; {@see IdentifierCase::fromConfig()} normalises both forms.
  */
-abstract readonly class AbstractNamingRule implements Rule
+abstract class AbstractNamingRule implements Rule
 {
-    protected IdentifierCase $case;
+    public Severity $severity = Severity::Inconsistent;
+
+    abstract public string $description { get; }
+
+    protected readonly IdentifierCase $case;
 
     /**
      * @throws TypeError
@@ -32,15 +35,6 @@ abstract readonly class AbstractNamingRule implements Rule
     {
         $this->case = IdentifierCase::fromConfig($case);
     }
-
-    #[Override]
-    final public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
-
-    #[Override]
-    abstract public function description(): string;
 
     /**
      * Whether the given name conforms to the configured case.

--- a/src/Lint/Rules/ActionMissingReturnType.php
+++ b/src/Lint/Rules/ActionMissingReturnType.php
@@ -25,6 +25,10 @@ use function sprintf;
  */
 final class ActionMissingReturnType implements Rule, OperationRuleVisitor
 {
+    public string $id = 'operation.return-type-missing';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Action has no typed return value or response attribute, so no response schema can be inferred.';
+
     /**
      * @return iterable<Finding>
      */
@@ -42,8 +46,8 @@ final class ActionMissingReturnType implements Rule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s::%s() has no return type or response attribute, so no response schema can be inferred',
                 $descriptor->controller?->getShortName() ?? '(unknown)',
@@ -78,21 +82,6 @@ final class ActionMissingReturnType implements Rule, OperationRuleVisitor
         return !in_array($returnType->getName(), ['mixed', 'void', 'never'], true);
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.return-type-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Action has no typed return value or response attribute, so no response schema can be inferred.';
-    }
 }

--- a/src/Lint/Rules/ComponentNameNamingInconsistent.php
+++ b/src/Lint/Rules/ComponentNameNamingInconsistent.php
@@ -19,8 +19,11 @@ use function sprintf;
  * Reports component schema names that do not follow the configured naming convention.
  */
 #[Scoped]
-final readonly class ComponentNameNamingInconsistent extends AbstractNamingRule implements ComponentSchemaRuleVisitor
+final class ComponentNameNamingInconsistent extends AbstractNamingRule implements ComponentSchemaRuleVisitor
 {
+    public string $id = 'component.name-naming-inconsistent';
+    public string $description = 'Component schema name does not follow the configured component_name_case convention.';
+
     public function __construct(
         #[Config('openapi.lint.style.component_name_case', 'pascal')]
         IdentifierCase|string $case = IdentifierCase::Pascal,
@@ -39,8 +42,8 @@ final readonly class ComponentNameNamingInconsistent extends AbstractNamingRule 
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Component schema name "%s" does not follow the %s naming convention',
                 $componentSchema->name,
@@ -50,15 +53,5 @@ final readonly class ComponentNameNamingInconsistent extends AbstractNamingRule 
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'component.name-naming-inconsistent';
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Component schema name does not follow the configured component_name_case convention.';
-    }
 }

--- a/src/Lint/Rules/ComponentOrphaned.php
+++ b/src/Lint/Rules/ComponentOrphaned.php
@@ -22,6 +22,10 @@ use function sprintf;
  */
 final class ComponentOrphaned implements Rule, ApiRuleVisitor
 {
+    public string $id = 'component.orphaned';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Component schema is registered but never referenced.';
+
     /**
      * @return iterable<Finding>
      */
@@ -40,8 +44,8 @@ final class ComponentOrphaned implements Rule, ApiRuleVisitor
                 }
 
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Component #/components/%s/%s is defined but never referenced',
                         $type,
@@ -55,21 +59,6 @@ final class ComponentOrphaned implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'component.orphaned';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Component schema is registered but never referenced.';
-    }
 }

--- a/src/Lint/Rules/DeprecatedAttribute.php
+++ b/src/Lint/Rules/DeprecatedAttribute.php
@@ -28,6 +28,10 @@ use function str_starts_with;
  */
 final class DeprecatedAttribute implements Rule, OperationRuleVisitor, Resettable
 {
+    public string $id = 'deprecated.attribute';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'A deprecated authoring attribute (#[Deprecated] or @deprecated) is still used on a controller.';
+
     private readonly string $attributeNamespace;
 
     /** @var array<class-string, ReflectionClass<object>> */
@@ -108,8 +112,8 @@ final class DeprecatedAttribute implements Rule, OperationRuleVisitor, Resettabl
             $shortName = $attrReflection->getShortName();
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Attribute #[%s] is deprecated and should be replaced on %s',
                     $shortName,
@@ -136,21 +140,6 @@ final class DeprecatedAttribute implements Rule, OperationRuleVisitor, Resettabl
         return str_contains($docComment, '@deprecated');
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'deprecated.attribute';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A deprecated authoring attribute (#[Deprecated] or @deprecated) is still used on a controller.';
-    }
 }

--- a/src/Lint/Rules/DeprecatedNoReplacement.php
+++ b/src/Lint/Rules/DeprecatedNoReplacement.php
@@ -24,6 +24,10 @@ use function sprintf;
  */
 final class DeprecatedNoReplacement implements Rule, OperationRuleVisitor
 {
+    public string $id = 'deprecated.no-replacement';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'Deprecated operation/field has no x-replacement or suggested alternative.';
+
     private const string REPLACEMENT_PATTERN = "/\b(use|replaced\s+by|replacement|sunset)\b/i";
 
     /**
@@ -51,8 +55,8 @@ final class DeprecatedNoReplacement implements Rule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Deprecated operation %s %s does not mention a replacement in its description',
                 $operation->method->forDisplay(),
@@ -62,21 +66,6 @@ final class DeprecatedNoReplacement implements Rule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'deprecated.no-replacement';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Deprecated operation/field has no x-replacement or suggested alternative.';
-    }
 }

--- a/src/Lint/Rules/DeprecatedNoSunsetDate.php
+++ b/src/Lint/Rules/DeprecatedNoSunsetDate.php
@@ -22,6 +22,10 @@ use function sprintf;
  */
 final class DeprecatedNoSunsetDate implements Rule, OperationRuleVisitor
 {
+    public string $id = 'deprecated.no-sunset-date';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'Deprecated operation has no x-sunset date.';
+
     private const string DATE_PATTERN = "/\b(\d{4}-\d{2}-\d{2}|Q[1-4]\s*\d{4})\b/";
 
     /**
@@ -49,8 +53,8 @@ final class DeprecatedNoSunsetDate implements Rule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Deprecated operation %s %s does not mention a sunset date or timeline',
                 $operation->method->forDisplay(),
@@ -60,21 +64,6 @@ final class DeprecatedNoSunsetDate implements Rule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'deprecated.no-sunset-date';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Deprecated operation has no x-sunset date.';
-    }
 }

--- a/src/Lint/Rules/DiscriminatorInvalidMapping.php
+++ b/src/Lint/Rules/DiscriminatorInvalidMapping.php
@@ -29,6 +29,10 @@ use function str_starts_with;
  */
 final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisitor, Finalizable, Resettable
 {
+    public string $id = 'discriminator.invalid-mapping';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Discriminator mapping references a missing component schema.';
+
     /** @var array<string, OA\Schema> */
     private array $schemaMap = [];
 
@@ -107,8 +111,8 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
 
             if ($targetSchema === null) {
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Discriminator mapping "%s" on schema "%s" references unknown schema "%s"',
                         $discriminatorValue,
@@ -130,8 +134,8 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
 
             if (!$this->schemaHasProperty($targetSchema, $propertyName, $schemaMap)) {
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Schema "%s" mapped by discriminator on "%s" does not declare property "%s"',
                         $targetSchemaName,
@@ -172,17 +176,7 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
         return null;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'discriminator.invalid-mapping';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
     /**
      * @param array<string, OA\Schema> $schemaMap
@@ -262,9 +256,4 @@ final class DiscriminatorInvalidMapping implements Rule, ComponentSchemaRuleVisi
         return false;
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Discriminator mapping references a missing component schema.';
-    }
 }

--- a/src/Lint/Rules/EnumValuesUndocumented.php
+++ b/src/Lint/Rules/EnumValuesUndocumented.php
@@ -26,6 +26,10 @@ use function trim;
  */
 final class EnumValuesUndocumented implements Rule, FieldRuleVisitor
 {
+    public string $id = 'enum.values-undocumented';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Enum field has no description explaining the allowed values.';
+
     private const string LIST_PATTERN = "/^\s*[-*]\s+/m";
 
     /**
@@ -42,8 +46,8 @@ final class EnumValuesUndocumented implements Rule, FieldRuleVisitor
 
         if ($description === null || trim($description) === '') {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Enum field "%s" has no description documenting its values',
                     $field->name,
@@ -59,8 +63,8 @@ final class EnumValuesUndocumented implements Rule, FieldRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Enum field "%s" description does not mention any of its values',
                 $field->name,
@@ -69,17 +73,7 @@ final class EnumValuesUndocumented implements Rule, FieldRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'enum.values-undocumented';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
     /**
      * @param list<mixed> $enumValues
@@ -96,9 +90,4 @@ final class EnumValuesUndocumented implements Rule, FieldRuleVisitor
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Enum field has no description explaining the allowed values.';
-    }
 }

--- a/src/Lint/Rules/ErrorsResolverFailed.php
+++ b/src/Lint/Rules/ErrorsResolverFailed.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Support\Generator\Stages\ErrorResponseInferenceStage;
@@ -16,6 +15,10 @@ use Radiergummi\OpenApi\Support\Generator\Stages\ErrorResponseInferenceStage;
  */
 final class ErrorsResolverFailed implements Rule
 {
+    public string $id = 'errors.resolver-failed';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'An ErrorResponseResolver threw while resolving an error response body; the chain continued and a bodyless response was emitted.';
+
     /**
      * fixHint: alias for {@see ErrorResponseInferenceStage::RESOLVER_FAILED_FIX_HINT}. The
      * stage emits this hint with every `errors.resolver-failed` finding; the alias here lets
@@ -24,21 +27,6 @@ final class ErrorsResolverFailed implements Rule
      */
     public const string FIX_HINT = ErrorResponseInferenceStage::RESOLVER_FAILED_FIX_HINT;
 
-    #[Override]
-    public function id(): string
-    {
-        return 'errors.resolver-failed';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'An ErrorResponseResolver threw while resolving an error response body; the chain continued and a bodyless response was emitted.';
-    }
 }

--- a/src/Lint/Rules/ExternaldocsInvalidUrl.php
+++ b/src/Lint/Rules/ExternaldocsInvalidUrl.php
@@ -23,6 +23,10 @@ use const FILTER_VALIDATE_URL;
 
 final class ExternaldocsInvalidUrl implements Rule, OperationRuleVisitor
 {
+    public string $id = 'externaldocs.invalid-url';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'externalDocs.url is not a valid URL.';
+
     /**
      * @return iterable<Finding>
      */
@@ -60,8 +64,8 @@ final class ExternaldocsInvalidUrl implements Rule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'ExternalDocs URL "%s" on %s::%s() is not a valid HTTP(S) URL',
                     $url,
@@ -73,21 +77,6 @@ final class ExternaldocsInvalidUrl implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'externaldocs.invalid-url';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'externalDocs.url is not a valid URL.';
-    }
 }

--- a/src/Lint/Rules/FieldConflictingType.php
+++ b/src/Lint/Rules/FieldConflictingType.php
@@ -16,6 +16,10 @@ use function sprintf;
 
 final class FieldConflictingType extends AbstractFieldRule
 {
+    public string $id = 'field.conflicting-type';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Field declares conflicting type and format values.';
+
     /**
      * Maps PHP built-in type names to OpenAPI type strings.
      *
@@ -29,11 +33,6 @@ final class FieldConflictingType extends AbstractFieldRule
         'array' => 'array',
     ];
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Field declares conflicting type and format values.';
-    }
 
     /**
      * @return iterable<Finding>
@@ -74,8 +73,8 @@ final class FieldConflictingType extends AbstractFieldRule
         );
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: $message,
             fixHint: sprintf(
                 'Change the #[%s] type to "%s" or adjust the PHP type hint.',
@@ -85,15 +84,5 @@ final class FieldConflictingType extends AbstractFieldRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.conflicting-type';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 }

--- a/src/Lint/Rules/FieldDescriptionMissing.php
+++ b/src/Lint/Rules/FieldDescriptionMissing.php
@@ -20,6 +20,10 @@ use function trim;
  */
 final class FieldDescriptionMissing implements Rule, FieldRuleVisitor
 {
+    public string $id = 'field.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Schema property has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -31,28 +35,13 @@ final class FieldDescriptionMissing implements Rule, FieldRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf('Schema property "%s" has no description', $field->name),
             fixHint: 'Add a description to the schema property explaining its meaning and constraints.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Schema property has no description.';
-    }
 }

--- a/src/Lint/Rules/FieldEnumMismatch.php
+++ b/src/Lint/Rules/FieldEnumMismatch.php
@@ -22,11 +22,10 @@ use function sprintf;
 
 final class FieldEnumMismatch extends AbstractFieldRule
 {
-    #[Override]
-    public function description(): string
-    {
-        return "Enum value type doesn't match the field's declared type.";
-    }
+    public string $id = 'field.enum-mismatch';
+    public Severity $severity = Severity::Broken;
+    public string $description = "Enum value type doesn't match the field's declared type.";
+
 
     /**
      * @return iterable<Finding>
@@ -91,8 +90,8 @@ final class FieldEnumMismatch extends AbstractFieldRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '#[%s] enum values on %s::$%s do not match %s cases: %s',
                 $this->attributeName($field),
@@ -109,15 +108,5 @@ final class FieldEnumMismatch extends AbstractFieldRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.enum-mismatch';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 }

--- a/src/Lint/Rules/FieldInvalidFormat.php
+++ b/src/Lint/Rules/FieldInvalidFormat.php
@@ -17,6 +17,10 @@ use function sprintf;
 
 final class FieldInvalidFormat extends AbstractFieldRule
 {
+    public string $id = 'field.invalid-format';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'format value is not a recognised OAS 3.1 format (custom formats are advisory but non-standard).';
+
     /** @var list<string> */
     private const array VALID_FORMATS = [
         'date-time',
@@ -47,11 +51,6 @@ final class FieldInvalidFormat extends AbstractFieldRule
         'uri-template',
     ];
 
-    #[Override]
-    public function description(): string
-    {
-        return 'format value is not a recognised OAS 3.1 format (custom formats are advisory but non-standard).';
-    }
 
     /**
      * @return iterable<Finding>
@@ -71,8 +70,8 @@ final class FieldInvalidFormat extends AbstractFieldRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Property %s::$%s uses non-standard format "%s" in #[%s]; consider using a registered OAS 3.1 format',
                 $property->getDeclaringClass()->getName(),
@@ -87,15 +86,5 @@ final class FieldInvalidFormat extends AbstractFieldRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.invalid-format';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 }

--- a/src/Lint/Rules/FieldNameNamingInconsistent.php
+++ b/src/Lint/Rules/FieldNameNamingInconsistent.php
@@ -21,8 +21,11 @@ use function sprintf;
  * Recursion into nested objects is handled by the walker; this rule only checks the single node passed in.
  */
 #[Scoped]
-final readonly class FieldNameNamingInconsistent extends AbstractNamingRule implements FieldRuleVisitor
+final class FieldNameNamingInconsistent extends AbstractNamingRule implements FieldRuleVisitor
 {
+    public string $id = 'field.name-naming-inconsistent';
+    public string $description = "Field name doesn't follow the project's property_name_case convention.";
+
     public function __construct(
         #[Config('openapi.lint.style.property_name_case', 'camel')]
         IdentifierCase|string $case = IdentifierCase::Camel,
@@ -41,8 +44,8 @@ final readonly class FieldNameNamingInconsistent extends AbstractNamingRule impl
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Field name "%s" does not follow the %s naming convention',
                 $field->name,
@@ -52,15 +55,5 @@ final readonly class FieldNameNamingInconsistent extends AbstractNamingRule impl
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.name-naming-inconsistent';
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Field name doesn't follow the project's property_name_case convention.";
-    }
 }

--- a/src/Lint/Rules/FieldNoEffect.php
+++ b/src/Lint/Rules/FieldNoEffect.php
@@ -20,11 +20,10 @@ use function sprintf;
 
 final class FieldNoEffect extends AbstractFieldRule implements FixableRule
 {
-    #[Override]
-    public function description(): string
-    {
-        return 'A field attribute was applied but has no visible effect on the schema.';
-    }
+    public string $id = 'field.no-effect';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'A field attribute was applied but has no visible effect on the schema.';
+
 
     /** Removes the no-op attribute; location is identified via context keys stamped by {@see AbstractFieldRule}. */
     #[Override]
@@ -51,8 +50,8 @@ final class FieldNoEffect extends AbstractFieldRule implements FixableRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '#[%s] on %s::$%s has no parameters set — the attribute has no effect',
                 $this->attributeName($field),
@@ -92,15 +91,5 @@ final class FieldNoEffect extends AbstractFieldRule implements FixableRule
             && $field->conditional === false;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.no-effect';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 }

--- a/src/Lint/Rules/HeaderDescriptionMissing.php
+++ b/src/Lint/Rules/HeaderDescriptionMissing.php
@@ -21,6 +21,10 @@ use function trim;
  */
 final class HeaderDescriptionMissing implements Rule, HeaderRuleVisitor
 {
+    public string $id = 'header.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Response header has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -35,8 +39,8 @@ final class HeaderDescriptionMissing implements Rule, HeaderRuleVisitor
         $operation = $parent instanceof ResponseNode ? $parent->operation() : null;
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Header "%s" on %s %s has no description',
                 $header->name,
@@ -47,21 +51,6 @@ final class HeaderDescriptionMissing implements Rule, HeaderRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'header.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Response header has no description.';
-    }
 }

--- a/src/Lint/Rules/HeaderInvalidName.php
+++ b/src/Lint/Rules/HeaderInvalidName.php
@@ -24,6 +24,10 @@ use function sprintf;
  */
 final class HeaderInvalidName implements Rule, OperationRuleVisitor
 {
+    public string $id = 'header.invalid-name';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Header name contains invalid characters.';
+
     /** HTTP token grammar from RFC 7230 §3.2.6. */
     private const string HTTP_TOKEN_PATTERN = '/^[A-Za-z0-9!#$%&\'*+.^_`|~-]+$/';
 
@@ -57,8 +61,8 @@ final class HeaderInvalidName implements Rule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Header name "%s" on %s::%s() is not a valid HTTP token',
                     $header->name,
@@ -70,21 +74,6 @@ final class HeaderInvalidName implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'header.invalid-name';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Header name contains invalid characters.';
-    }
 }

--- a/src/Lint/Rules/HeaderNameNamingInconsistent.php
+++ b/src/Lint/Rules/HeaderNameNamingInconsistent.php
@@ -20,8 +20,11 @@ use function sprintf;
  * HTTP header names are case-insensitive (RFC 7230), so this is a documentation consistency check.
  */
 #[Scoped]
-final readonly class HeaderNameNamingInconsistent extends AbstractNamingRule implements HeaderRuleVisitor
+final class HeaderNameNamingInconsistent extends AbstractNamingRule implements HeaderRuleVisitor
 {
+    public string $id = 'header.name-naming-inconsistent';
+    public string $description = "Header name doesn't follow the project's header_case convention.";
+
     public function __construct(
         #[Config('openapi.lint.style.header_case', 'train')]
         IdentifierCase|string $case = IdentifierCase::Train,
@@ -40,8 +43,8 @@ final readonly class HeaderNameNamingInconsistent extends AbstractNamingRule imp
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Header name "%s" does not follow the %s naming convention',
                 $header->name,
@@ -51,15 +54,5 @@ final readonly class HeaderNameNamingInconsistent extends AbstractNamingRule imp
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'header.name-naming-inconsistent';
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Header name doesn't follow the project's header_case convention.";
-    }
 }

--- a/src/Lint/Rules/HideExposeConflict.php
+++ b/src/Lint/Rules/HideExposeConflict.php
@@ -24,11 +24,10 @@ use function sprintf;
  */
 final class HideExposeConflict implements Rule, RouteRule
 {
-    #[Override]
-    public function description(): string
-    {
-        return 'Route carries overlapping #[Hide] and #[Expose] in the current environment.';
-    }
+    public string $id = 'visibility.hide-expose-conflict';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Route carries overlapping #[Hide] and #[Expose] in the current environment.';
+
 
     /**
      * @return iterable<Finding>
@@ -53,8 +52,8 @@ final class HideExposeConflict implements Rule, RouteRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Route carries both #[Hide] and #[Expose] attributes that apply in environment "%s". #[Hide] wins.',
                 $env,
@@ -63,15 +62,5 @@ final class HideExposeConflict implements Rule, RouteRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'visibility.hide-expose-conflict';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 }

--- a/src/Lint/Rules/InfoDescriptionMissing.php
+++ b/src/Lint/Rules/InfoDescriptionMissing.php
@@ -22,6 +22,10 @@ use function trim;
  */
 final class InfoDescriptionMissing implements Rule, ApiRuleVisitor
 {
+    public string $id = 'info.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'The document info.description is empty.';
+
     /**
      * @return iterable<Finding>
      */
@@ -33,8 +37,8 @@ final class InfoDescriptionMissing implements Rule, ApiRuleVisitor
         // UNDEFINED when spec is incomplete, not merely null
         if (is_undefined($info) || $info === null) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'The document info object is missing',
                 location: new FindingLocation(jsonPointer: '#/info'),
                 fixHint: 'Add an info.description to the OpenAPI document.',
@@ -51,8 +55,8 @@ final class InfoDescriptionMissing implements Rule, ApiRuleVisitor
             || trim($description) === ''
         ) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'The document info.description is empty',
                 location: new FindingLocation(jsonPointer: '#/info/description'),
                 fixHint: 'Add a description to info explaining the API purpose and intended audience.',
@@ -60,21 +64,6 @@ final class InfoDescriptionMissing implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'info.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'The document info.description is empty.';
-    }
 }

--- a/src/Lint/Rules/InfoMetadataIncomplete.php
+++ b/src/Lint/Rules/InfoMetadataIncomplete.php
@@ -21,6 +21,10 @@ use function Radiergummi\OpenApi\is_undefined;
  */
 final class InfoMetadataIncomplete implements Rule, ApiRuleVisitor
 {
+    public string $id = 'info.metadata-incomplete';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'The document info is missing contact and/or license.';
+
     /**
      * @return iterable<Finding>
      */
@@ -50,29 +54,14 @@ final class InfoMetadataIncomplete implements Rule, ApiRuleVisitor
         $missingList = implode(' and ', $missing);
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: "The document info is missing {$missingList}",
             location: new FindingLocation(jsonPointer: '#/info'),
             fixHint: 'Add the missing ' . $missingList . ' field(s) to the info object.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'info.metadata-incomplete';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'The document info is missing contact and/or license.';
-    }
 }

--- a/src/Lint/Rules/LinkBothOperationIdAndRef.php
+++ b/src/Lint/Rules/LinkBothOperationIdAndRef.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class LinkBothOperationIdAndRef implements Rule, LinkRuleVisitor
 {
+    public string $id = 'link.both-operation-id-and-ref';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Link declares both operationId and operationRef (mutually exclusive).';
+
     /**
      * @return iterable<Finding>
      */
@@ -35,8 +39,8 @@ final class LinkBothOperationIdAndRef implements Rule, LinkRuleVisitor
         $routeUri = $operation?->pathUri;
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Link "%s" on %s %s sets both operationId ("%s") and operationRef ("%s"); only one is allowed',
                 $link->name,
@@ -49,21 +53,6 @@ final class LinkBothOperationIdAndRef implements Rule, LinkRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'link.both-operation-id-and-ref';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Link declares both operationId and operationRef (mutually exclusive).';
-    }
 }

--- a/src/Lint/Rules/LinkDuplicateName.php
+++ b/src/Lint/Rules/LinkDuplicateName.php
@@ -28,6 +28,10 @@ use function sprintf;
  */
 final class LinkDuplicateName implements FixableRule, OperationRuleVisitor
 {
+    public string $id = 'link.duplicate-name';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Two links on the same response share the same name.';
+
     /**
      * @return iterable<Finding>
      */
@@ -57,8 +61,8 @@ final class LinkDuplicateName implements FixableRule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Link name "%s" is declared %d times on %s::%s()',
                     $name,
@@ -72,17 +76,7 @@ final class LinkDuplicateName implements FixableRule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'link.duplicate-name';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -98,9 +92,4 @@ final class LinkDuplicateName implements FixableRule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two links on the same response share the same name.';
-    }
 }

--- a/src/Lint/Rules/LinkInvalidOperation.php
+++ b/src/Lint/Rules/LinkInvalidOperation.php
@@ -19,6 +19,10 @@ use function sprintf;
  */
 final class LinkInvalidOperation implements Rule, LinkRuleVisitor
 {
+    public string $id = 'link.invalid-operation';
+    public Severity $severity = Severity::Degraded;
+    public string $description = "Link references an operationId that doesn't exist in the document.";
+
     /**
      * @return iterable<Finding>
      */
@@ -45,28 +49,13 @@ final class LinkInvalidOperation implements Rule, LinkRuleVisitor
         );
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: $message,
             fixHint: 'Fix the operationId, or use operationRef for cross-document links.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'link.invalid-operation';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Link references an operationId that doesn't exist in the document.";
-    }
 }

--- a/src/Lint/Rules/LinkInvalidParameter.php
+++ b/src/Lint/Rules/LinkInvalidParameter.php
@@ -28,6 +28,10 @@ use function sprintf;
  */
 final class LinkInvalidParameter implements Rule, LinkRuleVisitor
 {
+    public string $id = 'link.invalid-parameter';
+    public Severity $severity = Severity::Broken;
+    public string $description = "Link references a parameter that the target operation doesn't declare.";
+
     /**
      * @return iterable<Finding>
      */
@@ -68,8 +72,8 @@ final class LinkInvalidParameter implements Rule, LinkRuleVisitor
             );
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: $message,
                 fixHint: 'Remove the parameter or add it to the target operation.',
             );
@@ -89,21 +93,6 @@ final class LinkInvalidParameter implements Rule, LinkRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'link.invalid-parameter';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Link references a parameter that the target operation doesn't declare.";
-    }
 }

--- a/src/Lint/Rules/LinkNeitherOperationIdNorRef.php
+++ b/src/Lint/Rules/LinkNeitherOperationIdNorRef.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class LinkNeitherOperationIdNorRef implements Rule, LinkRuleVisitor
 {
+    public string $id = 'link.neither-operation-id-nor-ref';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Link has neither operationId nor operationRef.';
+
     /**
      * @return iterable<Finding>
      */
@@ -41,28 +45,13 @@ final class LinkNeitherOperationIdNorRef implements Rule, LinkRuleVisitor
         );
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: $message,
             fixHint: 'Add either operationId (for same-document links) or operationRef (for cross-document links).',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'link.neither-operation-id-nor-ref';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Link has neither operationId nor operationRef.';
-    }
 }

--- a/src/Lint/Rules/LinkParameterRequiredMissing.php
+++ b/src/Lint/Rules/LinkParameterRequiredMissing.php
@@ -25,6 +25,10 @@ use function sprintf;
  */
 final class LinkParameterRequiredMissing implements Rule, LinkRuleVisitor
 {
+    public string $id = 'link.parameter-required-missing';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Link omits a parameter that the target operation requires.';
+
     /**
      * @return iterable<Finding>
      */
@@ -61,8 +65,8 @@ final class LinkParameterRequiredMissing implements Rule, LinkRuleVisitor
             );
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: $message,
                 fixHint: 'Add the missing required parameter to the Link parameters map.',
             );
@@ -89,21 +93,6 @@ final class LinkParameterRequiredMissing implements Rule, LinkRuleVisitor
         return $names;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'link.parameter-required-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Link omits a parameter that the target operation requires.';
-    }
 }

--- a/src/Lint/Rules/MetaNoSuppressionReason.php
+++ b/src/Lint/Rules/MetaNoSuppressionReason.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class MetaNoSuppressionReason implements Rule, ApiRuleVisitor
 {
+    public string $id = 'meta.no-suppression-reason';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = '#[IgnoreLint] has no reason parameter.';
+
     /**
      * @return iterable<Finding>
      */
@@ -32,8 +36,8 @@ final class MetaNoSuppressionReason implements Rule, ApiRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     "Suppression of '%s' has no reason — change to #[IgnoreLint('%s', reason: '…')]",
                     $directive->ruleId,
@@ -48,21 +52,6 @@ final class MetaNoSuppressionReason implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'meta.no-suppression-reason';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return '#[IgnoreLint] has no reason parameter.';
-    }
 }

--- a/src/Lint/Rules/MetaSuppressionStale.php
+++ b/src/Lint/Rules/MetaSuppressionStale.php
@@ -25,6 +25,10 @@ use function sprintf;
  */
 final class MetaSuppressionStale implements Rule, PostWalkRule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = '#[IgnoreLint] directive did not suppress any finding.';
+
     /** Not in the registered rule set, so callers reference the ID via this constant. */
     public const string ID = 'meta.suppression-stale';
 
@@ -52,8 +56,8 @@ final class MetaSuppressionStale implements Rule, PostWalkRule
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Suppression for %s did not suppress any finding — it may be stale',
                     $directive->ruleId,
@@ -80,21 +84,6 @@ final class MetaSuppressionStale implements Rule, PostWalkRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return '#[IgnoreLint] directive did not suppress any finding.';
-    }
 }

--- a/src/Lint/Rules/MetaTooManySuppressions.php
+++ b/src/Lint/Rules/MetaTooManySuppressions.php
@@ -18,8 +18,12 @@ use function sprintf;
 /**
  * Reports files with more suppression directives than the configured threshold.
  */
-final readonly class MetaTooManySuppressions implements Rule, ApiRuleVisitor
+final class MetaTooManySuppressions implements Rule, ApiRuleVisitor
 {
+    public string $id = 'meta.too-many-suppressions';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Symbol carries an excessive number of suppression directives.';
+
     public function __construct(private int $threshold = 5) {}
 
     /**
@@ -41,8 +45,8 @@ final readonly class MetaTooManySuppressions implements Rule, ApiRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'File %s has %d suppression directives (threshold: %d) — consider fixing the underlying issues',
                     $file,
@@ -55,21 +59,6 @@ final readonly class MetaTooManySuppressions implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'meta.too-many-suppressions';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Symbol carries an excessive number of suppression directives.';
-    }
 }

--- a/src/Lint/Rules/MetaTooManySuppressions.php
+++ b/src/Lint/Rules/MetaTooManySuppressions.php
@@ -24,7 +24,7 @@ final class MetaTooManySuppressions implements Rule, ApiRuleVisitor
     public Severity $severity = Severity::Inconsistent;
     public string $description = 'Symbol carries an excessive number of suppression directives.';
 
-    public function __construct(private int $threshold = 5) {}
+    public function __construct(private readonly int $threshold = 5) {}
 
     /**
      * @return iterable<Finding>

--- a/src/Lint/Rules/MetaUnknownRule.php
+++ b/src/Lint/Rules/MetaUnknownRule.php
@@ -18,6 +18,10 @@ use function sprintf;
 
 final class MetaUnknownRule implements Rule, ApiRuleVisitor
 {
+    public string $id = 'meta.unknown-rule';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = '#[IgnoreLint] references a rule ID not in the registry.';
+
     /**
      * @return iterable<Finding>
      */
@@ -32,8 +36,8 @@ final class MetaUnknownRule implements Rule, ApiRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf('Suppression references unknown rule "%s"', $directive->ruleId),
                 location: new FindingLocation(file: $directive->file, line: $directive->line),
                 fixHint: 'Check spelling or remove the obsolete suppression',
@@ -42,21 +46,6 @@ final class MetaUnknownRule implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'meta.unknown-rule';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return '#[IgnoreLint] references a rule ID not in the registry.';
-    }
 }

--- a/src/Lint/Rules/OperationDescriptionMissing.php
+++ b/src/Lint/Rules/OperationDescriptionMissing.php
@@ -21,6 +21,10 @@ use function sprintf;
  */
 final class OperationDescriptionMissing implements Rule, OperationRuleVisitor
 {
+    public string $id = 'operation.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Operation has no description (beyond the summary).';
+
     /**
      * @return iterable<Finding>
      */
@@ -33,8 +37,8 @@ final class OperationDescriptionMissing implements Rule, OperationRuleVisitor
 
         if ($operation->description === null) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s has no description',
                     $operation->method->forDisplay(),
@@ -45,21 +49,6 @@ final class OperationDescriptionMissing implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation has no description (beyond the summary).';
-    }
 }

--- a/src/Lint/Rules/OperationIdDuplicate.php
+++ b/src/Lint/Rules/OperationIdDuplicate.php
@@ -23,6 +23,10 @@ use function sprintf;
  */
 final class OperationIdDuplicate implements Rule, OperationRuleVisitor, Finalizable, Resettable
 {
+    public string $id = 'operation.id-duplicate';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Two operations share the same operationId.';
+
     /** @var OperationNode[][] */
     private array $seen = [];
 
@@ -56,8 +60,8 @@ final class OperationIdDuplicate implements Rule, OperationRuleVisitor, Finaliza
 
             foreach ($nodes as $node) {
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Duplicate operationId "%s" on %s %s (%d occurrences)',
                         $operationId,
@@ -72,21 +76,6 @@ final class OperationIdDuplicate implements Rule, OperationRuleVisitor, Finaliza
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.id-duplicate';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two operations share the same operationId.';
-    }
 }

--- a/src/Lint/Rules/OperationIdInvalidChars.php
+++ b/src/Lint/Rules/OperationIdInvalidChars.php
@@ -25,6 +25,10 @@ use function sprintf;
  */
 final class OperationIdInvalidChars implements FixableRule, OperationRuleVisitor
 {
+    public string $id = 'operation.id-invalid-chars';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'operationId is not a codegen-safe identifier.';
+
     /** The codegen-safe identifier shape; {@see OperationIdDeriver::sanitise()} maps to this set. */
     public const string PATTERN = '/^[A-Za-z][A-Za-z0-9._-]*$/';
 
@@ -60,8 +64,8 @@ final class OperationIdInvalidChars implements FixableRule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Operation ID "%s" on %s %s contains characters that are not safe for code generation',
                 $operation->operationId,
@@ -79,21 +83,6 @@ final class OperationIdInvalidChars implements FixableRule, OperationRuleVisitor
         return new SanitizeOperationIdFixer();
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.id-invalid-chars';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'operationId is not a codegen-safe identifier.';
-    }
 }

--- a/src/Lint/Rules/OperationIdMissing.php
+++ b/src/Lint/Rules/OperationIdMissing.php
@@ -24,6 +24,10 @@ use function sprintf;
  */
 final class OperationIdMissing implements FixableRule, OperationRuleVisitor
 {
+    public string $id = 'operation.id-missing';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Operation has no operationId.';
+
     public function __construct(
         private readonly OperationIdDeriver $operationIdDeriver = new OperationIdDeriver(),
     ) {}
@@ -53,8 +57,8 @@ final class OperationIdMissing implements FixableRule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Operation %s %s has no operationId',
                 $operation->method->forDisplay(),
@@ -71,21 +75,6 @@ final class OperationIdMissing implements FixableRule, OperationRuleVisitor
         return new AddOperationIdFixer();
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.id-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation has no operationId.';
-    }
 }

--- a/src/Lint/Rules/OperationIdNamingInconsistent.php
+++ b/src/Lint/Rules/OperationIdNamingInconsistent.php
@@ -21,8 +21,11 @@ use function sprintf;
  * operationId are skipped (caught by `operation.id-missing`).
  */
 #[Scoped]
-final readonly class OperationIdNamingInconsistent extends AbstractNamingRule implements OperationRuleVisitor
+final class OperationIdNamingInconsistent extends AbstractNamingRule implements OperationRuleVisitor
 {
+    public string $id = 'operation.id-naming-inconsistent';
+    public string $description = "operationId doesn't follow the project's operation_id_case convention.";
+
     public function __construct(
         #[Config('openapi.lint.style.operation_id_case', 'dot')]
         IdentifierCase|string $case = IdentifierCase::Dot,
@@ -45,8 +48,8 @@ final readonly class OperationIdNamingInconsistent extends AbstractNamingRule im
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Operation ID "%s" on %s %s does not follow the %s naming convention',
                 $operation->operationId,
@@ -58,15 +61,5 @@ final readonly class OperationIdNamingInconsistent extends AbstractNamingRule im
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.id-naming-inconsistent';
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "operationId doesn't follow the project's operation_id_case convention.";
-    }
 }

--- a/src/Lint/Rules/OperationSecurityMissing.php
+++ b/src/Lint/Rules/OperationSecurityMissing.php
@@ -34,7 +34,7 @@ final class OperationSecurityMissing implements Rule, OperationRuleVisitor
     public string $description = 'Route enforces auth middleware but the operation declares no security, implying the endpoint is public.';
 
     public function __construct(
-        private RouteMiddlewareGatherer $middlewareGatherer,
+        private readonly RouteMiddlewareGatherer $middlewareGatherer,
     ) {}
 
     /**

--- a/src/Lint/Rules/OperationSecurityMissing.php
+++ b/src/Lint/Rules/OperationSecurityMissing.php
@@ -27,8 +27,12 @@ use function str_starts_with;
  * requirement. Fires only when `security` is `UNDEFINED` (not even an explicit empty array)
  * and the action lacks `#[PublicEndpoint]`.
  */
-final readonly class OperationSecurityMissing implements Rule, OperationRuleVisitor
+final class OperationSecurityMissing implements Rule, OperationRuleVisitor
 {
+    public string $id = 'operation.security-missing';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Route enforces auth middleware but the operation declares no security, implying the endpoint is public.';
+
     public function __construct(
         private RouteMiddlewareGatherer $middlewareGatherer,
     ) {}
@@ -60,8 +64,8 @@ final readonly class OperationSecurityMissing implements Rule, OperationRuleVisi
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s::%s() has auth/scope middleware but declares no security requirement in the spec.',
                 $operation->descriptor->controller?->getShortName() ?? '(unknown)',
@@ -102,21 +106,6 @@ final readonly class OperationSecurityMissing implements Rule, OperationRuleVisi
         return is_array($security);
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.security-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Route enforces auth middleware but the operation declares no security, implying the endpoint is public.';
-    }
 }

--- a/src/Lint/Rules/OperationSummaryEqualsDescription.php
+++ b/src/Lint/Rules/OperationSummaryEqualsDescription.php
@@ -22,6 +22,10 @@ use function trim;
  */
 final class OperationSummaryEqualsDescription implements Rule, OperationRuleVisitor
 {
+    public string $id = 'operation.summary-equals-description';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Operation summary and description are identical (redundant).';
+
     /**
      * @return iterable<Finding>
      */
@@ -34,8 +38,8 @@ final class OperationSummaryEqualsDescription implements Rule, OperationRuleVisi
 
         if (strcasecmp(trim($operation->summary), trim($operation->description)) === 0) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s has a description identical to its summary',
                     $operation->method->forDisplay(),
@@ -46,21 +50,6 @@ final class OperationSummaryEqualsDescription implements Rule, OperationRuleVisi
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.summary-equals-description';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation summary and description are identical (redundant).';
-    }
 }

--- a/src/Lint/Rules/OperationTagMissing.php
+++ b/src/Lint/Rules/OperationTagMissing.php
@@ -19,6 +19,10 @@ use function sprintf;
  */
 final class OperationTagMissing implements Rule, OperationRuleVisitor
 {
+    public string $id = 'operation.tag-missing';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Operation has no tags.';
+
     /**
      * @return iterable<Finding>
      */
@@ -27,8 +31,8 @@ final class OperationTagMissing implements Rule, OperationRuleVisitor
     {
         if ($operation->tags === []) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s has no tags',
                     $operation->method->forDisplay(),
@@ -39,21 +43,6 @@ final class OperationTagMissing implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'operation.tag-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation has no tags.';
-    }
 }

--- a/src/Lint/Rules/OverridesUnknownField.php
+++ b/src/Lint/Rules/OverridesUnknownField.php
@@ -22,8 +22,13 @@ use function is_array;
  * ({@see OverrideMatcher::ALLOWED_FIELDS} plus any `x-*` extension). Such fields are silently
  * skipped at apply time, so without this rule a typo'd field key would be a silent no-op.
  */
-final readonly class OverridesUnknownField implements PreBuildRule, Rule
+final class OverridesUnknownField implements PreBuildRule, Rule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Override block sets a field outside the allowlist '
+        . '(operationId, summary, description, tags, deprecated, x-*).';
+
     public const string ID = 'overrides.unknown-field';
 
     /**
@@ -34,18 +39,7 @@ final readonly class OverridesUnknownField implements PreBuildRule, Rule
         private array $overrides = [],
     ) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Override block sets a field outside the allowlist '
-            . '(operationId, summary, description, tags, deprecated, x-*).';
-    }
 
     #[Override]
     public function checkConfiguration(
@@ -66,7 +60,7 @@ final readonly class OverridesUnknownField implements PreBuildRule, Rule
                 $findings->emit(
                     new Finding(
                         ruleId: self::ID,
-                        severity: $this->severity(),
+                        severity: $this->severity,
                         message: "Override '{$key}' sets unknown field '{$field}'.",
                         fixHint: 'Allowed: ' . implode(', ', OverrideMatcher::ALLOWED_FIELDS) . ', x-*',
                     ),
@@ -75,9 +69,4 @@ final readonly class OverridesUnknownField implements PreBuildRule, Rule
         }
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 }

--- a/src/Lint/Rules/OverridesUnknownField.php
+++ b/src/Lint/Rules/OverridesUnknownField.php
@@ -36,7 +36,7 @@ final class OverridesUnknownField implements PreBuildRule, Rule
      */
     public function __construct(
         #[Config('openapi.overrides')]
-        private array $overrides = [],
+        private readonly array $overrides = [],
     ) {}
 
 

--- a/src/Lint/Rules/OverridesUnused.php
+++ b/src/Lint/Rules/OverridesUnused.php
@@ -25,7 +25,7 @@ final class OverridesUnused implements PreBuildRule, Rule
 
     public const string ID = 'overrides.unused';
 
-    public function __construct(private OverrideMatcher $matcher) {}
+    public function __construct(private readonly OverrideMatcher $matcher) {}
 
 
 

--- a/src/Lint/Rules/OverridesUnused.php
+++ b/src/Lint/Rules/OverridesUnused.php
@@ -17,23 +17,17 @@ use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
  * Flags `openapi.overrides` keys that match no route name, path URI, or webhook name.
  * Delegates to {@see OverrideMatcher::unusedKeys()} to avoid duplicating match logic.
  */
-final readonly class OverridesUnused implements PreBuildRule, Rule
+final class OverridesUnused implements PreBuildRule, Rule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Override key matches no route name, path URI, or webhook name.';
+
     public const string ID = 'overrides.unused';
 
     public function __construct(private OverrideMatcher $matcher) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Override key matches no route name, path URI, or webhook name.';
-    }
 
     #[Override]
     public function checkConfiguration(
@@ -56,7 +50,7 @@ final readonly class OverridesUnused implements PreBuildRule, Rule
             $findings->emit(
                 new Finding(
                     ruleId: self::ID,
-                    severity: $this->severity(),
+                    severity: $this->severity,
                     message: "Override key '{$key}' matched no route name, path URI, or webhook name.",
                     fixHint: 'Fix the route name/glob, or remove the override entry.',
                 ),
@@ -64,9 +58,4 @@ final readonly class OverridesUnused implements PreBuildRule, Rule
         }
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 }

--- a/src/Lint/Rules/ParameterDescriptionMissing.php
+++ b/src/Lint/Rules/ParameterDescriptionMissing.php
@@ -20,6 +20,10 @@ use function trim;
  */
 final class ParameterDescriptionMissing implements Rule, ParameterRuleVisitor
 {
+    public string $id = 'parameter.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Parameter has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -31,28 +35,13 @@ final class ParameterDescriptionMissing implements Rule, ParameterRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf('Parameter "%s" has no description', $parameter->name),
             fixHint: 'Add a description to the parameter explaining what value it accepts and its effect.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Parameter has no description.';
-    }
 }

--- a/src/Lint/Rules/ParameterDuplicateName.php
+++ b/src/Lint/Rules/ParameterDuplicateName.php
@@ -19,6 +19,10 @@ use function sprintf;
 /** Reports parameters that share the same (name, in) within a single operation. */
 final class ParameterDuplicateName implements Rule, OperationRuleVisitor
 {
+    public string $id = 'parameter.duplicate-name';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Two parameters in the same operation share the same name and location.';
+
     /**
      * @return iterable<Finding>
      */
@@ -35,8 +39,8 @@ final class ParameterDuplicateName implements Rule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Parameter "%s" (in: path) is declared %d times on %s %s',
                     $name,
@@ -49,21 +53,6 @@ final class ParameterDuplicateName implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.duplicate-name';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two parameters in the same operation share the same name and location.';
-    }
 }

--- a/src/Lint/Rules/ParameterExampleConflict.php
+++ b/src/Lint/Rules/ParameterExampleConflict.php
@@ -21,6 +21,10 @@ use function sprintf;
  */
 final class ParameterExampleConflict implements Rule, ParameterRuleVisitor
 {
+    public string $id = 'parameter.example-conflict';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A parameter sets both example and examples (mutually exclusive).';
+
     /**
      * @return iterable<Finding>
      */
@@ -39,8 +43,8 @@ final class ParameterExampleConflict implements Rule, ParameterRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Parameter "%s" sets both "example" and "examples", which are mutually exclusive.',
                 $parameter->name,
@@ -49,21 +53,6 @@ final class ParameterExampleConflict implements Rule, ParameterRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.example-conflict';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A parameter sets both example and examples (mutually exclusive).';
-    }
 }

--- a/src/Lint/Rules/ParameterExampleMissing.php
+++ b/src/Lint/Rules/ParameterExampleMissing.php
@@ -23,6 +23,10 @@ use function sprintf;
  */
 final class ParameterExampleMissing implements Rule, ParameterRuleVisitor
 {
+    public string $id = 'parameter.example-missing';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'Parameter has no example.';
+
     /**
      * @return iterable<Finding>
      */
@@ -45,28 +49,13 @@ final class ParameterExampleMissing implements Rule, ParameterRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf('Parameter "%s" has no example value', $parameter->name),
             fixHint: 'Add an "example" or "examples" property to the parameter to improve documentation.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.example-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Parameter has no example.';
-    }
 }

--- a/src/Lint/Rules/ParameterNameNamingInconsistent.php
+++ b/src/Lint/Rules/ParameterNameNamingInconsistent.php
@@ -38,9 +38,9 @@ final class ParameterNameNamingInconsistent extends AbstractNamingRule implement
     /** @var list<string> */
     private const array FRAMEWORK_QUERY_PARAMS = ['page', 'per_page', 'sort', 'include'];
 
-    private IdentifierCase $pathCase;
+    private readonly IdentifierCase $pathCase;
 
-    private IdentifierCase $queryCase;
+    private readonly IdentifierCase $queryCase;
 
     public function __construct(
         #[Config('openapi.lint.style.path_parameter_case', 'camel')]

--- a/src/Lint/Rules/ParameterNameNamingInconsistent.php
+++ b/src/Lint/Rules/ParameterNameNamingInconsistent.php
@@ -28,10 +28,13 @@ use function str_contains;
  * are excluded.
  */
 #[Scoped]
-final readonly class ParameterNameNamingInconsistent extends AbstractNamingRule implements
+final class ParameterNameNamingInconsistent extends AbstractNamingRule implements
     ParameterRuleVisitor,
     QueryParameterRuleVisitor
 {
+    public string $id = 'parameter.name-naming-inconsistent';
+    public string $description = "Parameter name doesn't follow the project's path_parameter_case / query_parameter_case convention.";
+
     /** @var list<string> */
     private const array FRAMEWORK_QUERY_PARAMS = ['page', 'per_page', 'sort', 'include'];
 
@@ -67,8 +70,8 @@ final readonly class ParameterNameNamingInconsistent extends AbstractNamingRule 
     private function finding(string $name, IdentifierCase $case): Finding
     {
         return new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Parameter name "%s" does not follow the %s naming convention',
                 $name,
@@ -82,11 +85,6 @@ final readonly class ParameterNameNamingInconsistent extends AbstractNamingRule 
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.name-naming-inconsistent';
-    }
 
     /**
      * @return iterable<Finding>
@@ -114,9 +112,4 @@ final readonly class ParameterNameNamingInconsistent extends AbstractNamingRule 
         return in_array($name, self::FRAMEWORK_QUERY_PARAMS, strict: true);
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Parameter name doesn't follow the project's path_parameter_case / query_parameter_case convention.";
-    }
 }

--- a/src/Lint/Rules/ParameterPathMustBeRequired.php
+++ b/src/Lint/Rules/ParameterPathMustBeRequired.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class ParameterPathMustBeRequired implements Rule, ParameterRuleVisitor
 {
+    public string $id = 'parameter.path-must-be-required';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Path parameter is not marked required: true.';
+
     /**
      * @return iterable<Finding>
      */
@@ -33,8 +37,8 @@ final class ParameterPathMustBeRequired implements Rule, ParameterRuleVisitor
         $operation = $parameter->parent();
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Path parameter "%s" on %s %s must be required',
                 $parameter->name,
@@ -45,21 +49,6 @@ final class ParameterPathMustBeRequired implements Rule, ParameterRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.path-must-be-required';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Path parameter is not marked required: true.';
-    }
 }

--- a/src/Lint/Rules/ParameterQueryArrayNoExplode.php
+++ b/src/Lint/Rules/ParameterQueryArrayNoExplode.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class ParameterQueryArrayNoExplode implements Rule, QueryParameterRuleVisitor
 {
+    public string $id = 'parameter.query-array-no-explode';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Array query parameter is missing explode: true.';
+
     /**
      * @return iterable<Finding>
      */
@@ -39,8 +43,8 @@ final class ParameterQueryArrayNoExplode implements Rule, QueryParameterRuleVisi
         $operation = $queryParameter->parent();
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Query parameter "%s" on %s %s has an array schema but does not set style or explode',
                 $queryParameter->name,
@@ -51,21 +55,6 @@ final class ParameterQueryArrayNoExplode implements Rule, QueryParameterRuleVisi
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.query-array-no-explode';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Array query parameter is missing explode: true.';
-    }
 }

--- a/src/Lint/Rules/ParameterQueryNoSchema.php
+++ b/src/Lint/Rules/ParameterQueryNoSchema.php
@@ -18,6 +18,10 @@ use function sprintf;
 /** Reports query parameters that have no schema defined. */
 final class ParameterQueryNoSchema implements Rule, QueryParameterRuleVisitor
 {
+    public string $id = 'parameter.query-no-schema';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Query parameter has no schema.';
+
     /**
      * @return iterable<Finding>
      */
@@ -33,8 +37,8 @@ final class ParameterQueryNoSchema implements Rule, QueryParameterRuleVisitor
         $operation = $queryParameter->parent();
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Query parameter "%s" on %s %s has no schema',
                 $queryParameter->name,
@@ -45,21 +49,6 @@ final class ParameterQueryNoSchema implements Rule, QueryParameterRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'parameter.query-no-schema';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Query parameter has no schema.';
-    }
 }

--- a/src/Lint/Rules/PathParameterUndeclared.php
+++ b/src/Lint/Rules/PathParameterUndeclared.php
@@ -24,6 +24,10 @@ use function sprintf;
  */
 final class PathParameterUndeclared implements Rule, OperationRuleVisitor
 {
+    public string $id = 'path.parameter-undeclared';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Path template uses a variable not declared as a parameter.';
+
     /**
      * @return iterable<Finding>
      */
@@ -47,8 +51,8 @@ final class PathParameterUndeclared implements Rule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Path placeholder "{%s}" on %s %s is not declared as a path parameter',
                     $placeholder,
@@ -78,21 +82,6 @@ final class PathParameterUndeclared implements Rule, OperationRuleVisitor
         return [];
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'path.parameter-undeclared';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Path template uses a variable not declared as a parameter.';
-    }
 }

--- a/src/Lint/Rules/PathParameterUndefined.php
+++ b/src/Lint/Rules/PathParameterUndefined.php
@@ -24,6 +24,10 @@ use function str_contains;
  */
 final class PathParameterUndefined implements Rule, OperationRuleVisitor
 {
+    public string $id = 'path.parameter-undefined';
+    public Severity $severity = Severity::Broken;
+    public string $description = "A declared path parameter doesn't appear in the path template.";
+
     /**
      * @return iterable<Finding>
      */
@@ -55,8 +59,8 @@ final class PathParameterUndefined implements Rule, OperationRuleVisitor
                 );
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: $message,
                 fixHint: sprintf(
                     'Remove the parameter or add {%s} to the path template.',
@@ -66,21 +70,6 @@ final class PathParameterUndefined implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'path.parameter-undefined';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "A declared path parameter doesn't appear in the path template.";
-    }
 }

--- a/src/Lint/Rules/PathSegmentNamingInconsistent.php
+++ b/src/Lint/Rules/PathSegmentNamingInconsistent.php
@@ -25,8 +25,11 @@ use function str_starts_with;
  * Default: {@see IdentifierCase::Kebab}.
  */
 #[Scoped]
-final readonly class PathSegmentNamingInconsistent extends AbstractNamingRule implements OperationRuleVisitor
+final class PathSegmentNamingInconsistent extends AbstractNamingRule implements OperationRuleVisitor
 {
+    public string $id = 'path.segment-naming-inconsistent';
+    public string $description = "URL path segment doesn't follow the project's path_segment_case convention.";
+
     public function __construct(
         #[Config('openapi.lint.style.path_segment_case', 'kebab')]
         IdentifierCase|string $case = IdentifierCase::Kebab,
@@ -68,8 +71,8 @@ final readonly class PathSegmentNamingInconsistent extends AbstractNamingRule im
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Path segment(s) [%s] on %s %s do not follow the %s naming convention',
                 implode(', ', $offending),
@@ -81,15 +84,5 @@ final readonly class PathSegmentNamingInconsistent extends AbstractNamingRule im
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'path.segment-naming-inconsistent';
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "URL path segment doesn't follow the project's path_segment_case convention.";
-    }
 }

--- a/src/Lint/Rules/PathTrailingSlashInconsistent.php
+++ b/src/Lint/Rules/PathTrailingSlashInconsistent.php
@@ -24,6 +24,10 @@ use function str_ends_with;
  */
 final class PathTrailingSlashInconsistent implements Rule, ApiRuleVisitor
 {
+    public string $id = 'path.trailing-slash-inconsistent';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Trailing-slash usage is inconsistent across paths.';
+
     /**
      * @return iterable<Finding>
      */
@@ -62,8 +66,8 @@ final class PathTrailingSlashInconsistent implements Rule, ApiRuleVisitor
         $withoutSlashExamples = implode(', ', array_slice($withoutSlash, 0, 3));
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Inconsistent trailing slashes: %d path(s) end with a slash (e.g., %s) and %d do not (e.g., %s)',
                 count($withSlash),
@@ -75,21 +79,6 @@ final class PathTrailingSlashInconsistent implements Rule, ApiRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'path.trailing-slash-inconsistent';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Trailing-slash usage is inconsistent across paths.';
-    }
 }

--- a/src/Lint/Rules/PublicEndpointContradictsMiddleware.php
+++ b/src/Lint/Rules/PublicEndpointContradictsMiddleware.php
@@ -31,7 +31,7 @@ final class PublicEndpointContradictsMiddleware implements Rule, OperationRuleVi
     public string $description = '#[PublicEndpoint] is present but the route has auth/scope middleware.';
 
     public function __construct(
-        private RouteMiddlewareGatherer $middlewareGatherer,
+        private readonly RouteMiddlewareGatherer $middlewareGatherer,
     ) {}
 
     /**

--- a/src/Lint/Rules/PublicEndpointContradictsMiddleware.php
+++ b/src/Lint/Rules/PublicEndpointContradictsMiddleware.php
@@ -24,8 +24,12 @@ use function str_starts_with;
  * Reports when a controller method or class is marked `#[PublicEndpoint]` but the route still
  * carries `auth:*` or `scope:*` middleware.
  */
-final readonly class PublicEndpointContradictsMiddleware implements Rule, OperationRuleVisitor
+final class PublicEndpointContradictsMiddleware implements Rule, OperationRuleVisitor
 {
+    public string $id = 'publicendpoint.contradicts-middleware';
+    public Severity $severity = Severity::Degraded;
+    public string $description = '#[PublicEndpoint] is present but the route has auth/scope middleware.';
+
     public function __construct(
         private RouteMiddlewareGatherer $middlewareGatherer,
     ) {}
@@ -56,8 +60,8 @@ final readonly class PublicEndpointContradictsMiddleware implements Rule, Operat
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s::%s() is marked #[PublicEndpoint] but the route has conflicting middleware: %s',
                 $descriptor->controller?->getShortName() ?? '(unknown)',
@@ -93,21 +97,6 @@ final readonly class PublicEndpointContradictsMiddleware implements Rule, Operat
         return $conflicting;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'publicendpoint.contradicts-middleware';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return '#[PublicEndpoint] is present but the route has auth/scope middleware.';
-    }
 }

--- a/src/Lint/Rules/QueryParamDuplicate.php
+++ b/src/Lint/Rules/QueryParamDuplicate.php
@@ -29,6 +29,10 @@ use function sprintf;
  */
 final class QueryParamDuplicate implements FixableRule, OperationRuleVisitor
 {
+    public string $id = 'queryparam.duplicate';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Two #[QueryParam] attributes on the same controller method share the same name.';
+
     /**
      * @return iterable<Finding>
      */
@@ -60,8 +64,8 @@ final class QueryParamDuplicate implements FixableRule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Query parameter "%s" is declared %d times on %s %s',
                     $name,
@@ -75,17 +79,7 @@ final class QueryParamDuplicate implements FixableRule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'queryparam.duplicate';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -101,9 +95,4 @@ final class QueryParamDuplicate implements FixableRule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two #[QueryParam] attributes on the same controller method share the same name.';
-    }
 }

--- a/src/Lint/Rules/RefBroken.php
+++ b/src/Lint/Rules/RefBroken.php
@@ -27,6 +27,10 @@ use function sprintf;
  */
 final class RefBroken implements Rule, ApiRuleVisitor
 {
+    public string $id = 'ref.broken';
+    public Severity $severity = Severity::Broken;
+    public string $description = "A \$ref points to a component that doesn't exist in the spec.";
+
     /**
      * @return iterable<Finding>
      */
@@ -54,8 +58,8 @@ final class RefBroken implements Rule, ApiRuleVisitor
 
             if (!$this->refExists($ref, $componentIndex)) {
                 $findings[] = new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf('Broken $ref "%s": referenced component does not exist', $ref),
                     location: new FindingLocation(jsonPointer: $ref),
                     fixHint: 'Ensure the referenced component is defined under #/components/.',
@@ -106,21 +110,6 @@ final class RefBroken implements Rule, ApiRuleVisitor
         return isset($componentIndex[$type][$name]);
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'ref.broken';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "A \$ref points to a component that doesn't exist in the spec.";
-    }
 }

--- a/src/Lint/Rules/RequestBodyDescriptionMissing.php
+++ b/src/Lint/Rules/RequestBodyDescriptionMissing.php
@@ -19,6 +19,10 @@ use function trim;
  */
 final class RequestBodyDescriptionMissing implements Rule, RequestBodyRuleVisitor
 {
+    public string $id = 'request-body.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'requestBody has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -30,28 +34,13 @@ final class RequestBodyDescriptionMissing implements Rule, RequestBodyRuleVisito
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: 'Request body has no description',
             fixHint: 'Add a description to the requestBody explaining the expected payload.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'request-body.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'requestBody has no description.';
-    }
 }

--- a/src/Lint/Rules/RequestBodyExampleMissing.php
+++ b/src/Lint/Rules/RequestBodyExampleMissing.php
@@ -17,6 +17,10 @@ use Radiergummi\OpenApi\Lint\Visitors\RequestBodyRule as RequestBodyRuleVisitor;
  */
 final class RequestBodyExampleMissing implements Rule, RequestBodyRuleVisitor
 {
+    public string $id = 'request-body.example-missing';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'requestBody has no example.';
+
     /**
      * @return iterable<Finding>
      */
@@ -28,28 +32,13 @@ final class RequestBodyExampleMissing implements Rule, RequestBodyRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: 'Request body has no example value',
             fixHint: 'Add an "examples" entry to the requestBody media type to illustrate the expected payload.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'request-body.example-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'requestBody has no example.';
-    }
 }

--- a/src/Lint/Rules/RequestBodyNoContent.php
+++ b/src/Lint/Rules/RequestBodyNoContent.php
@@ -18,6 +18,10 @@ use Radiergummi\OpenApi\Lint\Visitors\RequestBodyRule as RequestBodyRuleVisitor;
  */
 final class RequestBodyNoContent implements Rule, RequestBodyRuleVisitor
 {
+    public string $id = 'request-body.no-content';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A requestBody object has no media-type entries.';
+
     /**
      * @return iterable<Finding>
      */
@@ -29,28 +33,13 @@ final class RequestBodyNoContent implements Rule, RequestBodyRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: 'A requestBody object has no media-type entries',
             fixHint: 'Add at least one content entry (e.g., application/json) with a schema.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'request-body.no-content';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A requestBody object has no media-type entries.';
-    }
 }

--- a/src/Lint/Rules/RequestBodyOnGetOrDelete.php
+++ b/src/Lint/Rules/RequestBodyOnGetOrDelete.php
@@ -23,6 +23,10 @@ use function sprintf;
  */
 final class RequestBodyOnGetOrDelete implements Rule, OperationRuleVisitor
 {
+    public string $id = 'request-body.on-get-or-delete';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'GET or DELETE operation has a request body.';
+
     /** @var list<HttpMethod> */
     private const array DISALLOWED_METHODS = [HttpMethod::Get, HttpMethod::Delete];
 
@@ -41,8 +45,8 @@ final class RequestBodyOnGetOrDelete implements Rule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Operation %s %s defines a request body, which is unconventional for %s requests',
                 $operation->method->forDisplay(),
@@ -53,21 +57,6 @@ final class RequestBodyOnGetOrDelete implements Rule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'request-body.on-get-or-delete';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'GET or DELETE operation has a request body.';
-    }
 }

--- a/src/Lint/Rules/RequestEmpty.php
+++ b/src/Lint/Rules/RequestEmpty.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Lint\Rules;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\FindingsCollector;
@@ -25,23 +24,12 @@ use Radiergummi\OpenApi\Support\Extraction\RequestBodyExtractor;
  */
 final class RequestEmpty implements Rule
 {
+    public string $id = 'request.empty';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'POST/PUT/PATCH action has no resolvable request-body schema. Add a Data class or FormRequest.';
+
     public const string FIX_HINT = 'Type-hint a Data class or FormRequest on the controller or injected Action.';
 
-    #[Override]
-    public function id(): string
-    {
-        return 'request.empty';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'POST/PUT/PATCH action has no resolvable request-body schema. Add a Data class or FormRequest.';
-    }
 }

--- a/src/Lint/Rules/ResponseDescriptionMissing.php
+++ b/src/Lint/Rules/ResponseDescriptionMissing.php
@@ -21,6 +21,10 @@ use function trim;
  */
 final class ResponseDescriptionMissing implements Rule, ResponseRuleVisitor
 {
+    public string $id = 'response.description-missing';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Response has no description. OAS 3.1 requires description on every Response Object.';
+
     /**
      * @return iterable<Finding>
      */
@@ -34,8 +38,8 @@ final class ResponseDescriptionMissing implements Rule, ResponseRuleVisitor
         $operation = $response->operation();
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Response %d on %s %s has no description',
                 $response->statusCode,
@@ -46,21 +50,6 @@ final class ResponseDescriptionMissing implements Rule, ResponseRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Response has no description. OAS 3.1 requires description on every Response Object.';
-    }
 }

--- a/src/Lint/Rules/ResponseDuplicateStatus.php
+++ b/src/Lint/Rules/ResponseDuplicateStatus.php
@@ -24,6 +24,10 @@ use function sprintf;
 
 final class ResponseDuplicateStatus implements FixableRule, OperationRuleVisitor
 {
+    public string $id = 'response.duplicate-status';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Two responses on the same operation share the same status code.';
+
     /**
      * @return iterable<Finding>
      */
@@ -47,8 +51,8 @@ final class ResponseDuplicateStatus implements FixableRule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'HTTP status %s is declared %d times on %s %s',
                     $statusCode,
@@ -62,17 +66,7 @@ final class ResponseDuplicateStatus implements FixableRule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.duplicate-status';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -88,9 +82,4 @@ final class ResponseDuplicateStatus implements FixableRule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two responses on the same operation share the same status code.';
-    }
 }

--- a/src/Lint/Rules/ResponseExampleMissing.php
+++ b/src/Lint/Rules/ResponseExampleMissing.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class ResponseExampleMissing implements Rule, ResponseRuleVisitor
 {
+    public string $id = 'response.example-missing';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'Response media type has no example.';
+
     /**
      * @return iterable<Finding>
      */
@@ -37,8 +41,8 @@ final class ResponseExampleMissing implements Rule, ResponseRuleVisitor
         $operation = $response->operation();
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Response %d on %s %s has no example',
                 $response->statusCode,
@@ -49,21 +53,6 @@ final class ResponseExampleMissing implements Rule, ResponseRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.example-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Response media type has no example.';
-    }
 }

--- a/src/Lint/Rules/ResponseNoError.php
+++ b/src/Lint/Rules/ResponseNoError.php
@@ -19,6 +19,10 @@ use function sprintf;
  */
 final class ResponseNoError implements Rule, OperationRuleVisitor
 {
+    public string $id = 'response.no-error';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Operation has no error responses (4xx/5xx).';
+
     /**
      * @return iterable<Finding>
      */
@@ -41,8 +45,8 @@ final class ResponseNoError implements Rule, OperationRuleVisitor
             && $operation->errorResponses() === []
         ) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s has no error response (4xx/5xx)',
                     $operation->method->forDisplay(),
@@ -53,21 +57,6 @@ final class ResponseNoError implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.no-error';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation has no error responses (4xx/5xx).';
-    }
 }

--- a/src/Lint/Rules/ResponseNoSuccess.php
+++ b/src/Lint/Rules/ResponseNoSuccess.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class ResponseNoSuccess implements Rule, OperationRuleVisitor
 {
+    public string $id = 'response.no-success';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Operation has no 2xx response.';
+
     /**
      * @return iterable<Finding>
      */
@@ -36,8 +40,8 @@ final class ResponseNoSuccess implements Rule, OperationRuleVisitor
 
         if ($operation->successResponses() === []) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s has no 2xx success response',
                     $operation->method->forDisplay(),
@@ -48,21 +52,6 @@ final class ResponseNoSuccess implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.no-success';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation has no 2xx response.';
-    }
 }

--- a/src/Lint/Rules/ResponseRedirectWithoutLocation.php
+++ b/src/Lint/Rules/ResponseRedirectWithoutLocation.php
@@ -21,6 +21,10 @@ use function strtolower;
  */
 final class ResponseRedirectWithoutLocation implements Rule, ResponseRuleVisitor
 {
+    public string $id = 'response.redirect-without-location';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = '3xx response has no Location header.';
+
     /**
      * @return iterable<Finding>
      */
@@ -38,8 +42,8 @@ final class ResponseRedirectWithoutLocation implements Rule, ResponseRuleVisitor
         $operation = $response->operation();
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Redirect response %d on %s %s has no Location header',
                 $response->statusCode,
@@ -50,21 +54,6 @@ final class ResponseRedirectWithoutLocation implements Rule, ResponseRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.redirect-without-location';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return '3xx response has no Location header.';
-    }
 }

--- a/src/Lint/Rules/ResponseRefUnresolvable.php
+++ b/src/Lint/Rules/ResponseRefUnresolvable.php
@@ -22,8 +22,12 @@ use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
  * response with no body schema (no broken `$ref` for `ref.broken` to catch). This rule surfaces
  * that silent degradation at lint time, using the side-effect-free `canResolve()` check.
  */
-final readonly class ResponseRefUnresolvable implements Rule, PreBuildRule
+final class ResponseRefUnresolvable implements Rule, PreBuildRule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Broken;
+    public string $description = '#[Response(ref:)] points to a class no registered schema resolver can resolve; the response is emitted without a body schema.';
+
     public const string ID = 'response.ref-unresolvable';
 
     /**
@@ -31,17 +35,7 @@ final readonly class ResponseRefUnresolvable implements Rule, PreBuildRule
      */
     public function __construct(private array $refSchemaResolvers) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return '#[Response(ref:)] points to a class no registered schema resolver can resolve; the response is emitted without a body schema.';
-    }
 
     #[Override]
     public function checkConfiguration(
@@ -63,7 +57,7 @@ final readonly class ResponseRefUnresolvable implements Rule, PreBuildRule
                 $findings->emit(
                     new Finding(
                         ruleId: self::ID,
-                        severity: $this->severity(),
+                        severity: $this->severity,
                         message: "Response ref '{$ref}' on status {$response->status} cannot be resolved by any registered schema resolver; the response will be emitted without a body schema.",
                         location: FindingLocation::fromDescriptor($descriptor),
                         fixHint: 'Reference a class a registered schema resolver handles, or supply an inline `schema:` instead.',
@@ -85,9 +79,4 @@ final readonly class ResponseRefUnresolvable implements Rule, PreBuildRule
         );
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 }

--- a/src/Lint/Rules/ResponseRefUnresolvable.php
+++ b/src/Lint/Rules/ResponseRefUnresolvable.php
@@ -33,7 +33,7 @@ final class ResponseRefUnresolvable implements Rule, PreBuildRule
     /**
      * @param list<RefSchemaResolver> $refSchemaResolvers
      */
-    public function __construct(private array $refSchemaResolvers) {}
+    public function __construct(private readonly array $refSchemaResolvers) {}
 
 
 

--- a/src/Lint/Rules/ResponseStatusUnconventional.php
+++ b/src/Lint/Rules/ResponseStatusUnconventional.php
@@ -21,6 +21,10 @@ use function sprintf;
  */
 final class ResponseStatusUnconventional implements Rule, ResponseRuleVisitor
 {
+    public string $id = 'response.status-unconventional';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Response uses a status code that is unusual for the HTTP method.';
+
     /**
      * @return iterable<Finding>
      */
@@ -64,8 +68,8 @@ final class ResponseStatusUnconventional implements Rule, ResponseRuleVisitor
         $expected = $method === HttpMethod::Post ? '201' : '204';
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Operation %s %s uses status 200 as its only success response; consider using %s instead',
                 $method->forDisplay(),
@@ -80,21 +84,6 @@ final class ResponseStatusUnconventional implements Rule, ResponseRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.status-unconventional';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Response uses a status code that is unusual for the HTTP method.';
-    }
 }

--- a/src/Lint/Rules/ResponseSuccessEmptyBody.php
+++ b/src/Lint/Rules/ResponseSuccessEmptyBody.php
@@ -22,6 +22,10 @@ use function sprintf;
  */
 final class ResponseSuccessEmptyBody implements Rule, ResponseRuleVisitor
 {
+    public string $id = 'response.success-empty-body';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A 2xx response (other than 204/205/304) declares no body schema. Likely a void-return controller.';
+
     /** @var list<int|string> */
     private const array BODILESS_CODES = [204, 205, 304, '204', '205', '304'];
 
@@ -53,8 +57,8 @@ final class ResponseSuccessEmptyBody implements Rule, ResponseRuleVisitor
             : '<unknown operation>';
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Response %s on %s has no body schema',
                 $response->statusCode,
@@ -64,21 +68,6 @@ final class ResponseSuccessEmptyBody implements Rule, ResponseRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'response.success-empty-body';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A 2xx response (other than 204/205/304) declares no body schema. Likely a void-return controller.';
-    }
 }

--- a/src/Lint/Rules/SchemaAllOfTypeConflict.php
+++ b/src/Lint/Rules/SchemaAllOfTypeConflict.php
@@ -29,6 +29,10 @@ use function sprintf;
  */
 final class SchemaAllOfTypeConflict implements Rule, ComponentSchemaRuleVisitor
 {
+    public string $id = 'schema.allof-type-conflict';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'allOf members declare conflicting type values.';
+
     /**
      * @return iterable<Finding>
      */
@@ -92,8 +96,8 @@ final class SchemaAllOfTypeConflict implements Rule, ComponentSchemaRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Schema "%s" has allOf with conflicting types: %s',
                 $schemaName,
@@ -104,21 +108,6 @@ final class SchemaAllOfTypeConflict implements Rule, ComponentSchemaRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.allof-type-conflict';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'allOf members declare conflicting type values.';
-    }
 }

--- a/src/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributes.php
+++ b/src/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributes.php
@@ -31,6 +31,12 @@ use function sprintf;
  */
 final class SchemaClassAttributeConflictsWithFieldAttributes implements OperationRuleVisitor, Rule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'A class carries a class-level #[RawSchema] together with field attributes '
+        . '(#[RequestField]/#[ResponseField]/#[ResourceField]); the raw schema replaces the '
+        . 'inferred body wholesale, so the field attributes have no effect.';
+
     public const string ID = 'schema.class-attribute-conflicts-with-field-attributes';
 
     /** @var array<class-string, true> */
@@ -40,19 +46,7 @@ final class SchemaClassAttributeConflictsWithFieldAttributes implements Operatio
         private readonly PayloadParameterScanner $scanner,
     ) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A class carries a class-level #[RawSchema] together with field attributes '
-            . '(#[RequestField]/#[ResponseField]/#[ResourceField]); the raw schema replaces the '
-            . 'inferred body wholesale, so the field attributes have no effect.';
-    }
 
     /**
      * @return iterable<Finding>
@@ -135,7 +129,7 @@ final class SchemaClassAttributeConflictsWithFieldAttributes implements Operatio
 
         yield new Finding(
             ruleId: self::ID,
-            severity: $this->severity(),
+            severity: $this->severity,
             message: sprintf(
                 '#[RawSchema] on %s replaces the inferred body, so these field attributes have '
                 . 'no effect: %s.',
@@ -162,9 +156,4 @@ final class SchemaClassAttributeConflictsWithFieldAttributes implements Operatio
         return is_string($name) && $name !== '' ? $name : null;
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 }

--- a/src/Lint/Rules/SchemaCompositeFieldsUninspected.php
+++ b/src/Lint/Rules/SchemaCompositeFieldsUninspected.php
@@ -33,6 +33,10 @@ final class SchemaCompositeFieldsUninspected implements
     ResponseRuleVisitor,
     RequestBodyRuleVisitor
 {
+    public string $id = 'schema.composite-fields-uninspected';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Schema is a oneOf/anyOf of multiple alternatives whose fields are not inspected by field-level rules.';
+
     /**
      * @return iterable<Finding>
      */
@@ -48,8 +52,8 @@ final class SchemaCompositeFieldsUninspected implements
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Field "%s" is a oneOf/anyOf union of multiple alternatives; its branches are not inspected by field-level rules',
                 $field->name,
@@ -58,17 +62,7 @@ final class SchemaCompositeFieldsUninspected implements
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.composite-fields-uninspected';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
     /**
      * @return iterable<Finding>
@@ -96,8 +90,8 @@ final class SchemaCompositeFieldsUninspected implements
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s is a oneOf/anyOf union of multiple alternatives; its branches are not inspected by field-level rules',
                 $subject,
@@ -147,9 +141,4 @@ final class SchemaCompositeFieldsUninspected implements
         yield from $this->flagUninspectedComposite($schema, 'Request body');
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Schema is a oneOf/anyOf of multiple alternatives whose fields are not inspected by field-level rules.';
-    }
 }

--- a/src/Lint/Rules/SchemaConstraintsMissing.php
+++ b/src/Lint/Rules/SchemaConstraintsMissing.php
@@ -30,6 +30,10 @@ use function sprintf;
  */
 final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, ComponentSchemaRuleVisitor
 {
+    public string $id = 'schema.constraints-missing';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A string has no maxLength, an array no maxItems, or a number no bounds.';
+
     /**
      * @return iterable<Finding>
      */
@@ -79,8 +83,8 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf('String schema "%s" has no maxLength constraint', $name),
                 location: $loc,
                 fixHint: 'Add a "maxLength" to cap the string length, or add a "format" or "enum" if the values are bounded by other means.',
@@ -95,8 +99,8 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf('Array schema "%s" has no maxItems constraint', $name),
                 location: $loc,
                 fixHint: 'Add a "maxItems" to prevent unbounded arrays from being accepted or returned.',
@@ -114,8 +118,8 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf('Numeric schema "%s" has no minimum or maximum constraint', $name),
                 location: $loc,
                 fixHint: 'Add a "minimum" and/or "maximum" to bound the numeric range.',
@@ -123,17 +127,7 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.constraints-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     /**
      * @return iterable<Finding>
@@ -175,9 +169,4 @@ final class SchemaConstraintsMissing implements Rule, FieldRuleVisitor, Componen
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A string has no maxLength, an array no maxItems, or a number no bounds.';
-    }
 }

--- a/src/Lint/Rules/SchemaDescriptionMissing.php
+++ b/src/Lint/Rules/SchemaDescriptionMissing.php
@@ -24,6 +24,10 @@ use function trim;
  */
 final class SchemaDescriptionMissing implements Rule, ComponentSchemaRuleVisitor
 {
+    public string $id = 'schema.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Named component schema has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -35,29 +39,14 @@ final class SchemaDescriptionMissing implements Rule, ComponentSchemaRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf('Component schema "%s" has no description', $componentSchema->name),
             location: new FindingLocation(jsonPointer: $componentSchema->pointer()),
             fixHint: 'Add a description to the component schema explaining what it represents.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Named component schema has no description.';
-    }
 }

--- a/src/Lint/Rules/SchemaEnumEmpty.php
+++ b/src/Lint/Rules/SchemaEnumEmpty.php
@@ -24,6 +24,10 @@ use function Radiergummi\OpenApi\is_undefined;
  */
 final class SchemaEnumEmpty implements Rule, FieldRuleVisitor, ComponentSchemaRuleVisitor
 {
+    public string $id = 'schema.enum-empty';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A schema declares an empty enum (enum: []) and is unsatisfiable.';
+
     /**
      * @return iterable<Finding>
      */
@@ -32,8 +36,8 @@ final class SchemaEnumEmpty implements Rule, FieldRuleVisitor, ComponentSchemaRu
     {
         if ($this->isEmptyEnum($field->enum)) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Field "%s" declares an empty enum (enum: []) and is unsatisfiable',
                     $field->name,
@@ -52,17 +56,7 @@ final class SchemaEnumEmpty implements Rule, FieldRuleVisitor, ComponentSchemaRu
         return $enum === [];
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.enum-empty';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
     /**
      * @return iterable<Finding>
@@ -84,8 +78,8 @@ final class SchemaEnumEmpty implements Rule, FieldRuleVisitor, ComponentSchemaRu
 
         if ($this->isEmptyEnum($enum)) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Component schema "%s" declares an empty enum (enum: []) and is unsatisfiable',
                     $componentSchema->name,
@@ -96,9 +90,4 @@ final class SchemaEnumEmpty implements Rule, FieldRuleVisitor, ComponentSchemaRu
         }
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A schema declares an empty enum (enum: []) and is unsatisfiable.';
-    }
 }

--- a/src/Lint/Rules/SchemaEnumTypeMismatch.php
+++ b/src/Lint/Rules/SchemaEnumTypeMismatch.php
@@ -26,6 +26,10 @@ use function sprintf;
  */
 final class SchemaEnumTypeMismatch implements Rule, FieldRuleVisitor
 {
+    public string $id = 'schema.enum-type-mismatch';
+    public Severity $severity = Severity::Broken;
+    public string $description = "Schema enum contains values that don't match the declared type.";
+
     /**
      * @return iterable<Finding>
      */
@@ -52,8 +56,8 @@ final class SchemaEnumTypeMismatch implements Rule, FieldRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Field "%s" declares type "%s" but enum value at index %d is %s (%s)',
                     $field->name,
@@ -87,21 +91,6 @@ final class SchemaEnumTypeMismatch implements Rule, FieldRuleVisitor
         };
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.enum-type-mismatch';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Schema enum contains values that don't match the declared type.";
-    }
 }

--- a/src/Lint/Rules/SchemaExampleMissing.php
+++ b/src/Lint/Rules/SchemaExampleMissing.php
@@ -24,6 +24,10 @@ use function sprintf;
  */
 final class SchemaExampleMissing implements Rule, ComponentSchemaRuleVisitor
 {
+    public string $id = 'schema.example-missing';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'Schema property has no example value.';
+
     /**
      * @return iterable<Finding>
      */
@@ -55,8 +59,8 @@ final class SchemaExampleMissing implements Rule, ComponentSchemaRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf('Schema "%s" has no example value', $componentSchema->name),
             location: new FindingLocation(
                 jsonPointer: ComponentReference::pointer($componentSchema->name),
@@ -65,21 +69,6 @@ final class SchemaExampleMissing implements Rule, ComponentSchemaRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.example-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Schema property has no example value.';
-    }
 }

--- a/src/Lint/Rules/SchemaNullableViaDeprecatedKeyword.php
+++ b/src/Lint/Rules/SchemaNullableViaDeprecatedKeyword.php
@@ -20,6 +20,10 @@ use function sprintf;
  */
 final class SchemaNullableViaDeprecatedKeyword implements Rule, FieldRuleVisitor
 {
+    public string $id = 'schema.nullable-via-deprecated-keyword';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Schema uses the deprecated OpenAPI 3.0 nullable: true keyword instead of a type array.';
+
     /**
      * @return iterable<Finding>
      */
@@ -37,8 +41,8 @@ final class SchemaNullableViaDeprecatedKeyword implements Rule, FieldRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Field "%s" uses the deprecated nullable keyword; use type union with "null" instead',
                 $field->name,
@@ -47,21 +51,6 @@ final class SchemaNullableViaDeprecatedKeyword implements Rule, FieldRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.nullable-via-deprecated-keyword';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Schema uses the deprecated OpenAPI 3.0 nullable: true keyword instead of a type array.';
-    }
 }

--- a/src/Lint/Rules/SchemaRawKeywordUnsupported.php
+++ b/src/Lint/Rules/SchemaRawKeywordUnsupported.php
@@ -27,6 +27,11 @@ use function sprintf;
  */
 final class SchemaRawKeywordUnsupported implements OperationRuleVisitor, Rule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A #[RawSchema] uses a keyword swagger-php cannot serialise '
+        . '(if/then/else, dependentRequired/dependentSchemas, dependencies).';
+
     public const string ID = 'schema.raw-keyword-unsupported';
 
     /** @var array<class-string, true> */
@@ -36,18 +41,7 @@ final class SchemaRawKeywordUnsupported implements OperationRuleVisitor, Rule
         private readonly PayloadParameterScanner $scanner,
     ) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A #[RawSchema] uses a keyword swagger-php cannot serialise '
-            . '(if/then/else, dependentRequired/dependentSchemas, dependencies).';
-    }
 
     /**
      * @return iterable<Finding>
@@ -104,7 +98,7 @@ final class SchemaRawKeywordUnsupported implements OperationRuleVisitor, Rule
 
         yield new Finding(
             ruleId: self::ID,
-            severity: $this->severity(),
+            severity: $this->severity,
             message: sprintf(
                 '#[RawSchema] on %s uses unsupported keyword(s): %s.',
                 $className,
@@ -117,9 +111,4 @@ final class SchemaRawKeywordUnsupported implements OperationRuleVisitor, Rule
         );
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 }

--- a/src/Lint/Rules/SchemaRequiredWithoutProperty.php
+++ b/src/Lint/Rules/SchemaRequiredWithoutProperty.php
@@ -28,6 +28,10 @@ use function sprintf;
  */
 final class SchemaRequiredWithoutProperty implements Rule, ComponentSchemaRuleVisitor
 {
+    public string $id = 'schema.required-without-property';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'required names a field not in properties.';
+
     /**
      * @return iterable<Finding>
      */
@@ -56,8 +60,8 @@ final class SchemaRequiredWithoutProperty implements Rule, ComponentSchemaRuleVi
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Schema "%s" marks "%s" as required, but no such property is defined',
                     $componentSchema->name,
@@ -153,21 +157,6 @@ final class SchemaRequiredWithoutProperty implements Rule, ComponentSchemaRuleVi
         return ComponentReference::name($ref);
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'schema.required-without-property';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'required names a field not in properties.';
-    }
 }

--- a/src/Lint/Rules/ScopeOverlyBroad.php
+++ b/src/Lint/Rules/ScopeOverlyBroad.php
@@ -21,8 +21,12 @@ use function sprintf;
  * Reports when an operation's only OAuth scope is the wildcard `*` and more specific scopes are
  * available in Passport. Using `*` alone defeats the purpose of scope-based access control.
  */
-final readonly class ScopeOverlyBroad implements Rule, OperationRuleVisitor
+final class ScopeOverlyBroad implements Rule, OperationRuleVisitor
 {
+    public string $id = 'scope.overly-broad';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Operation requires a scope that is broader than the resource warrants.';
+
     /**
      * @param null|list<string> $registeredScopes Known scope identifiers. When null, scopes are
      *                                            resolved from the context index.
@@ -54,8 +58,8 @@ final readonly class ScopeOverlyBroad implements Rule, OperationRuleVisitor
 
             if (count($scopeList) === 1 && $scopeList[0] === '*') {
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Operation %s %s uses only the wildcard scope "*" — consider using more specific scopes',
                         $operation->method->forDisplay(),
@@ -67,21 +71,6 @@ final readonly class ScopeOverlyBroad implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'scope.overly-broad';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation requires a scope that is broader than the resource warrants.';
-    }
 }

--- a/src/Lint/Rules/ScopeOverlyBroad.php
+++ b/src/Lint/Rules/ScopeOverlyBroad.php
@@ -31,7 +31,7 @@ final class ScopeOverlyBroad implements Rule, OperationRuleVisitor
      * @param null|list<string> $registeredScopes Known scope identifiers. When null, scopes are
      *                                            resolved from the context index.
      */
-    public function __construct(private ?array $registeredScopes = null) {}
+    public function __construct(private readonly ?array $registeredScopes = null) {}
 
     /**
      * @return iterable<Finding>

--- a/src/Lint/Rules/SecurityInvalidScope.php
+++ b/src/Lint/Rules/SecurityInvalidScope.php
@@ -16,8 +16,12 @@ use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
 use function in_array;
 use function sprintf;
 
-final readonly class SecurityInvalidScope implements Rule, OperationRuleVisitor
+final class SecurityInvalidScope implements Rule, OperationRuleVisitor
 {
+    public string $id = 'security.invalid-scope';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Operation requires a scope not declared in securitySchemes.';
+
     /**
      * @param null|list<string> $registeredScopes Known scope identifiers. When null, scopes are
      *                                            resolved from the context index.
@@ -54,8 +58,8 @@ final readonly class SecurityInvalidScope implements Rule, OperationRuleVisitor
                 }
 
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Operation %s %s references undefined scope "%s"',
                         $operation->method->forDisplay(),
@@ -68,21 +72,6 @@ final readonly class SecurityInvalidScope implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'security.invalid-scope';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation requires a scope not declared in securitySchemes.';
-    }
 }

--- a/src/Lint/Rules/SecurityInvalidScope.php
+++ b/src/Lint/Rules/SecurityInvalidScope.php
@@ -26,7 +26,7 @@ final class SecurityInvalidScope implements Rule, OperationRuleVisitor
      * @param null|list<string> $registeredScopes Known scope identifiers. When null, scopes are
      *                                            resolved from the context index.
      */
-    public function __construct(private ?array $registeredScopes = null) {}
+    public function __construct(private readonly ?array $registeredScopes = null) {}
 
     /**
      * @return iterable<Finding>

--- a/src/Lint/Rules/SecuritySchemeUndefined.php
+++ b/src/Lint/Rules/SecuritySchemeUndefined.php
@@ -26,6 +26,10 @@ use function sprintf;
  */
 final class SecuritySchemeUndefined implements Rule, OperationRuleVisitor, Resettable
 {
+    public string $id = 'security.scheme-undefined';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Operation references a security scheme not declared at the document level.';
+
     /** @var null|list<string> Memoized for the duration of a single walk. */
     private ?array $declaredSchemes = null;
 
@@ -52,8 +56,8 @@ final class SecuritySchemeUndefined implements Rule, OperationRuleVisitor, Reset
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s references undefined security scheme "%s"',
                     $operation->method->forDisplay(),
@@ -100,21 +104,6 @@ final class SecuritySchemeUndefined implements Rule, OperationRuleVisitor, Reset
         return $names;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'security.scheme-undefined';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation references a security scheme not declared at the document level.';
-    }
 }

--- a/src/Lint/Rules/ServerInvalidUrl.php
+++ b/src/Lint/Rules/ServerInvalidUrl.php
@@ -24,6 +24,10 @@ use const FILTER_VALIDATE_URL;
 
 final class ServerInvalidUrl implements Rule, ApiRuleVisitor
 {
+    public string $id = 'server.invalid-url';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'A servers[].url is malformed.';
+
     /**
      * @return iterable<Finding>
      */
@@ -56,29 +60,14 @@ final class ServerInvalidUrl implements Rule, ApiRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf('Server URL "%s" is not a valid URL.', $url),
                 fixHint: 'Provide a fully-qualified URL (e.g., https://api.example.com/v1), a relative path (e.g., /api/v0), or a valid URL template.',
             );
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'server.invalid-url';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A servers[].url is malformed.';
-    }
 }

--- a/src/Lint/Rules/ServerVariableUndeclared.php
+++ b/src/Lint/Rules/ServerVariableUndeclared.php
@@ -23,6 +23,10 @@ use function sprintf;
 
 final class ServerVariableUndeclared implements Rule, ApiRuleVisitor
 {
+    public string $id = 'server.variable-undeclared';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'A server URL template uses a {var} with no matching variables entry.';
+
     /**
      * @return iterable<Finding>
      */
@@ -68,8 +72,8 @@ final class ServerVariableUndeclared implements Rule, ApiRuleVisitor
                 }
 
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Server URL "%s" uses template variable "{%s}" but no matching entry exists in servers[].variables.',
                         $url,
@@ -84,21 +88,6 @@ final class ServerVariableUndeclared implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'server.variable-undeclared';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A server URL template uses a {var} with no matching variables entry.';
-    }
 }

--- a/src/Lint/Rules/SpecConfigOrphaned.php
+++ b/src/Lint/Rules/SpecConfigOrphaned.php
@@ -27,9 +27,9 @@ final class SpecConfigOrphaned implements PreBuildRule, Rule
     public const string ID = 'spec.config-orphaned';
 
     public function __construct(
-        private InclusionEvaluator $evaluator,
+        private readonly InclusionEvaluator $evaluator,
         #[Config('app.env')]
-        private string $environment,
+        private readonly string $environment,
     ) {}
 
 

--- a/src/Lint/Rules/SpecConfigOrphaned.php
+++ b/src/Lint/Rules/SpecConfigOrphaned.php
@@ -18,8 +18,12 @@ use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
  * Reports specs declared in config('openapi.specs') that match no routes. An empty spec produces
  * an invalid or useless document and usually indicates a misconfigured match filter.
  */
-final readonly class SpecConfigOrphaned implements PreBuildRule, Rule
+final class SpecConfigOrphaned implements PreBuildRule, Rule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = "Spec is defined in config('openapi.specs') but matches no routes.";
+
     public const string ID = 'spec.config-orphaned';
 
     public function __construct(
@@ -28,17 +32,7 @@ final readonly class SpecConfigOrphaned implements PreBuildRule, Rule
         private string $environment,
     ) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Spec is defined in config('openapi.specs') but matches no routes.";
-    }
 
     #[Override]
     public function checkConfiguration(
@@ -61,7 +55,7 @@ final readonly class SpecConfigOrphaned implements PreBuildRule, Rule
                 $findings->emit(
                     new Finding(
                         ruleId: self::ID,
-                        severity: $this->severity(),
+                        severity: $this->severity,
                         message: "Spec '{$spec->name}' is defined in config but matches no routes.",
                         fixHint: "Adjust the spec's match config or remove the spec entry.",
                     ),
@@ -70,9 +64,4 @@ final readonly class SpecConfigOrphaned implements PreBuildRule, Rule
         }
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 }

--- a/src/Lint/Rules/SpecInvalid.php
+++ b/src/Lint/Rules/SpecInvalid.php
@@ -42,9 +42,9 @@ final class SpecInvalid implements Rule, ApiRuleVisitor
     public Severity $severity = Severity::Broken;
     public string $description = 'Spec fails swagger-php validation. Cannot be suppressed or remapped.';
 
-    private string $schemaPath;
+    private readonly string $schemaPath;
 
-    private ErrorFormatter $formatter;
+    private readonly ErrorFormatter $formatter;
 
     public function __construct(?string $schemaPath = null)
     {

--- a/src/Lint/Rules/SpecInvalid.php
+++ b/src/Lint/Rules/SpecInvalid.php
@@ -36,8 +36,12 @@ use function strtoupper;
 
 use const JSON_THROW_ON_ERROR;
 
-final readonly class SpecInvalid implements Rule, ApiRuleVisitor
+final class SpecInvalid implements Rule, ApiRuleVisitor
 {
+    public string $id = 'spec.invalid';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Spec fails swagger-php validation. Cannot be suppressed or remapped.';
+
     private string $schemaPath;
 
     private ErrorFormatter $formatter;
@@ -48,23 +52,8 @@ final readonly class SpecInvalid implements Rule, ApiRuleVisitor
         $this->formatter = new ErrorFormatter();
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'spec.invalid';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Spec fails swagger-php validation. Cannot be suppressed or remapped.';
-    }
 
     /**
      * @return iterable<Finding>
@@ -237,7 +226,7 @@ final readonly class SpecInvalid implements Rule, ApiRuleVisitor
 
         return new Finding(
             ruleId: 'spec.invalid',
-            severity: $this->severity(),
+            severity: $this->severity,
             message: "{$humanPath}: {$interpolatedMessage}",
             location: $location,
             fixHint: $this->buildFixHint($parsed, $keyword),

--- a/src/Lint/Rules/SpecRouteOrphaned.php
+++ b/src/Lint/Rules/SpecRouteOrphaned.php
@@ -24,23 +24,17 @@ use function array_map;
  * Uses {@see SpecResolver} so the route's effective name set matches what the
  * generator sees (method-level #[Spec] shadows class-level).
  */
-final readonly class SpecRouteOrphaned implements Rule, PreBuildRule
+final class SpecRouteOrphaned implements Rule, PreBuildRule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Route is pinned via #[Spec] to specs that do not exist and will not appear in any document.';
+
     public const string ID = 'spec.route-orphaned';
 
     public function __construct(private SpecResolver $resolver) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Route is pinned via #[Spec] to specs that do not exist and will not appear in any document.';
-    }
 
     #[Override]
     public function checkConfiguration(
@@ -61,7 +55,7 @@ final readonly class SpecRouteOrphaned implements Rule, PreBuildRule
                 $findings->emit(
                     new Finding(
                         ruleId: self::ID,
-                        severity: $this->severity(),
+                        severity: $this->severity,
                         message: 'Route is pinned to specs that do not exist; it will not appear anywhere.',
                         location: FindingLocation::fromDescriptor($descriptor),
                         fixHint: 'Fix the #[Spec] argument(s) or declare the spec in config.',
@@ -71,9 +65,4 @@ final readonly class SpecRouteOrphaned implements Rule, PreBuildRule
         }
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 }

--- a/src/Lint/Rules/SpecRouteOrphaned.php
+++ b/src/Lint/Rules/SpecRouteOrphaned.php
@@ -32,7 +32,7 @@ final class SpecRouteOrphaned implements Rule, PreBuildRule
 
     public const string ID = 'spec.route-orphaned';
 
-    public function __construct(private SpecResolver $resolver) {}
+    public function __construct(private readonly SpecResolver $resolver) {}
 
 
 

--- a/src/Lint/Rules/SpecUnknownReference.php
+++ b/src/Lint/Rules/SpecUnknownReference.php
@@ -27,7 +27,7 @@ final class SpecUnknownReference implements Rule, PreBuildRule
 
     public const string ID = 'spec.unknown-reference';
 
-    public function __construct(private SpecResolver $resolver) {}
+    public function __construct(private readonly SpecResolver $resolver) {}
 
 
 

--- a/src/Lint/Rules/SpecUnknownReference.php
+++ b/src/Lint/Rules/SpecUnknownReference.php
@@ -19,23 +19,17 @@ use Radiergummi\OpenApi\Support\Spec\SpecResolver;
  * Uses {@see SpecResolver} to apply the same method-shadows-class precedence as generation,
  * so overridden class-level attributes are not flagged.
  */
-final readonly class SpecUnknownReference implements Rule, PreBuildRule
+final class SpecUnknownReference implements Rule, PreBuildRule
 {
+    public string $id = self::ID;
+    public Severity $severity = Severity::Broken;
+    public string $description = "#[Spec(name:)] references a spec name not declared in config('openapi.specs').";
+
     public const string ID = 'spec.unknown-reference';
 
     public function __construct(private SpecResolver $resolver) {}
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "#[Spec(name:)] references a spec name not declared in config('openapi.specs').";
-    }
 
     #[Override]
     public function checkConfiguration(
@@ -51,7 +45,7 @@ final readonly class SpecUnknownReference implements Rule, PreBuildRule
                     $findings->emit(
                         new Finding(
                             ruleId: self::ID,
-                            severity: $this->severity(),
+                            severity: $this->severity,
                             message: "Spec name '{$name}' referenced by #[Spec] is not declared in config('openapi.specs').",
                             location: FindingLocation::fromDescriptor($descriptor),
                             fixHint: "Add '{$name}' to config('openapi.specs') or remove the attribute argument.",
@@ -62,9 +56,4 @@ final readonly class SpecUnknownReference implements Rule, PreBuildRule
         }
     }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 }

--- a/src/Lint/Rules/StreamingNoContentType.php
+++ b/src/Lint/Rules/StreamingNoContentType.php
@@ -26,6 +26,10 @@ use function sprintf;
  */
 final class StreamingNoContentType implements Rule, OperationRuleVisitor
 {
+    public string $id = 'streaming.no-content-type';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Streaming operation has no content-type: text/event-stream response.';
+
     /**
      * @return iterable<Finding>
      */
@@ -60,8 +64,8 @@ final class StreamingNoContentType implements Rule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'Streaming endpoint %s::%s() does not declare text/event-stream content type in its responses',
                 $operation->descriptor->controller?->getName() ?? '(unknown)',
@@ -108,21 +112,6 @@ final class StreamingNoContentType implements Rule, OperationRuleVisitor
         return false;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'streaming.no-content-type';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Streaming operation has no content-type: text/event-stream response.';
-    }
 }

--- a/src/Lint/Rules/SummaryMissing.php
+++ b/src/Lint/Rules/SummaryMissing.php
@@ -20,6 +20,10 @@ use function trim;
  */
 final class SummaryMissing implements Rule, OperationRuleVisitor
 {
+    public string $id = 'summary.missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Operation has no summary.';
+
     /**
      * @return iterable<Finding>
      */
@@ -28,8 +32,8 @@ final class SummaryMissing implements Rule, OperationRuleVisitor
     {
         if ($operation->summary === null || trim($operation->summary) === '') {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Operation %s %s has no summary',
                     $operation->method->forDisplay(),
@@ -40,21 +44,6 @@ final class SummaryMissing implements Rule, OperationRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'summary.missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation has no summary.';
-    }
 }

--- a/src/Lint/Rules/TagDuplicate.php
+++ b/src/Lint/Rules/TagDuplicate.php
@@ -25,6 +25,10 @@ use function sprintf;
 
 final class TagDuplicate implements FixableRule, OperationRuleVisitor
 {
+    public string $id = 'tag.duplicate';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'The same #[Tag] is applied more than once to a controller method.';
+
     /**
      * @return iterable<Finding>
      */
@@ -56,8 +60,8 @@ final class TagDuplicate implements FixableRule, OperationRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Tag "%s" is applied %d times on %s %s',
                     $tag,
@@ -84,17 +88,7 @@ final class TagDuplicate implements FixableRule, OperationRuleVisitor
         return $attr->name;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'tag.duplicate';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -107,9 +101,4 @@ final class TagDuplicate implements FixableRule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'The same #[Tag] is applied more than once to a controller method.';
-    }
 }

--- a/src/Lint/Rules/TagNameNamingInconsistent.php
+++ b/src/Lint/Rules/TagNameNamingInconsistent.php
@@ -23,8 +23,11 @@ use function sprintf;
  * so the default convention is {@see IdentifierCase::Pascal}.
  */
 #[Scoped]
-final readonly class TagNameNamingInconsistent extends AbstractNamingRule implements ApiRuleVisitor
+final class TagNameNamingInconsistent extends AbstractNamingRule implements ApiRuleVisitor
 {
+    public string $id = 'tag.name-naming-inconsistent';
+    public string $description = "Tag name doesn't follow the project's tag_case convention.";
+
     public function __construct(
         #[Config('openapi.lint.style.tag_case', 'pascal')]
         IdentifierCase|string $case = IdentifierCase::Pascal,
@@ -44,8 +47,8 @@ final readonly class TagNameNamingInconsistent extends AbstractNamingRule implem
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'Tag name "%s" does not follow the %s naming convention',
                     $tagName,
@@ -57,15 +60,5 @@ final readonly class TagNameNamingInconsistent extends AbstractNamingRule implem
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'tag.name-naming-inconsistent';
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return "Tag name doesn't follow the project's tag_case convention.";
-    }
 }

--- a/src/Lint/Rules/TagUndeclaredAtRoot.php
+++ b/src/Lint/Rules/TagUndeclaredAtRoot.php
@@ -21,6 +21,10 @@ use function sprintf;
  */
 final class TagUndeclaredAtRoot implements Rule, ApiRuleVisitor
 {
+    public string $id = 'tag.undeclared-at-root';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Operation uses a tag not declared in the document-level tags array.';
+
     /**
      * @return iterable<Finding>
      */
@@ -34,8 +38,8 @@ final class TagUndeclaredAtRoot implements Rule, ApiRuleVisitor
                 }
 
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Tag "%s" used on %s %s is not declared in the top-level tags array',
                         $tag,
@@ -52,21 +56,6 @@ final class TagUndeclaredAtRoot implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'tag.undeclared-at-root';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Operation uses a tag not declared in the document-level tags array.';
-    }
 }

--- a/src/Lint/Rules/TagsNoDescription.php
+++ b/src/Lint/Rules/TagsNoDescription.php
@@ -21,6 +21,10 @@ use function trim;
  */
 final class TagsNoDescription implements Rule, ApiRuleVisitor
 {
+    public string $id = 'tags.no-description';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Document-level tag has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -35,8 +39,8 @@ final class TagsNoDescription implements Rule, ApiRuleVisitor
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf('Tag "%s" has no description', $tagName),
                 location: new FindingLocation(jsonPointer: '#/tags/' . $index),
                 fixHint: 'Add a description to the tag to improve API documentation.',
@@ -44,21 +48,6 @@ final class TagsNoDescription implements Rule, ApiRuleVisitor
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'tags.no-description';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Document-level tag has no description.';
-    }
 }

--- a/src/Lint/Rules/ThrowsTransitiveMissing.php
+++ b/src/Lint/Rules/ThrowsTransitiveMissing.php
@@ -40,7 +40,7 @@ final class ThrowsTransitiveMissing implements Rule, OperationRuleVisitor
     public Severity $severity = Severity::Degraded;
     public string $description = 'Action::handle() declares @throws exceptions not redeclared on the controller method.';
 
-    private ThrowsExtractor $throwsExtractor;
+    private readonly ThrowsExtractor $throwsExtractor;
 
     public function __construct(?ThrowsExtractor $throwsExtractor = null)
     {

--- a/src/Lint/Rules/ThrowsTransitiveMissing.php
+++ b/src/Lint/Rules/ThrowsTransitiveMissing.php
@@ -34,8 +34,12 @@ use function str_ends_with;
  * propagating it to the controller's PHPDoc, which in turn means the OpenAPI spec will lack the
  * corresponding error response.
  */
-final readonly class ThrowsTransitiveMissing implements Rule, OperationRuleVisitor
+final class ThrowsTransitiveMissing implements Rule, OperationRuleVisitor
 {
+    public string $id = 'throws.transitive-missing';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Action::handle() declares @throws exceptions not redeclared on the controller method.';
+
     private ThrowsExtractor $throwsExtractor;
 
     public function __construct(?ThrowsExtractor $throwsExtractor = null)
@@ -145,8 +149,8 @@ final readonly class ThrowsTransitiveMissing implements Rule, OperationRuleVisit
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '%s::handle() declares @throws %s, but %s::%s() does not redeclare it',
                     $actionShortName,
@@ -164,21 +168,6 @@ final readonly class ThrowsTransitiveMissing implements Rule, OperationRuleVisit
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'throws.transitive-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Action::handle() declares @throws exceptions not redeclared on the controller method.';
-    }
 }

--- a/src/Lint/Rules/VisibilityAttributeNoOp.php
+++ b/src/Lint/Rules/VisibilityAttributeNoOp.php
@@ -28,7 +28,7 @@ final class VisibilityAttributeNoOp implements Rule, RouteRule
     public Severity $severity = Severity::Underspecified;
     public string $description = 'Unconditional visibility attribute that has no effect under the active default.';
 
-    public function __construct(private VisibilityResolver $visibility) {}
+    public function __construct(private readonly VisibilityResolver $visibility) {}
 
 
     /**

--- a/src/Lint/Rules/VisibilityAttributeNoOp.php
+++ b/src/Lint/Rules/VisibilityAttributeNoOp.php
@@ -22,15 +22,14 @@ use Radiergummi\OpenApi\Support\Visibility\VisibilityResolver;
  * have no effect under the active default. Env-scoped variants are never
  * flagged because their effect can flip across environments.
  */
-final readonly class VisibilityAttributeNoOp implements Rule, RouteRule
+final class VisibilityAttributeNoOp implements Rule, RouteRule
 {
+    public string $id = 'visibility.attribute-no-op';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Unconditional visibility attribute that has no effect under the active default.';
+
     public function __construct(private VisibilityResolver $visibility) {}
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Unconditional visibility attribute that has no effect under the active default.';
-    }
 
     /**
      * @return iterable<Finding>
@@ -48,8 +47,8 @@ final readonly class VisibilityAttributeNoOp implements Rule, RouteRule
             foreach ($this->collectInstances($descriptor, Expose::class) as $expose) {
                 if ($expose->only === null && $expose->except === null) {
                     yield new Finding(
-                        ruleId: $this->id(),
-                        severity: $this->severity(),
+                        ruleId: $this->id,
+                        severity: $this->severity,
                         message: '#[Expose] has no effect in public-default visibility mode.',
                         fixHint: "Remove the attribute, or set `config('openapi.visibility.default') = 'hidden'`.",
                     );
@@ -68,8 +67,8 @@ final readonly class VisibilityAttributeNoOp implements Rule, RouteRule
         foreach ($this->collectInstances($descriptor, Hide::class) as $hide) {
             if ($hide->only === null && $hide->except === null) {
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: '#[Hide] has no effect in hidden-default visibility mode (routes are already hidden by default).',
                     fixHint: "Remove the attribute, or set `config('openapi.visibility.default') = 'public'`.",
                 );
@@ -101,15 +100,5 @@ final readonly class VisibilityAttributeNoOp implements Rule, RouteRule
         return $out;
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'visibility.attribute-no-op';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 }

--- a/src/Lint/Rules/WebhookDescriptionMissing.php
+++ b/src/Lint/Rules/WebhookDescriptionMissing.php
@@ -24,6 +24,10 @@ use function trim;
  */
 final class WebhookDescriptionMissing implements Rule, WebhookRuleVisitor
 {
+    public string $id = 'webhook.description-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'Webhook operation has no description.';
+
     /**
      * @return iterable<Finding>
      */
@@ -37,29 +41,14 @@ final class WebhookDescriptionMissing implements Rule, WebhookRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf('Webhook "%s" has no description', $webhook->name),
             location: new FindingLocation(jsonPointer: $webhook->pointer()),
             fixHint: 'Add a description explaining when and why this webhook fires.',
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'webhook.description-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Webhook operation has no description.';
-    }
 }

--- a/src/Lint/Rules/WebhookNameDuplicate.php
+++ b/src/Lint/Rules/WebhookNameDuplicate.php
@@ -23,6 +23,10 @@ use function sprintf;
  */
 final class WebhookNameDuplicate implements Rule, WebhookRuleVisitor, Finalizable, Resettable
 {
+    public string $id = 'webhook.name-duplicate';
+    public Severity $severity = Severity::Broken;
+    public string $description = 'Two webhooks share the same name.';
+
     /**
      * @var array<string, list<WebhookNode>>
      */
@@ -56,8 +60,8 @@ final class WebhookNameDuplicate implements Rule, WebhookRuleVisitor, Finalizabl
 
             foreach ($nodes as $node) {
                 yield new Finding(
-                    ruleId: $this->id(),
-                    severity: $this->severity(),
+                    ruleId: $this->id,
+                    severity: $this->severity,
                     message: sprintf(
                         'Webhook name "%s" is used %d times across the spec; names must be globally unique',
                         $name,
@@ -70,21 +74,6 @@ final class WebhookNameDuplicate implements Rule, WebhookRuleVisitor, Finalizabl
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'webhook.name-duplicate';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Broken;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two webhooks share the same name.';
-    }
 }

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldTypeMissing.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldTypeMissing.php
@@ -27,7 +27,7 @@ final class ResourceFieldTypeMissing implements Rule, OperationRuleVisitor
     public string $description = 'A #[ResourceField] is declared without a resolvable type.';
 
     public function __construct(
-        private ResourceTargetLocator $locator,
+        private readonly ResourceTargetLocator $locator,
     ) {}
 
     /**

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldTypeMissing.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldTypeMissing.php
@@ -20,8 +20,12 @@ use function sprintf;
  * Flags a `#[ResourceField]` declared with no `type`; its schema cannot be derived, so the
  * field is emitted untyped.
  */
-final readonly class ResourceFieldTypeMissing implements Rule, OperationRuleVisitor
+final class ResourceFieldTypeMissing implements Rule, OperationRuleVisitor
 {
+    public string $id = 'resource.field-type-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A #[ResourceField] is declared without a resolvable type.';
+
     public function __construct(
         private ResourceTargetLocator $locator,
     ) {}
@@ -57,8 +61,8 @@ final readonly class ResourceFieldTypeMissing implements Rule, OperationRuleVisi
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '#[ResourceField(\'%s\')] on %s has no type — the field is emitted untyped',
                     $field->name,
@@ -69,21 +73,6 @@ final readonly class ResourceFieldTypeMissing implements Rule, OperationRuleVisi
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'resource.field-type-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A #[ResourceField] is declared without a resolvable type.';
-    }
 }

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
@@ -26,8 +26,13 @@ use function sprintf;
  * shape the generator cannot infer either (no readable `toArray()` literal, no wrapped model),
  * so the response schema is genuinely empty.
  */
-final readonly class ResourceFieldsUndeclared implements Rule, OperationRuleVisitor
+final class ResourceFieldsUndeclared implements Rule, OperationRuleVisitor
 {
+    public string $id = 'resource.fields-undeclared';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'An API Resource used as a response declares no #[ResourceField] attributes '
+        . 'and its shape cannot be inferred from toArray() or a wrapped model.';
+
     public function __construct(
         private ResourceTargetLocator $locator,
         private ResourceToArrayReader $toArrayReader,
@@ -83,8 +88,8 @@ final readonly class ResourceFieldsUndeclared implements Rule, OperationRuleVisi
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s %s returns %s but it declares no #[ResourceField] — the response schema is empty',
                 $operation->method->forDisplay(),
@@ -96,22 +101,6 @@ final readonly class ResourceFieldsUndeclared implements Rule, OperationRuleVisi
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'resource.fields-undeclared';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'An API Resource used as a response declares no #[ResourceField] attributes '
-            . 'and its shape cannot be inferred from toArray() or a wrapped model.';
-    }
 }

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceFieldsUndeclared.php
@@ -34,9 +34,9 @@ final class ResourceFieldsUndeclared implements Rule, OperationRuleVisitor
         . 'and its shape cannot be inferred from toArray() or a wrapped model.';
 
     public function __construct(
-        private ResourceTargetLocator $locator,
-        private ResourceToArrayReader $toArrayReader,
-        private WrappedModelLocator $wrappedModelLocator,
+        private readonly ResourceTargetLocator $locator,
+        private readonly ResourceToArrayReader $toArrayReader,
+        private readonly WrappedModelLocator $wrappedModelLocator,
     ) {}
 
     /**

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
@@ -28,7 +28,7 @@ final class ResourceResponseAmbiguous implements Rule, OperationRuleVisitor
         . 'nor the collection\'s #[Collects]/$collects declaration, nor the return expression resolves one.';
 
     public function __construct(
-        private ResourceTargetLocator $locator,
+        private readonly ResourceTargetLocator $locator,
     ) {}
 
     /**

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceResponseAmbiguous.php
@@ -20,8 +20,13 @@ use function sprintf;
  * naming the item class: the response shape cannot be derived and the endpoint falls back to a
  * bare `200 OK`.
  */
-final readonly class ResourceResponseAmbiguous implements Rule, OperationRuleVisitor
+final class ResourceResponseAmbiguous implements Rule, OperationRuleVisitor
 {
+    public string $id = 'resource.response-ambiguous';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A resource collection response names no item class — neither a #[ResponseResource] attribute, '
+        . 'nor the collection\'s #[Collects]/$collects declaration, nor the return expression resolves one.';
+
     public function __construct(
         private ResourceTargetLocator $locator,
     ) {}
@@ -43,8 +48,8 @@ final readonly class ResourceResponseAmbiguous implements Rule, OperationRuleVis
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s %s returns a resource collection but no #[ResponseResource] names the item class',
                 $operation->method->forDisplay(),
@@ -54,22 +59,6 @@ final readonly class ResourceResponseAmbiguous implements Rule, OperationRuleVis
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'resource.response-ambiguous';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A resource collection response names no item class — neither a #[ResponseResource] attribute, '
-            . 'nor the collection\'s #[Collects]/$collects declaration, nor the return expression resolves one.';
-    }
 }

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceResponseEmpty.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceResponseEmpty.php
@@ -34,9 +34,9 @@ final class ResourceResponseEmpty implements Rule, OperationRuleVisitor
         . 'shape. It ships an empty {data: {}} envelope.';
 
     public function __construct(
-        private ResourceTargetLocator $locator,
-        private ResourceToArrayReader $toArrayReader,
-        private WrappedModelLocator $wrappedModelLocator,
+        private readonly ResourceTargetLocator $locator,
+        private readonly ResourceToArrayReader $toArrayReader,
+        private readonly WrappedModelLocator $wrappedModelLocator,
     ) {}
 
     /**

--- a/src/Plugins/ApiResources/Lint/Rules/ResourceResponseEmpty.php
+++ b/src/Plugins/ApiResources/Lint/Rules/ResourceResponseEmpty.php
@@ -26,8 +26,13 @@ use function sprintf;
  * (concrete resource, empty shape) and {@see ResourceResponseAmbiguous} (collection, no item class).
  * Skips when the shape is actually inferable from `toArray()` or a wrapped model.
  */
-final readonly class ResourceResponseEmpty implements Rule, OperationRuleVisitor
+final class ResourceResponseEmpty implements Rule, OperationRuleVisitor
 {
+    public string $id = 'resource.response-empty';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A resource response resolves to the base or an abstract JsonResource with no inferable '
+        . 'shape. It ships an empty {data: {}} envelope.';
+
     public function __construct(
         private ResourceTargetLocator $locator,
         private ResourceToArrayReader $toArrayReader,
@@ -77,8 +82,8 @@ final readonly class ResourceResponseEmpty implements Rule, OperationRuleVisitor
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s %s resolves to %s — the response schema is an empty {data: {}} envelope',
                 $operation->method->forDisplay(),
@@ -90,22 +95,6 @@ final readonly class ResourceResponseEmpty implements Rule, OperationRuleVisitor
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'resource.response-empty';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A resource response resolves to the base or an abstract JsonResource with no inferable '
-            . 'shape. It ships an empty {data: {}} envelope.';
-    }
 }

--- a/src/Plugins/Core/Lint/RequestBodySchemaDegraded.php
+++ b/src/Plugins/Core/Lint/RequestBodySchemaDegraded.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Core\Lint;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\FindingsCollector;
@@ -25,21 +24,10 @@ use Radiergummi\OpenApi\Plugins\Core\Support\SchemaFromFormRequest;
  */
 final class RequestBodySchemaDegraded implements Rule
 {
-    #[Override]
-    public function id(): string
-    {
-        return 'request-body.schema-degraded';
-    }
+    public string $id = 'request-body.schema-degraded';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A FormRequest threw during introspection; its request body schema is a placeholder and does not reflect the real validation rules.';
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A FormRequest threw during introspection; its request body schema is a placeholder and does not reflect the real validation rules.';
-    }
+
 }

--- a/src/Plugins/Core/Lint/RuleInvalidEnumValue.php
+++ b/src/Plugins/Core/Lint/RuleInvalidEnumValue.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Core\Lint;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\FindingsCollector;
@@ -19,21 +18,10 @@ use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
  */
 final class RuleInvalidEnumValue implements Rule
 {
-    #[Override]
-    public function id(): string
-    {
-        return 'rule.invalid-enum-value';
-    }
+    public string $id = 'rule.invalid-enum-value';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A SelfDocumentingRule returned a non-scalar enum value; the entry was dropped.';
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A SelfDocumentingRule returned a non-scalar enum value; the entry was dropped.';
-    }
+
 }

--- a/src/Plugins/Core/Lint/RuleUnknown.php
+++ b/src/Plugins/Core/Lint/RuleUnknown.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Core\Lint;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\RuleRegistry;
@@ -17,21 +16,10 @@ use Radiergummi\OpenApi\Support\Extraction\ValidationRulesToSchema;
  */
 final class RuleUnknown implements Rule
 {
-    #[Override]
-    public function id(): string
-    {
-        return 'rule.unknown';
-    }
+    public string $id = 'rule.unknown';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A Laravel validation Rule object cannot be mapped to a JSON Schema constraint and was dropped.';
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A Laravel validation Rule object cannot be mapped to a JSON Schema constraint and was dropped.';
-    }
+
 }

--- a/src/Plugins/Core/Lint/ThrowsUnmapped.php
+++ b/src/Plugins/Core/Lint/ThrowsUnmapped.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\Core\Lint;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Plugins\Core\ErrorContributors\ThrowsErrorContributor;
@@ -17,21 +16,10 @@ use Radiergummi\OpenApi\Plugins\Core\ErrorContributors\ThrowsErrorContributor;
  */
 final class ThrowsUnmapped implements Rule
 {
-    #[Override]
-    public function id(): string
-    {
-        return 'throws.unmapped';
-    }
+    public string $id = 'throws.unmapped';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A @throws FQCN has no entry in the exception map or #[ExceptionResponse] attribute.';
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A @throws FQCN has no entry in the exception map or #[ExceptionResponse] attribute.';
-    }
+
 }

--- a/src/Plugins/Fractal/Lint/Rules/FractalDuplicateKey.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalDuplicateKey.php
@@ -23,8 +23,12 @@ use function sprintf;
  * `#[TransformerField]` and/or `#[TransformerInclude]`. swagger-php emits both properties; the
  * resulting OpenAPI schema is invalid.
  */
-final readonly class FractalDuplicateKey implements Rule, OperationRule
+final class FractalDuplicateKey implements Rule, OperationRule
 {
+    public string $id = 'fractal.duplicate-key';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A transformer declares the same output key in more than one #[TransformerField]/#[TransformerInclude].';
+
     /**
      * @return iterable<Finding>
      */
@@ -73,8 +77,8 @@ final readonly class FractalDuplicateKey implements Rule, OperationRule
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '%s declares the key \'%s\' %d times across #[TransformerField]/#[TransformerInclude]',
                     $transformer,
@@ -86,21 +90,6 @@ final readonly class FractalDuplicateKey implements Rule, OperationRule
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'fractal.duplicate-key';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A transformer declares the same output key in more than one #[TransformerField]/#[TransformerInclude].';
-    }
 }

--- a/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
@@ -31,7 +31,7 @@ final class FractalFieldsUndeclared implements Rule, OperationRule
     public string $description = 'A transformer bound via #[FractalResponse] declares no #[TransformerField] attributes.';
 
     public function __construct(
-        private TransformerTransformReader $transformReader,
+        private readonly TransformerTransformReader $transformReader,
     ) {}
 
     /**

--- a/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalFieldsUndeclared.php
@@ -24,8 +24,12 @@ use function sprintf;
  * `#[TransformerField]`, and whose shape the generator cannot infer from the `transform()`
  * literal either, so the response schema is genuinely empty.
  */
-final readonly class FractalFieldsUndeclared implements Rule, OperationRule
+final class FractalFieldsUndeclared implements Rule, OperationRule
 {
+    public string $id = 'fractal.fields-undeclared';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A transformer bound via #[FractalResponse] declares no #[TransformerField] attributes.';
+
     public function __construct(
         private TransformerTransformReader $transformReader,
     ) {}
@@ -67,8 +71,8 @@ final readonly class FractalFieldsUndeclared implements Rule, OperationRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s %s is bound to %s, which declares no #[TransformerField] — the response schema is empty',
                 $operation->method->forDisplay(),
@@ -79,21 +83,6 @@ final readonly class FractalFieldsUndeclared implements Rule, OperationRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'fractal.fields-undeclared';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A transformer bound via #[FractalResponse] declares no #[TransformerField] attributes.';
-    }
 }

--- a/src/Plugins/Fractal/Lint/Rules/FractalIncludeTransformerMissing.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalIncludeTransformerMissing.php
@@ -21,8 +21,12 @@ use function sprintf;
  * Flags a `#[TransformerInclude]` declared with no `transformer` class; the included resource
  * is emitted as an opaque `type: object`.
  */
-final readonly class FractalIncludeTransformerMissing implements Rule, OperationRule
+final class FractalIncludeTransformerMissing implements Rule, OperationRule
 {
+    public string $id = 'fractal.include-transformer-missing';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A #[TransformerInclude] is declared without a transformer class.';
+
     /**
      * @return iterable<Finding>
      */
@@ -60,8 +64,8 @@ final readonly class FractalIncludeTransformerMissing implements Rule, Operation
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '#[TransformerInclude(\'%s\')] on %s has no transformer — the include is emitted as an opaque object',
                     $include->name,
@@ -72,21 +76,6 @@ final readonly class FractalIncludeTransformerMissing implements Rule, Operation
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'fractal.include-transformer-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A #[TransformerInclude] is declared without a transformer class.';
-    }
 }

--- a/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
@@ -35,7 +35,7 @@ final class FractalResponseUnbound implements Rule, OperationRule
     private const string MANAGER_CLASS = 'League\\Fractal\\Manager';
 
     public function __construct(
-        private PayloadParameterScanner $scanner,
+        private readonly PayloadParameterScanner $scanner,
     ) {}
 
     /**

--- a/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalResponseUnbound.php
@@ -24,8 +24,14 @@ use function sprintf;
  * Ships at level 2 because the `fractal()` helper and facade never inject a `Manager`, so they
  * would never trigger this rule; silencing them at level 1 would be misleading.
  */
-final readonly class FractalResponseUnbound implements Rule, OperationRule
+final class FractalResponseUnbound implements Rule, OperationRule
 {
+    public string $id = 'fractal.response-unbound';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A method injects a Fractal Manager but declares no #[FractalResponse]. '
+        . 'Does not cover the fractal() helper or the Spatie\\Fractalistic\\Fractal facade, '
+        . 'which are invoked inside method bodies and never inject a Manager.';
+
     private const string MANAGER_CLASS = 'League\\Fractal\\Manager';
 
     public function __construct(
@@ -54,8 +60,8 @@ final readonly class FractalResponseUnbound implements Rule, OperationRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s %s injects a Fractal Manager but declares no #[FractalResponse]',
                 $operation->method->forDisplay(),
@@ -65,23 +71,6 @@ final readonly class FractalResponseUnbound implements Rule, OperationRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'fractal.response-unbound';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A method injects a Fractal Manager but declares no #[FractalResponse]. '
-            . 'Does not cover the fractal() helper or the Spatie\\Fractalistic\\Fractal facade, '
-            . 'which are invoked inside method bodies and never inject a Manager.';
-    }
 }

--- a/src/Plugins/Fractal/Lint/Rules/FractalTransformerClassMissing.php
+++ b/src/Plugins/Fractal/Lint/Rules/FractalTransformerClassMissing.php
@@ -22,8 +22,12 @@ use function sprintf;
  * returns null in this case, so the operation silently loses its 200 response. This rule
  * surfaces it during `openapi:lint` instead.
  */
-final readonly class FractalTransformerClassMissing implements Rule, OperationRule
+final class FractalTransformerClassMissing implements Rule, OperationRule
 {
+    public string $id = 'fractal.transformer-class-missing';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'A #[FractalResponse] names a transformer class that does not exist.';
+
     /**
      * @return iterable<Finding>
      */
@@ -49,8 +53,8 @@ final readonly class FractalTransformerClassMissing implements Rule, OperationRu
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '#[FractalResponse] on %s %s names unknown transformer %s',
                 $operation->method->forDisplay(),
@@ -61,21 +65,6 @@ final readonly class FractalTransformerClassMissing implements Rule, OperationRu
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'fractal.transformer-class-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A #[FractalResponse] names a transformer class that does not exist.';
-    }
 }

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterDuplicate.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterDuplicate.php
@@ -22,8 +22,12 @@ use function sprintf;
  * When names collide, `OperationBuilder`'s name+in dedup silently keeps only the last instance;
  * the earlier ones are dropped without any diagnostic.
  */
-final readonly class QueryBuilderFilterDuplicate implements Rule, OperationRule
+final class QueryBuilderFilterDuplicate implements Rule, OperationRule
 {
+    public string $id = 'query-builder.filter-duplicate';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'Two or more #[AllowedFilter] attributes on the same action share the same name — only the last is emitted. (QueryBuilder plugin.)';
+
     /**
      * @return iterable<Finding>
      */
@@ -47,8 +51,8 @@ final readonly class QueryBuilderFilterDuplicate implements Rule, OperationRule
 
         foreach ($duplicatedNames as $name) {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '#[AllowedFilter(\'%s\')] is declared %d times on %s %s — only the last instance is emitted',
                     $name,
@@ -61,21 +65,6 @@ final readonly class QueryBuilderFilterDuplicate implements Rule, OperationRule
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'query-builder.filter-duplicate';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Two or more #[AllowedFilter] attributes on the same action share the same name — only the last is emitted. (QueryBuilder plugin.)';
-    }
 }

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterTypeMissing.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderFilterTypeMissing.php
@@ -19,8 +19,12 @@ use function sprintf;
  * Flags an `#[AllowedFilter]` declared with no `type`; the filter parameter falls back to
  * `string`, which may misrepresent the accepted value.
  */
-final readonly class QueryBuilderFilterTypeMissing implements Rule, OperationRule
+final class QueryBuilderFilterTypeMissing implements Rule, OperationRule
 {
+    public string $id = 'query-builder.filter-type-missing';
+    public Severity $severity = Severity::Inconsistent;
+    public string $description = 'An #[AllowedFilter] is declared without an explicit value type.';
+
     /**
      * @return iterable<Finding>
      */
@@ -41,8 +45,8 @@ final readonly class QueryBuilderFilterTypeMissing implements Rule, OperationRul
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '#[AllowedFilter(\'%s\')] on %s %s has no type — the filter parameter defaults to string',
                     $filter->name,
@@ -54,21 +58,6 @@ final readonly class QueryBuilderFilterTypeMissing implements Rule, OperationRul
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'query-builder.filter-type-missing';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Inconsistent;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'An #[AllowedFilter] is declared without an explicit value type.';
-    }
 }

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
@@ -28,8 +28,12 @@ use function sprintf;
  * by FQCN string via {@see PayloadParameterScanner}, so the package need not be installed), not a
  * body-inference heuristic.
  */
-final readonly class QueryBuilderParamsUndeclared implements Rule, OperationRule
+final class QueryBuilderParamsUndeclared implements Rule, OperationRule
 {
+    public string $id = 'query-builder.params-undeclared';
+    public Severity $severity = Severity::Underspecified;
+    public string $description = 'A method injects a QueryBuilder but declares no allowed filter/sort/include attributes.';
+
     private const string QUERY_BUILDER_CLASS = 'Spatie\\QueryBuilder\\QueryBuilder';
 
     public function __construct(
@@ -62,8 +66,8 @@ final readonly class QueryBuilderParamsUndeclared implements Rule, OperationRule
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s %s injects a QueryBuilder but declares no #[AllowedFilter]/#[AllowedSort]/#[AllowedInclude]',
                 $operation->method->forDisplay(),
@@ -73,21 +77,6 @@ final readonly class QueryBuilderParamsUndeclared implements Rule, OperationRule
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'query-builder.params-undeclared';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Underspecified;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A method injects a QueryBuilder but declares no allowed filter/sort/include attributes.';
-    }
 }

--- a/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
+++ b/src/Plugins/QueryBuilder/Lint/Rules/QueryBuilderParamsUndeclared.php
@@ -37,7 +37,7 @@ final class QueryBuilderParamsUndeclared implements Rule, OperationRule
     private const string QUERY_BUILDER_CLASS = 'Spatie\\QueryBuilder\\QueryBuilder';
 
     public function __construct(
-        private PayloadParameterScanner $scanner,
+        private readonly PayloadParameterScanner $scanner,
     ) {}
 
     /**

--- a/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
+++ b/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
@@ -30,8 +30,12 @@ use function sprintf;
  * Detection is limited to operation method parameters (unambiguous scope). Data classes injected
  * via Domain Actions are reached through {@see PayloadParameterScanner}.
  */
-final readonly class FieldAttributeWrongScope implements Rule, OperationRuleVisitor
+final class FieldAttributeWrongScope implements Rule, OperationRuleVisitor
 {
+    public string $id = 'field.attribute-wrong-scope';
+    public Severity $severity = Severity::Degraded;
+    public string $description = '#[RequestField] on a URI parameter, or #[PathParam] on a Data-class property.';
+
     public function __construct(
         private PayloadParameterScanner $scanner,
     ) {}
@@ -86,8 +90,8 @@ final readonly class FieldAttributeWrongScope implements Rule, OperationRuleVisi
             }
 
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     '#[PathParam] on %s::$%s applies to URI parameters, not request-body fields',
                     $property->getDeclaringClass()->getName(),
@@ -98,17 +102,7 @@ final readonly class FieldAttributeWrongScope implements Rule, OperationRuleVisi
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'field.attribute-wrong-scope';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
     /** @return iterable<Finding> */
     private function checkRouteParameter(ReflectionParameter $param, OperationNode $operation): iterable
@@ -118,8 +112,8 @@ final readonly class FieldAttributeWrongScope implements Rule, OperationRuleVisi
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '#[RequestField] on URI parameter $%s of %s %s applies to request-body fields, not URI parameters',
                 $param->getName(),
@@ -130,9 +124,4 @@ final readonly class FieldAttributeWrongScope implements Rule, OperationRuleVisi
         );
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return '#[RequestField] on a URI parameter, or #[PathParam] on a Data-class property.';
-    }
 }

--- a/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
+++ b/src/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScope.php
@@ -37,7 +37,7 @@ final class FieldAttributeWrongScope implements Rule, OperationRuleVisitor
     public string $description = '#[RequestField] on a URI parameter, or #[PathParam] on a Data-class property.';
 
     public function __construct(
-        private PayloadParameterScanner $scanner,
+        private readonly PayloadParameterScanner $scanner,
     ) {}
 
     /**

--- a/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
+++ b/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
@@ -31,8 +31,8 @@ final class MultipartFileWithoutMultipart implements Rule, OperationRuleVisitor
     public string $description = 'Data class carries a file property but a #[RequestBody] override forces a non-multipart body — the spec contradicts the code.';
 
     public function __construct(
-        private FilePropertyChecker $schemaBuilder,
-        private PayloadParameterScanner $scanner,
+        private readonly FilePropertyChecker $schemaBuilder,
+        private readonly PayloadParameterScanner $scanner,
     ) {}
 
     /**

--- a/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
+++ b/src/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipart.php
@@ -24,8 +24,12 @@ use function sprintf;
  * whose Data class carries an `UploadedFile` property, contradicting the code. The auto-generated
  * path never trips this rule; it only catches explicit overrides.
  */
-final readonly class MultipartFileWithoutMultipart implements Rule, OperationRuleVisitor
+final class MultipartFileWithoutMultipart implements Rule, OperationRuleVisitor
 {
+    public string $id = 'multipart.file-without-multipart';
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Data class carries a file property but a #[RequestBody] override forces a non-multipart body — the spec contradicts the code.';
+
     public function __construct(
         private FilePropertyChecker $schemaBuilder,
         private PayloadParameterScanner $scanner,
@@ -56,8 +60,8 @@ final readonly class MultipartFileWithoutMultipart implements Rule, OperationRul
         }
 
         yield new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s::%s() accepts an UploadedFile via a Data object, but %s %s overrides the body to a non-multipart media type — the file field will not transfer',
                 $operation->descriptor->controller?->getShortName() ?? '(unknown)',
@@ -84,21 +88,6 @@ final readonly class MultipartFileWithoutMultipart implements Rule, OperationRul
         return $dataClass !== null && $this->schemaBuilder->hasFileProperties($dataClass);
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'multipart.file-without-multipart';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Degraded;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'Data class carries a file property but a #[RequestBody] override forces a non-multipart body — the spec contradicts the code.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/DocumentAnnotationMigration.php
+++ b/src/Plugins/SwaggerPhp/Lint/DocumentAnnotationMigration.php
@@ -35,6 +35,10 @@ use function sprintf;
  */
 final class DocumentAnnotationMigration implements Rule, ApiRule, NeedsInferenceDocument
 {
+    public string $id = 'migration.document-annotation-in-config';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A document-level @OA\\Info / Server / SecurityScheme / root Tag annotation whose metadata belongs in config/openapi.php.';
+
     private readonly ConfigSnippetRenderer $renderer;
 
     public function __construct(
@@ -91,8 +95,8 @@ final class DocumentAnnotationMigration implements Rule, ApiRule, NeedsInference
     private function finding(string $what, string $configKey, string $snippet, OA\AbstractAnnotation $annotation): Finding
     {
         return new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 '%s declares document-level metadata that belongs in the `%s` config key.',
                 $what,
@@ -103,17 +107,7 @@ final class DocumentAnnotationMigration implements Rule, ApiRule, NeedsInference
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'migration.document-annotation-in-config';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     /**
      * @return list<class-string<SpecStage>>
@@ -124,9 +118,4 @@ final class DocumentAnnotationMigration implements Rule, ApiRule, NeedsInference
         return [HarvestAuthoredAnnotationsStage::class];
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A document-level @OA\\Info / Server / SecurityScheme / root Tag annotation whose metadata belongs in config/openapi.php.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantComponentWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantComponentWithInference.php
@@ -50,6 +50,10 @@ use function sprintf;
  */
 final class OaRedundantComponentWithInference implements Rule, ApiRule, FixableRule, NeedsInferenceDocument
 {
+    public string $id = 'migration.oa-redundant-component-with-inference';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A hand-authored reusable @OA\Response / @OA\Parameter component definition the generator already reproduces via inference.';
+
     public function __construct(
         private readonly AuthoredAnnotationScanner $scanner,
     ) {}
@@ -182,8 +186,8 @@ final class OaRedundantComponentWithInference implements Rule, ApiRule, FixableR
         $kind = $type === ComponentType::Responses ? '@OA\Response' : '@OA\Parameter';
 
         return new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'The reusable %s component "%s" on %s restates a %s the generator already infers; it can be removed.',
                 $kind,
@@ -201,17 +205,7 @@ final class OaRedundantComponentWithInference implements Rule, ApiRule, FixableR
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'migration.oa-redundant-component-with-inference';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -228,9 +222,4 @@ final class OaRedundantComponentWithInference implements Rule, ApiRule, FixableR
         return [HarvestAuthoredAnnotationsStage::class];
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A hand-authored reusable @OA\Response / @OA\Parameter component definition the generator already reproduces via inference.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantOperationWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantOperationWithInference.php
@@ -45,12 +45,12 @@ final class OaRedundantOperationWithInference implements Rule, OperationRule, Fi
     public Severity $severity = Severity::Improvable;
     public string $description = 'A hand-authored @OA / #[OA\*] operation annotation the generator already reproduces via inference.';
 
-    private OaRedundancyEngine $engine;
+    private readonly OaRedundancyEngine $engine;
 
-    private OperationSubsumption $comparator;
+    private readonly OperationSubsumption $comparator;
 
     public function __construct(
-        private AuthoredAnnotationScanner $scanner,
+        private readonly AuthoredAnnotationScanner $scanner,
         SchemaEquivalence $equivalence,
     ) {
         $this->engine = new OaRedundancyEngine();

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantOperationWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantOperationWithInference.php
@@ -39,8 +39,12 @@ use function sprintf;
  *
  * @internal
  */
-final readonly class OaRedundantOperationWithInference implements Rule, OperationRule, FixableRule, NeedsInferenceDocument
+final class OaRedundantOperationWithInference implements Rule, OperationRule, FixableRule, NeedsInferenceDocument
 {
+    public string $id = 'migration.oa-redundant-operation-with-inference';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A hand-authored @OA / #[OA\*] operation annotation the generator already reproduces via inference.';
+
     private OaRedundancyEngine $engine;
 
     private OperationSubsumption $comparator;
@@ -85,8 +89,8 @@ final readonly class OaRedundantOperationWithInference implements Rule, Operatio
             $this->comparator,
             fn(): ReflectionMethod => new ReflectionMethod($controller, $method),
             fn(AuthoredAnnotationShape $shape): Finding => new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'The %s on %s::%s restates an operation the generator already infers; it can be removed.',
                     $shape === AuthoredAnnotationShape::Docblock
@@ -110,17 +114,7 @@ final readonly class OaRedundantOperationWithInference implements Rule, Operatio
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'migration.oa-redundant-operation-with-inference';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -139,9 +133,4 @@ final readonly class OaRedundantOperationWithInference implements Rule, Operatio
         return [HarvestAuthoredAnnotationsStage::class];
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A hand-authored @OA / #[OA\*] operation annotation the generator already reproduces via inference.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantPropertyWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantPropertyWithInference.php
@@ -48,9 +48,12 @@ use function sprintf;
  *
  * @internal
  */
-final readonly class OaRedundantPropertyWithInference implements Rule, ComponentSchemaRule, FixableRule, NeedsInferenceDocument
+final class OaRedundantPropertyWithInference implements Rule, ComponentSchemaRule, FixableRule, NeedsInferenceDocument
 {
     use DetectsPropertyShape;
+    public string $id = 'migration.oa-redundant-property-with-inference';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A hand-authored member OA\Property on a Spatie Data class the generator already infers.';
 
     public function __construct(
         private AuthoredAnnotationScanner $scanner,
@@ -141,8 +144,8 @@ final readonly class OaRedundantPropertyWithInference implements Rule, Component
     private function finding(string $class, string $propertyName, AuthoredAnnotationShape $shape): Finding
     {
         return new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: sprintf(
                 'The %s on %s::$%s restates a property the generator already infers; it can be removed.',
                 $shape === AuthoredAnnotationShape::Docblock ? '@OA\Property docblock' : '#[OA\Property] attribute',
@@ -158,17 +161,7 @@ final readonly class OaRedundantPropertyWithInference implements Rule, Component
         );
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'migration.oa-redundant-property-with-inference';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -185,9 +178,4 @@ final readonly class OaRedundantPropertyWithInference implements Rule, Component
         return [HarvestAuthoredAnnotationsStage::class];
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A hand-authored member OA\Property on a Spatie Data class the generator already infers.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantPropertyWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantPropertyWithInference.php
@@ -56,7 +56,7 @@ final class OaRedundantPropertyWithInference implements Rule, ComponentSchemaRul
     public string $description = 'A hand-authored member OA\Property on a Spatie Data class the generator already infers.';
 
     public function __construct(
-        private AuthoredAnnotationScanner $scanner,
+        private readonly AuthoredAnnotationScanner $scanner,
     ) {}
 
     /**

--- a/src/Plugins/SwaggerPhp/Lint/OaRedundantWithInference.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaRedundantWithInference.php
@@ -42,6 +42,10 @@ use function sprintf;
  */
 final class OaRedundantWithInference implements Rule, ComponentSchemaRule, FixableRule, NeedsInferenceDocument
 {
+    public string $id = 'migration.oa-redundant-with-inference';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A hand-authored #[OA\Schema] / @OA\Schema annotation the generator already reproduces via inference.';
+
     private readonly OaRedundancyEngine $engine;
 
     public function __construct(
@@ -89,8 +93,8 @@ final class OaRedundantWithInference implements Rule, ComponentSchemaRule, Fixab
             $comparator,
             fn(): ReflectionClass => new ReflectionClass($class),
             fn(AuthoredAnnotationShape $shape): Finding => new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: sprintf(
                     'The %s annotation on %s restates a schema the generator already infers; it can be removed.',
                     $shape === AuthoredAnnotationShape::Docblock ? '@OA\Schema docblock' : '#[OA\Schema] attribute',
@@ -110,17 +114,7 @@ final class OaRedundantWithInference implements Rule, ComponentSchemaRule, Fixab
         }
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'migration.oa-redundant-with-inference';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -137,9 +131,4 @@ final class OaRedundantWithInference implements Rule, ComponentSchemaRule, Fixab
         return [HarvestAuthoredAnnotationsStage::class];
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A hand-authored #[OA\Schema] / @OA\Schema annotation the generator already reproduces via inference.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
@@ -74,7 +74,7 @@ final class OaReplaceableByAttribute implements Rule, ComponentSchemaRule, Opera
         private readonly AuthoredAnnotationScanner $scanner,
         private readonly SchemaEquivalence $equivalence,
         private readonly LoggerInterface $logger,
-        private OaAttributeArgumentMapper $mapper = new OaAttributeArgumentMapper(),
+        private readonly OaAttributeArgumentMapper $mapper = new OaAttributeArgumentMapper(),
     ) {}
 
     /**

--- a/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
@@ -71,10 +71,10 @@ final class OaReplaceableByAttribute implements Rule, ComponentSchemaRule, Opera
     public const string CONTEXT_ATTRIBUTE_ARGUMENTS = 'attributeArguments';
 
     public function __construct(
-        private AuthoredAnnotationScanner $scanner,
-        private SchemaEquivalence $equivalence,
-        private LoggerInterface $logger,
-        private OaAttributeArgumentMapper $mapper = new OaAttributeArgumentMapper(),
+        private readonly AuthoredAnnotationScanner $scanner,
+        private readonly SchemaEquivalence $equivalence,
+        private readonly LoggerInterface $logger,
+        private readonly OaAttributeArgumentMapper $mapper = new OaAttributeArgumentMapper(),
     ) {}
 
     /**

--- a/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
@@ -74,7 +74,7 @@ final class OaReplaceableByAttribute implements Rule, ComponentSchemaRule, Opera
         private readonly AuthoredAnnotationScanner $scanner,
         private readonly SchemaEquivalence $equivalence,
         private readonly LoggerInterface $logger,
-        private readonly OaAttributeArgumentMapper $mapper = new OaAttributeArgumentMapper(),
+        private OaAttributeArgumentMapper $mapper = new OaAttributeArgumentMapper(),
     ) {}
 
     /**

--- a/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
+++ b/src/Plugins/SwaggerPhp/Lint/OaReplaceableByAttribute.php
@@ -57,9 +57,12 @@ use function substr;
  *
  * @internal
  */
-final readonly class OaReplaceableByAttribute implements Rule, ComponentSchemaRule, OperationRule, FixableRule
+final class OaReplaceableByAttribute implements Rule, ComponentSchemaRule, OperationRule, FixableRule
 {
     use DetectsPropertyShape;
+    public string $id = 'migration.oa-replaceable-by-attribute';
+    public Severity $severity = Severity::Improvable;
+    public string $description = 'A hand-authored OA\Property / query OA\Parameter an authoring attribute expresses more concisely.';
 
     /** Finding-context key carrying the target attribute class-string. */
     public const string CONTEXT_TARGET_ATTRIBUTE = 'targetAttribute';
@@ -290,8 +293,8 @@ final readonly class OaReplaceableByAttribute implements Rule, ComponentSchemaRu
         array $arguments,
     ): Finding {
         return new Finding(
-            ruleId: $this->id(),
-            severity: $this->severity(),
+            ruleId: $this->id,
+            severity: $this->severity,
             message: $message,
             fixHint: sprintf('Rewrite the swagger-php annotation as #[%s].', $this->shortName($attribute)),
             context: [
@@ -326,17 +329,7 @@ final readonly class OaReplaceableByAttribute implements Rule, ComponentSchemaRu
         return $position === false ? $class : substr($class, $position + 1);
     }
 
-    #[Override]
-    public function id(): string
-    {
-        return 'migration.oa-replaceable-by-attribute';
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return Severity::Improvable;
-    }
 
     #[Override]
     public function fixer(): Fixer
@@ -344,9 +337,4 @@ final readonly class OaReplaceableByAttribute implements Rule, ComponentSchemaRu
         return new OaReplaceableByAttributeFixer();
     }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A hand-authored OA\Property / query OA\Parameter an authoring attribute expresses more concisely.';
-    }
 }

--- a/src/Plugins/SwaggerPhp/Lint/SchemaNameCollision.php
+++ b/src/Plugins/SwaggerPhp/Lint/SchemaNameCollision.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Plugins\SwaggerPhp\Lint;
 
-use Override;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Plugins\SwaggerPhp\Stages\HarvestAuthoredAnnotationsStage;
@@ -19,6 +18,10 @@ use Radiergummi\OpenApi\Plugins\SwaggerPhp\Stages\HarvestAuthoredAnnotationsStag
  */
 final class SchemaNameCollision implements Rule
 {
+    public string $id = self::ID;
+    public Severity $severity = self::SEVERITY;
+    public string $description = 'A hand-authored @OA\Schema collides with a convention-derived component of the same name; the authored definition was dropped and that name resolves to the convention schema.';
+
     public const string ID = 'component.schema-name-collision';
 
     public const Severity SEVERITY = Severity::Degraded;
@@ -28,21 +31,6 @@ final class SchemaNameCollision implements Rule
 
     public const string FIX_HINT = 'A hand-authored @OA\Schema is named the same as a component the generator already derives from your code, so the authored definition was dropped and references to that name resolve to the convention schema. Rename the authored schema (e.g., @OA\Schema(schema="...")), or remove it once inference covers it.';
 
-    #[Override]
-    public function id(): string
-    {
-        return self::ID;
-    }
 
-    #[Override]
-    public function severity(): Severity
-    {
-        return self::SEVERITY;
-    }
 
-    #[Override]
-    public function description(): string
-    {
-        return 'A hand-authored @OA\Schema collides with a convention-derived component of the same name; the authored definition was dropped and that name resolves to the convention schema.';
-    }
 }

--- a/tests/Feature/Lint/FixRunnerPartitionTest.php
+++ b/tests/Feature/Lint/FixRunnerPartitionTest.php
@@ -33,23 +33,14 @@ function bindSyntheticDestructiveRule(): void
     $rule = new class () implements FixableRule, OperationRule {
         public function checkOperation(OperationNode $operation, LintContext $context): iterable
         {
-            yield new Finding(ruleId: $this->id(), severity: Severity::Degraded, message: 'synthetic');
+            yield new Finding(ruleId: $this->id, severity: Severity::Degraded, message: 'synthetic');
         }
 
-        public function id(): string
-        {
-            return 'synthetic.destructive';
-        }
+        public string $id = 'synthetic.destructive';
 
-        public function severity(): Severity
-        {
-            return Severity::Degraded;
-        }
+        public Severity $severity = Severity::Degraded;
 
-        public function description(): string
-        {
-            return 'synthetic destructive rule';
-        }
+        public string $description = 'synthetic destructive rule';
 
         public function fixer(): Fixer
         {

--- a/tests/Feature/Lint/RuleCatalogCoverageTest.php
+++ b/tests/Feature/Lint/RuleCatalogCoverageTest.php
@@ -16,10 +16,10 @@ it('gives every registered rule a non-empty description and a valid severity', f
 
     foreach ($registry->all() as $rule) {
         expect($rule)->toBeInstanceOf(Rule::class);
-        expect($rule->severity())->toBeInstanceOf(Severity::class);
-        expect(trim($rule->description()))->not->toBe('');
-        expect($seenIds)->not->toContain($rule->id());
+        expect($rule->severity)->toBeInstanceOf(Severity::class);
+        expect(trim($rule->description))->not->toBe('');
+        expect($seenIds)->not->toContain($rule->id);
 
-        $seenIds[] = $rule->id();
+        $seenIds[] = $rule->id;
     }
 })->group('openapi', 'lint');

--- a/tests/Feature/SwaggerPhpComponentMigrationRuleTest.php
+++ b/tests/Feature/SwaggerPhpComponentMigrationRuleTest.php
@@ -211,5 +211,5 @@ it('exposes its fixer and human-readable description', function (): void {
 
     expect($rule->fixer())
         ->toBeInstanceOf(RedundantOaAnnotationFixer::class)
-        ->and($rule->description())->toContain('inference');
+        ->and($rule->description)->toContain('inference');
 });

--- a/tests/Feature/SwaggerPhpMigrationRuleTest.php
+++ b/tests/Feature/SwaggerPhpMigrationRuleTest.php
@@ -241,5 +241,5 @@ it('exposes its fixer and human-readable description', function (): void {
 
     expect($rule->fixer())
         ->toBeInstanceOf(RedundantOaAnnotationFixer::class)
-        ->and($rule->description())->toContain('inference');
+        ->and($rule->description)->toContain('inference');
 });

--- a/tests/Feature/SwaggerPhpOperationMigrationRuleTest.php
+++ b/tests/Feature/SwaggerPhpOperationMigrationRuleTest.php
@@ -142,5 +142,5 @@ it('exposes its fixer and human-readable description', function (): void {
 
     expect($rule->fixer())
         ->toBeInstanceOf(RedundantOaAnnotationFixer::class)
-        ->and($rule->description())->toContain('inference');
+        ->and($rule->description)->toContain('inference');
 });

--- a/tests/Feature/SwaggerPhpRedundantPropertyRuleTest.php
+++ b/tests/Feature/SwaggerPhpRedundantPropertyRuleTest.php
@@ -184,5 +184,5 @@ it('exposes its fixer and human-readable description', function (): void {
 
     expect($rule->fixer())
         ->toBeInstanceOf(RedundantOaPropertyFixer::class)
-        ->and($rule->description())->toContain('OA\Property');
+        ->and($rule->description)->toContain('OA\Property');
 });

--- a/tests/Feature/SwaggerPhpReplaceableRuleTest.php
+++ b/tests/Feature/SwaggerPhpReplaceableRuleTest.php
@@ -235,5 +235,5 @@ it('exposes its fixer and human-readable description', function (): void {
 
     expect($rule->fixer())
         ->toBeInstanceOf(OaReplaceableByAttributeFixer::class)
-        ->and($rule->description())->toContain('attribute');
+        ->and($rule->description)->toContain('attribute');
 });

--- a/tests/Support/AttributeFixFixture.php
+++ b/tests/Support/AttributeFixFixture.php
@@ -61,8 +61,8 @@ final class AttributeFixFixture
         }
 
         $finding = new Finding(
-            ruleId: $rule->id(),
-            severity: $rule->severity(),
+            ruleId: $rule->id,
+            severity: $rule->severity,
             message: 'fixture',
             location: new FindingLocation(file: $sourceFile),
             context: $context,

--- a/tests/Unit/Lint/Fix/AddOperationIdFixerTest.php
+++ b/tests/Unit/Lint/Fix/AddOperationIdFixerTest.php
@@ -48,7 +48,7 @@ it('adds the operationId argument to an existing #[Operation] without duplicatin
 it('yields nothing when the stamped operationId is absent (degrade)', function (): void {
     $finding = new Finding(
         ruleId: 'operation.id-missing',
-        severity: (new OperationIdMissing())->severity(),
+        severity: (new OperationIdMissing())->severity,
         message: 'fixture',
         context: [
             Finding::CONTEXT_SOURCE_CLASS => MissingOperationIdFixtureController::class,
@@ -64,7 +64,7 @@ it('yields nothing when the stamped operationId is absent (degrade)', function (
 it('yields nothing when the source member is unknown (degrade)', function (): void {
     $finding = new Finding(
         ruleId: 'operation.id-missing',
-        severity: (new OperationIdMissing())->severity(),
+        severity: (new OperationIdMissing())->severity,
         message: 'fixture',
         context: [AddOperationIdFixer::CONTEXT_OPERATION_ID => 'users.index'],
     );
@@ -94,7 +94,7 @@ function operationIdMissingFinding(string $member, string $operationId): Finding
 {
     return new Finding(
         ruleId: 'operation.id-missing',
-        severity: (new OperationIdMissing())->severity(),
+        severity: (new OperationIdMissing())->severity,
         message: 'fixture',
         context: [
             Finding::CONTEXT_SOURCE_CLASS => MissingOperationIdFixtureController::class,

--- a/tests/Unit/Lint/Fix/SanitizeOperationIdFixerTest.php
+++ b/tests/Unit/Lint/Fix/SanitizeOperationIdFixerTest.php
@@ -41,7 +41,7 @@ it('rewrites a leading-digit operationId to a letter-prefixed form', function ()
 it('yields nothing when the stamped sanitised value is absent (degrade)', function (): void {
     $finding = new Finding(
         ruleId: 'operation.id-invalid-chars',
-        severity: (new OperationIdInvalidChars())->severity(),
+        severity: (new OperationIdInvalidChars())->severity,
         message: 'fixture',
         context: [
             Finding::CONTEXT_SOURCE_CLASS => InvalidOperationIdFixtureController::class,
@@ -57,7 +57,7 @@ it('yields nothing when the stamped sanitised value is absent (degrade)', functi
 it('yields nothing when the method carries no #[Operation] attribute (degrade)', function (): void {
     $finding = new Finding(
         ruleId: 'operation.id-invalid-chars',
-        severity: (new OperationIdInvalidChars())->severity(),
+        severity: (new OperationIdInvalidChars())->severity,
         message: 'fixture',
         context: [
             Finding::CONTEXT_SOURCE_CLASS => Radiergummi\OpenApi\Tests\Fixtures\Lint\Fix\DuplicateTagFixtureController::class,

--- a/tests/Unit/Lint/RuleRegistryTest.php
+++ b/tests/Unit/Lint/RuleRegistryTest.php
@@ -7,23 +7,14 @@ use Radiergummi\OpenApi\Contracts\Lint\Severity;
 use Radiergummi\OpenApi\Lint\RuleRegistry;
 
 /** Builds a minimal {@see Rule} stub with the given id and severity. */
-$rule = static fn(string $id, Severity $severity): Rule => new readonly class ($id, $severity) implements Rule {
-    public function __construct(private string $ruleId, private Severity $ruleSeverity) {}
+$rule = static fn(string $id, Severity $severity): Rule => new class ($id, $severity) implements Rule {
+    public string $id { get => $this->ruleId; }
 
-    public function id(): string
-    {
-        return $this->ruleId;
-    }
+    public Severity $severity { get => $this->ruleSeverity; }
 
-    public function severity(): Severity
-    {
-        return $this->ruleSeverity;
-    }
+    public string $description = 'stub';
 
-    public function description(): string
-    {
-        return 'stub';
-    }
+    public function __construct(private readonly string $ruleId, private readonly Severity $ruleSeverity) {}
 };
 
 // The registry performs no duplicate-id detection; these tests pin the current observed

--- a/tests/Unit/Lint/Rules/ActionMissingReturnTypeTest.php
+++ b/tests/Unit/Lint/Rules/ActionMissingReturnTypeTest.php
@@ -23,9 +23,9 @@ function returnTypeNudgeFindings(string $method): array
 it('reports its id and level', function (): void {
     $rule = new ActionMissingReturnType();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('operation.return-type-missing')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when the action has no return type and no response attribute', function (): void {

--- a/tests/Unit/Lint/Rules/ComponentNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/ComponentNameNamingInconsistentTest.php
@@ -12,8 +12,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new ComponentNameNamingInconsistent();
 
-    expect($rule->id())->toBe('component.name-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('component.name-naming-inconsistent')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('pascal (default): flags non-PascalCase component names', function (string $name, string $expectedCaseLabel): void {

--- a/tests/Unit/Lint/Rules/ComponentOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/ComponentOrphanedTest.php
@@ -90,9 +90,9 @@ function componentOrphanedFindings(array $schemas, array $refsUsed): array
 it('has the correct rule id and level', function (): void {
     $rule = new ComponentOrphaned();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('component.orphaned')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding for an unreferenced schema', function (): void {

--- a/tests/Unit/Lint/Rules/DeprecatedAttributeTest.php
+++ b/tests/Unit/Lint/Rules/DeprecatedAttributeTest.php
@@ -26,8 +26,8 @@ function deprecatedAttributeFindings(string $controller, string $method): array
 it('has the correct rule id and level', function (): void {
     $rule = new DeprecatedAttribute(DEPRECATED_ATTR_NAMESPACE);
 
-    expect($rule->id())->toBe('deprecated.attribute')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('deprecated.attribute')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when a method uses a deprecated OpenAPI attribute', function (): void {

--- a/tests/Unit/Lint/Rules/DeprecatedNoReplacementTest.php
+++ b/tests/Unit/Lint/Rules/DeprecatedNoReplacementTest.php
@@ -13,9 +13,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new DeprecatedNoReplacement();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('deprecated.no-replacement')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding for deprecated operations missing replacement guidance', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/DeprecatedNoSunsetDateTest.php
+++ b/tests/Unit/Lint/Rules/DeprecatedNoSunsetDateTest.php
@@ -13,8 +13,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new DeprecatedNoSunsetDate();
 
-    expect($rule->id())->toBe('deprecated.no-sunset-date')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+    expect($rule->id)->toBe('deprecated.no-sunset-date')
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding when a deprecated operation has no concrete sunset date', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/DiscriminatorInvalidMappingTest.php
+++ b/tests/Unit/Lint/Rules/DiscriminatorInvalidMappingTest.php
@@ -80,8 +80,8 @@ function discriminatorInvalidMappingFindings(string $propertyName, array $mappin
 it('reports its id and level', function (): void {
     $rule = new DiscriminatorInvalidMapping();
 
-    expect($rule->id())->toBe('discriminator.invalid-mapping')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('discriminator.invalid-mapping')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all mapped schemas declare the discriminator property', function (): void {

--- a/tests/Unit/Lint/Rules/EnumValuesUndocumentedTest.php
+++ b/tests/Unit/Lint/Rules/EnumValuesUndocumentedTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new EnumValuesUndocumented();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('enum.values-undocumented')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when an enum field has no description', function (): void {

--- a/tests/Unit/Lint/Rules/ErrorsResolverFailedTest.php
+++ b/tests/Unit/Lint/Rules/ErrorsResolverFailedTest.php
@@ -13,15 +13,15 @@ uses()->group('openapi', 'lint');
 // the stub's registration contract so its identity stays stable.
 
 it('exposes the stable rule id', function (): void {
-    expect(new ErrorsResolverFailed()->id())->toBe('errors.resolver-failed');
+    expect(new ErrorsResolverFailed()->id)->toBe('errors.resolver-failed');
 });
 
 it('reports a warning-level severity', function (): void {
-    expect(new ErrorsResolverFailed()->severity())->toBe(Severity::Underspecified);
+    expect(new ErrorsResolverFailed()->severity)->toBe(Severity::Underspecified);
 });
 
 it('provides a non-empty description', function (): void {
-    expect(new ErrorsResolverFailed()->description())->not->toBe('');
+    expect(new ErrorsResolverFailed()->description)->not->toBe('');
 });
 
 it('exposes an actionable fix hint pointing at the resolver', function (): void {

--- a/tests/Unit/Lint/Rules/ExternaldocsInvalidUrlTest.php
+++ b/tests/Unit/Lint/Rules/ExternaldocsInvalidUrlTest.php
@@ -23,8 +23,8 @@ function externaldocsFindings(string $method): array
 it('has the correct rule id and level', function (): void {
     $rule = new ExternaldocsInvalidUrl();
 
-    expect($rule->id())->toBe('externaldocs.invalid-url')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('externaldocs.invalid-url')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding for an invalid URL', function (): void {

--- a/tests/Unit/Lint/Rules/FieldConflictingTypeTest.php
+++ b/tests/Unit/Lint/Rules/FieldConflictingTypeTest.php
@@ -23,9 +23,9 @@ function makeDirectScannerForConflictingType(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldConflictingType(makeDirectScannerForConflictingType());
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('field.conflicting-type')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when RequestField type contradicts the PHP type', function (): void {

--- a/tests/Unit/Lint/Rules/FieldDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/FieldDescriptionMissingTest.php
@@ -30,8 +30,8 @@ function makeFieldForDescription(?string $description, ?array $enum = null): Fie
 it('has the correct rule id and level', function (): void {
     $rule = new FieldDescriptionMissing();
 
-    expect($rule->id())->toBe('field.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('field.description-missing')
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a field has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/FieldEnumMismatchTest.php
+++ b/tests/Unit/Lint/Rules/FieldEnumMismatchTest.php
@@ -23,9 +23,9 @@ function makeDirectScannerForEnumMismatch(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldEnumMismatch(makeDirectScannerForEnumMismatch());
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('field.enum-mismatch')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding when RequestField enum values do not match BackedEnum cases', function (): void {

--- a/tests/Unit/Lint/Rules/FieldInvalidFormatTest.php
+++ b/tests/Unit/Lint/Rules/FieldInvalidFormatTest.php
@@ -23,9 +23,9 @@ function makeDirectScannerForInvalidFormat(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldInvalidFormat(makeDirectScannerForInvalidFormat());
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('field.invalid-format')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when RequestField declares an unrecognized format', function (): void {

--- a/tests/Unit/Lint/Rules/FieldNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/FieldNameNamingInconsistentTest.php
@@ -33,8 +33,8 @@ function makeFieldNamingNode(string $name): FieldNode
 it('reports its id and level', function (): void {
     $rule = new FieldNameNamingInconsistent();
 
-    expect($rule->id())->toBe('field.name-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('field.name-naming-inconsistent')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('default (camel): passes a valid camelCase field name', function (string $name): void {

--- a/tests/Unit/Lint/Rules/FieldNoEffectTest.php
+++ b/tests/Unit/Lint/Rules/FieldNoEffectTest.php
@@ -22,9 +22,9 @@ function makeDirectScannerForNoEffect(): PayloadParameterScanner
 it('reports its id and level', function (): void {
     $rule = new FieldNoEffect(makeDirectScannerForNoEffect());
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('field.no-effect')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when RequestField has all default values', function (): void {

--- a/tests/Unit/Lint/Rules/HeaderDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/HeaderDescriptionMissingTest.php
@@ -28,7 +28,7 @@ function makeHeaderUnderResponse(string $name, ?string $description): HeaderNode
 it('has the correct rule id and level', function (): void {
     $rule = new HeaderDescriptionMissing();
 
-    expect($rule->id())->toBe('header.description-missing')->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('header.description-missing')->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a response header has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/HeaderInvalidNameTest.php
+++ b/tests/Unit/Lint/Rules/HeaderInvalidNameTest.php
@@ -21,7 +21,7 @@ function makeOperationNodeForHeaderInvalidName(string $methodName): OperationNod
 it('has the correct rule id and level', function (): void {
     $rule = new HeaderInvalidName();
 
-    expect($rule->id())->toBe('header.invalid-name')->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('header.invalid-name')->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits no findings for valid header names', function (): void {

--- a/tests/Unit/Lint/Rules/HeaderNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/HeaderNameNamingInconsistentTest.php
@@ -24,8 +24,8 @@ function makeHeaderNamingNode(string $name): HeaderNode
 it('reports its id and level', function (): void {
     $rule = new HeaderNameNamingInconsistent();
 
-    expect($rule->id())->toBe('header.name-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('header.name-naming-inconsistent')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('default (train): passes a valid Train-Case header name', function (string $name): void {

--- a/tests/Unit/Lint/Rules/HideExposeConflictTest.php
+++ b/tests/Unit/Lint/Rules/HideExposeConflictTest.php
@@ -23,9 +23,9 @@ function hideExposeConflictFindings(string $method): array
 it('has the correct rule id and level', function (): void {
     $rule = new HideExposeConflict();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('visibility.hide-expose-conflict')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when #[Hide] and #[Expose] both apply unconditionally', function (): void {

--- a/tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php
@@ -51,8 +51,8 @@ function makeInfoContext(?string $infoDescription): LintContext
 it('has the correct rule id and level', function (): void {
     $rule = new InfoDescriptionMissing();
 
-    expect($rule->id())->toBe('info.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('info.description-missing')
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when info.description is missing or blank', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/InfoMetadataIncompleteTest.php
+++ b/tests/Unit/Lint/Rules/InfoMetadataIncompleteTest.php
@@ -50,9 +50,9 @@ function infoMetadataIncompleteFindings(bool $withContact, bool $withLicense, bo
 it('has the correct rule id and level', function (): void {
     $rule = new InfoMetadataIncomplete();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('info.metadata-incomplete')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding when both contact and license are absent', function (): void {

--- a/tests/Unit/Lint/Rules/LinkBothOperationIdAndRefTest.php
+++ b/tests/Unit/Lint/Rules/LinkBothOperationIdAndRefTest.php
@@ -27,7 +27,7 @@ function makeLinkBothFieldsNode(?string $operationId, ?string $operationRef): Li
 it('reports its id and level', function (): void {
     $rule = new LinkBothOperationIdAndRef();
 
-    expect($rule->id())->toBe('link.both-operation-id-and-ref')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('link.both-operation-id-and-ref')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/LinkDuplicateNameTest.php
+++ b/tests/Unit/Lint/Rules/LinkDuplicateNameTest.php
@@ -25,7 +25,7 @@ function makeLinkDuplicateNameOperation(string $method): OperationNode
 it('reports its id and level', function (): void {
     $rule = new LinkDuplicateName();
 
-    expect($rule->id())->toBe('link.duplicate-name')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('link.duplicate-name')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding when a method has duplicate link names', function (): void {

--- a/tests/Unit/Lint/Rules/LinkInvalidOperationTest.php
+++ b/tests/Unit/Lint/Rules/LinkInvalidOperationTest.php
@@ -24,7 +24,7 @@ function makeLinkInvalidOperationNode(?string $operationId): LinkNode
 it('reports its id and level', function (): void {
     $rule = new LinkInvalidOperation();
 
-    expect($rule->id())->toBe('link.invalid-operation')->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('link.invalid-operation')->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits no finding when all Link operationIds resolve', function (): void {

--- a/tests/Unit/Lint/Rules/LinkInvalidParameterTest.php
+++ b/tests/Unit/Lint/Rules/LinkInvalidParameterTest.php
@@ -63,7 +63,7 @@ function makeLinkInvalidParamContext(
 it('reports its id and level', function (): void {
     $rule = new LinkInvalidParameter();
 
-    expect($rule->id())->toBe('link.invalid-parameter')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('link.invalid-parameter')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/LinkNeitherOperationIdNorRefTest.php
+++ b/tests/Unit/Lint/Rules/LinkNeitherOperationIdNorRefTest.php
@@ -27,7 +27,7 @@ function makeLinkNeitherFieldNode(?string $operationId, ?string $operationRef): 
 it('reports its id and level', function (): void {
     $rule = new LinkNeitherOperationIdNorRef();
 
-    expect($rule->id())->toBe('link.neither-operation-id-nor-ref')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('link.neither-operation-id-nor-ref')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/LinkParameterRequiredMissingTest.php
+++ b/tests/Unit/Lint/Rules/LinkParameterRequiredMissingTest.php
@@ -67,9 +67,9 @@ function makeLinkRequiredMissingContext(
 it('reports its id and level', function (): void {
     $rule = new LinkParameterRequiredMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('link.parameter-required-missing')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all required parameters are supplied', function (): void {

--- a/tests/Unit/Lint/Rules/MetaSuppressionStaleTest.php
+++ b/tests/Unit/Lint/Rules/MetaSuppressionStaleTest.php
@@ -51,9 +51,9 @@ function staleDirective(
 it('reports its id and level', function (): void {
     $rule = new MetaSuppressionStale();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('meta.suppression-stale')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when a suppression did not match any finding', function (): void {

--- a/tests/Unit/Lint/Rules/MetaTooManySuppressionsTest.php
+++ b/tests/Unit/Lint/Rules/MetaTooManySuppressionsTest.php
@@ -51,9 +51,9 @@ function tooManyDirectives(int $count, string $file): array
 it('reports its id and level', function (): void {
     $rule = new MetaTooManySuppressions();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('meta.too-many-suppressions')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits no finding when suppressions are at or below the threshold', function (): void {

--- a/tests/Unit/Lint/Rules/OperationDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationDescriptionMissingTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new OperationDescriptionMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('operation.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when operation has a summary but no description', function (): void {

--- a/tests/Unit/Lint/Rules/OperationIdDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdDuplicateTest.php
@@ -12,9 +12,9 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new OperationIdDuplicate();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('operation.id-duplicate')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all operationIds are unique', function (): void {

--- a/tests/Unit/Lint/Rules/OperationIdInvalidCharsTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdInvalidCharsTest.php
@@ -15,8 +15,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new OperationIdInvalidChars();
 
-    expect($rule->id())->toBe('operation.id-invalid-chars')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('operation.id-invalid-chars')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding for an operationId that violates the charset', function (string $operationId, string $path): void {

--- a/tests/Unit/Lint/Rules/OperationIdMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdMissingTest.php
@@ -16,9 +16,9 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new OperationIdMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('operation.id-missing')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits no finding when the operation has an operationId', function (): void {

--- a/tests/Unit/Lint/Rules/OperationIdNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/OperationIdNamingInconsistentTest.php
@@ -12,8 +12,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new OperationIdNamingInconsistent();
 
-    expect($rule->id())->toBe('operation.id-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('operation.id-naming-inconsistent')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits no finding for a permitted dot-separated operationId', function (string $operationId, string $path): void {

--- a/tests/Unit/Lint/Rules/OperationSecurityMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationSecurityMissingTest.php
@@ -49,9 +49,9 @@ function operationSecurityFindings(
 it('reports its id and level', function (): void {
     $rule = new OperationSecurityMissing(app(RouteMiddlewareGatherer::class));
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('operation.security-missing')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when a route has auth middleware and no security is declared', function (): void {

--- a/tests/Unit/Lint/Rules/OperationSummaryEqualsDescriptionTest.php
+++ b/tests/Unit/Lint/Rules/OperationSummaryEqualsDescriptionTest.php
@@ -11,8 +11,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new OperationSummaryEqualsDescription();
 
-    expect($rule->id())->toBe('operation.summary-equals-description')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('operation.summary-equals-description')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when summary and description match (case-insensitive, trimmed)', function (string $summary, string $description): void {

--- a/tests/Unit/Lint/Rules/OperationTagMissingTest.php
+++ b/tests/Unit/Lint/Rules/OperationTagMissingTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new OperationTagMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('operation.tag-missing')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when an operation has no tags', function (): void {

--- a/tests/Unit/Lint/Rules/OverridesUnknownFieldTest.php
+++ b/tests/Unit/Lint/Rules/OverridesUnknownFieldTest.php
@@ -27,8 +27,8 @@ function overridesUnknownFieldCollect(array $overrides): array
 it('has the correct id and severity', function (): void {
     $rule = new OverridesUnknownField([]);
 
-    expect($rule->id())->toBe('overrides.unknown-field')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('overrides.unknown-field')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('stays silent for fully allowlisted blocks', function (): void {

--- a/tests/Unit/Lint/Rules/OverridesUnusedTest.php
+++ b/tests/Unit/Lint/Rules/OverridesUnusedTest.php
@@ -67,9 +67,9 @@ function overridesUnusedCollect(array $overrides, array $descriptors): array
 it('has the correct id and severity', function (): void {
     $rule = new OverridesUnused(new OverrideMatcher([]));
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('overrides.unused')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('stays silent when every key matches a route name or uri', function (): void {

--- a/tests/Unit/Lint/Rules/ParameterDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/ParameterDescriptionMissingTest.php
@@ -25,9 +25,9 @@ function makeParameterForDescription(?string $description): ParameterNode
 it('has the correct rule id and level', function (): void {
     $rule = new ParameterDescriptionMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('parameter.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a parameter has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/ParameterDuplicateNameTest.php
+++ b/tests/Unit/Lint/Rules/ParameterDuplicateNameTest.php
@@ -26,9 +26,9 @@ function makeOperationWithParameters(array $parameterNames): OperationNode
 it('reports its id and level', function (): void {
     $rule = new ParameterDuplicateName();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('parameter.duplicate-name')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all parameters are unique', function (): void {

--- a/tests/Unit/Lint/Rules/ParameterExampleConflictTest.php
+++ b/tests/Unit/Lint/Rules/ParameterExampleConflictTest.php
@@ -69,9 +69,9 @@ function oaExample(string $name = 'default', string $value = '123'): OA\Examples
 it('reports its id, level, and description', function (): void {
     $rule = new ParameterExampleConflict();
 
-    expect($rule->id())->toBe('parameter.example-conflict')
-        ->and($rule->severity())->toBe(Severity::Degraded)
-        ->and($rule->description())->toBe('A parameter sets both example and examples (mutually exclusive).');
+    expect($rule->id)->toBe('parameter.example-conflict')
+        ->and($rule->severity)->toBe(Severity::Degraded)
+        ->and($rule->description)->toBe('A parameter sets both example and examples (mutually exclusive).');
 });
 
 it('emits one finding when parameter has both example and examples set', function (): void {

--- a/tests/Unit/Lint/Rules/ParameterExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/ParameterExampleMissingTest.php
@@ -60,8 +60,8 @@ function makeUserIdParameterWithExamples(mixed $example, mixed $examples): Param
 it('has the correct rule id and level', function (): void {
     $rule = new ParameterExampleMissing();
 
-    expect($rule->id())->toBe('parameter.example-missing')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+    expect($rule->id)->toBe('parameter.example-missing')
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding when a parameter has neither example nor examples', function (): void {

--- a/tests/Unit/Lint/Rules/ParameterNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/ParameterNameNamingInconsistentTest.php
@@ -43,9 +43,9 @@ function makeQueryParamNamingNode(string $name): QueryParameterNode
 it('reports its id and level', function (): void {
     $rule = new ParameterNameNamingInconsistent();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('parameter.name-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 // region Path parameters

--- a/tests/Unit/Lint/Rules/ParameterPathMustBeRequiredTest.php
+++ b/tests/Unit/Lint/Rules/ParameterPathMustBeRequiredTest.php
@@ -28,9 +28,9 @@ function makePathParameter(string $name, bool $required): ParameterNode
 it('reports its id and level', function (): void {
     $rule = new ParameterPathMustBeRequired();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('parameter.path-must-be-required')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when a path parameter is required', function (): void {

--- a/tests/Unit/Lint/Rules/ParameterQueryArrayNoExplodeTest.php
+++ b/tests/Unit/Lint/Rules/ParameterQueryArrayNoExplodeTest.php
@@ -33,9 +33,9 @@ function makeQueryParamForArrayTest(
 it('reports its id and level', function (): void {
     $rule = new ParameterQueryArrayNoExplode();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('parameter.query-array-no-explode')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits no finding when an array query parameter declares serialization or is not an array', function (

--- a/tests/Unit/Lint/Rules/ParameterQueryNoSchemaTest.php
+++ b/tests/Unit/Lint/Rules/ParameterQueryNoSchemaTest.php
@@ -37,9 +37,9 @@ function makeQueryParamForSchemaTest(
 it('reports its id and level', function (): void {
     $rule = new ParameterQueryNoSchema();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('parameter.query-no-schema')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when a query parameter has a schema', function (

--- a/tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php
+++ b/tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php
@@ -12,7 +12,7 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new PathParameterUndeclared();
 
-    expect($rule->id())->toBe('path.parameter-undeclared')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('path.parameter-undeclared')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all placeholders are declared as path parameters', function (string $pathUri, array $names): void {

--- a/tests/Unit/Lint/Rules/PathParameterUndefinedTest.php
+++ b/tests/Unit/Lint/Rules/PathParameterUndefinedTest.php
@@ -12,7 +12,7 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new PathParameterUndefined();
 
-    expect($rule->id())->toBe('path.parameter-undefined')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('path.parameter-undefined')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all path parameters match placeholders', function (): void {

--- a/tests/Unit/Lint/Rules/PathSegmentNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/PathSegmentNamingInconsistentTest.php
@@ -12,8 +12,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new PathSegmentNamingInconsistent();
 
-    expect($rule->id())->toBe('path.segment-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('path.segment-naming-inconsistent')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('default (kebab): passes paths whose static segments are kebab-case', function (string $pathUri): void {

--- a/tests/Unit/Lint/Rules/PathTrailingSlashInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/PathTrailingSlashInconsistentTest.php
@@ -30,9 +30,9 @@ function trailingSlashContext(array $pathUris): LintContext
 it('reports its id and level', function (): void {
     $rule = new PathTrailingSlashInconsistent();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('path.trailing-slash-inconsistent')
-        ->and($rule->severity())
+        ->and($rule->severity)
         ->toBe(Severity::Inconsistent);
 });
 

--- a/tests/Unit/Lint/Rules/PublicEndpointContradictsMiddlewareTest.php
+++ b/tests/Unit/Lint/Rules/PublicEndpointContradictsMiddlewareTest.php
@@ -30,8 +30,8 @@ function publicEndpointFindings(string $controller, string $method, array $middl
 it('reports its id and level', function (): void {
     $rule = new PublicEndpointContradictsMiddleware(app(RouteMiddlewareGatherer::class));
 
-    expect($rule->id())->toBe('publicendpoint.contradicts-middleware')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('publicendpoint.contradicts-middleware')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when a method-level PublicEndpoint has auth middleware', function (): void {

--- a/tests/Unit/Lint/Rules/QueryParamDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/QueryParamDuplicateTest.php
@@ -25,8 +25,8 @@ function makeQueryParamDuplicateOperation(string $method): OperationNode
 it('has the correct rule id and level', function (): void {
     $rule = new QueryParamDuplicate();
 
-    expect($rule->id())->toBe('queryparam.duplicate')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('queryparam.duplicate')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when a method has duplicate query param names', function (): void {

--- a/tests/Unit/Lint/Rules/RefBrokenTest.php
+++ b/tests/Unit/Lint/Rules/RefBrokenTest.php
@@ -51,8 +51,8 @@ function specWithRef(string $ref, array $schemas): OA\OpenApi
 it('reports its id and level', function (): void {
     $rule = new RefBroken();
 
-    expect($rule->id())->toBe('ref.broken')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('ref.broken')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding when a ref points to a non-existent schema', function (): void {

--- a/tests/Unit/Lint/Rules/RequestBodyDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyDescriptionMissingTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new RequestBodyDescriptionMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('request-body.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a request body has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/RequestBodyExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyExampleMissingTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new RequestBodyExampleMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('request-body.example-missing')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding when a request body has no examples', function (): void {

--- a/tests/Unit/Lint/Rules/RequestBodyNoContentTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyNoContentTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('reports the correct id and level', function (): void {
     $rule = new RequestBodyNoContent();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('request-body.no-content')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when a request body has no media-type entries', function (): void {

--- a/tests/Unit/Lint/Rules/RequestBodyOnGetOrDeleteTest.php
+++ b/tests/Unit/Lint/Rules/RequestBodyOnGetOrDeleteTest.php
@@ -12,8 +12,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new RequestBodyOnGetOrDelete();
 
-    expect($rule->id())->toBe('request-body.on-get-or-delete')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('request-body.on-get-or-delete')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/RequestEmptyTest.php
+++ b/tests/Unit/Lint/Rules/RequestEmptyTest.php
@@ -12,15 +12,15 @@ uses()->group('openapi', 'lint');
 // the stub's registration contract so its identity stays stable.
 
 it('exposes the stable rule id', function (): void {
-    expect(new RequestEmpty()->id())->toBe('request.empty');
+    expect(new RequestEmpty()->id)->toBe('request.empty');
 });
 
 it('reports a warning-level severity', function (): void {
-    expect(new RequestEmpty()->severity())->toBe(Severity::Underspecified);
+    expect(new RequestEmpty()->severity)->toBe(Severity::Underspecified);
 });
 
 it('provides a non-empty description', function (): void {
-    expect(new RequestEmpty()->description())->not->toBe('');
+    expect(new RequestEmpty()->description)->not->toBe('');
 });
 
 it('exposes the request-body fix hint', function (): void {

--- a/tests/Unit/Lint/Rules/ResponseDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/ResponseDescriptionMissingTest.php
@@ -20,9 +20,9 @@ function makeResponseUnderOperation(?string $description): ResponseNode
 it('has the correct rule id and level', function (): void {
     $rule = new ResponseDescriptionMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('response.description-missing')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding when a response has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/ResponseDuplicateStatusTest.php
+++ b/tests/Unit/Lint/Rules/ResponseDuplicateStatusTest.php
@@ -11,8 +11,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new ResponseDuplicateStatus();
 
-    expect($rule->id())->toBe('response.duplicate-status')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('response.duplicate-status')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding when an operation has duplicate response status codes', function (): void {

--- a/tests/Unit/Lint/Rules/ResponseExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/ResponseExampleMissingTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new ResponseExampleMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('response.example-missing')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding when a response has no examples and has content', function (): void {

--- a/tests/Unit/Lint/Rules/ResponseNoErrorTest.php
+++ b/tests/Unit/Lint/Rules/ResponseNoErrorTest.php
@@ -13,8 +13,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new ResponseNoError();
 
-    expect($rule->id())->toBe('response.no-error')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('response.no-error')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/ResponseNoSuccessTest.php
+++ b/tests/Unit/Lint/Rules/ResponseNoSuccessTest.php
@@ -13,9 +13,9 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new ResponseNoSuccess();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('response.no-success')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/ResponseRedirectWithoutLocationTest.php
+++ b/tests/Unit/Lint/Rules/ResponseRedirectWithoutLocationTest.php
@@ -12,9 +12,9 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new ResponseRedirectWithoutLocation();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('response.redirect-without-location')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/ResponseRefUnresolvableTest.php
+++ b/tests/Unit/Lint/Rules/ResponseRefUnresolvableTest.php
@@ -93,8 +93,8 @@ function collectResponseRefUnresolvableFindings(array $resolvers, array $descrip
 it('has the correct id and level', function (): void {
     $rule = new ResponseRefUnresolvable([]);
 
-    expect($rule->id())->toBe('response.ref-unresolvable')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('response.ref-unresolvable')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no findings when the descriptors list is empty', function (): void {

--- a/tests/Unit/Lint/Rules/ResponseStatusUnconventionalTest.php
+++ b/tests/Unit/Lint/Rules/ResponseStatusUnconventionalTest.php
@@ -13,8 +13,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new ResponseStatusUnconventional();
 
-    expect($rule->id())->toBe('response.status-unconventional')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('response.status-unconventional')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it(

--- a/tests/Unit/Lint/Rules/ResponseSuccessEmptyBodyTest.php
+++ b/tests/Unit/Lint/Rules/ResponseSuccessEmptyBodyTest.php
@@ -12,8 +12,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new ResponseSuccessEmptyBody();
 
-    expect($rule->id())->toBe('response.success-empty-body')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('response.success-empty-body')
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding for a 200 response with no body schema', function (): void {

--- a/tests/Unit/Lint/Rules/SchemaAllofTypeConflictTest.php
+++ b/tests/Unit/Lint/Rules/SchemaAllofTypeConflictTest.php
@@ -45,8 +45,8 @@ function makeAllOfComponent(string $schemaName, array $types): ComponentSchemaNo
 it('reports its id and level', function (): void {
     $rule = new SchemaAllOfTypeConflict();
 
-    expect($rule->id())->toBe('schema.allof-type-conflict')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('schema.allof-type-conflict')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits no finding when allOf types do not conflict', function (string $label, array $types): void {

--- a/tests/Unit/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributesTest.php
+++ b/tests/Unit/Lint/Rules/SchemaClassAttributeConflictsWithFieldAttributesTest.php
@@ -30,9 +30,9 @@ function classAttributeConflictFindings(string $method): array
 it('reports its id and level 3', function (): void {
     $rule = classAttributeConflictRule();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.class-attribute-conflicts-with-field-attributes')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('flags a class carrying both #[RawSchema] and a field attribute', function (): void {

--- a/tests/Unit/Lint/Rules/SchemaConstraintsMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaConstraintsMissingTest.php
@@ -32,9 +32,9 @@ function makePropertyWithConstraints(string $propertyName, string $type, array $
 it('has the correct rule id and level', function (): void {
     $rule = new SchemaConstraintsMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.constraints-missing')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 // region FieldRule

--- a/tests/Unit/Lint/Rules/SchemaDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaDescriptionMissingTest.php
@@ -11,8 +11,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new SchemaDescriptionMissing();
 
-    expect($rule->id())->toBe('schema.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('schema.description-missing')
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a component schema has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/SchemaEnumEmptyTest.php
+++ b/tests/Unit/Lint/Rules/SchemaEnumEmptyTest.php
@@ -12,9 +12,9 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new SchemaEnumEmpty();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.enum-empty')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding for a field schema with an empty enum array', function (): void {

--- a/tests/Unit/Lint/Rules/SchemaEnumTypeMismatchTest.php
+++ b/tests/Unit/Lint/Rules/SchemaEnumTypeMismatchTest.php
@@ -11,9 +11,9 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new SchemaEnumTypeMismatch();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.enum-type-mismatch')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all enum values match the declared type', function (string $type, array $enum): void {

--- a/tests/Unit/Lint/Rules/SchemaExampleMissingTest.php
+++ b/tests/Unit/Lint/Rules/SchemaExampleMissingTest.php
@@ -47,8 +47,8 @@ function makeSchemaForExampleMissing(
 it('has the correct rule id and level', function (): void {
     $rule = new SchemaExampleMissing();
 
-    expect($rule->id())->toBe('schema.example-missing')
-        ->and($rule->severity())->toBe(Severity::Improvable);
+    expect($rule->id)->toBe('schema.example-missing')
+        ->and($rule->severity)->toBe(Severity::Improvable);
 });
 
 it('emits a finding when a schema has no example or null example', function (callable $build): void {

--- a/tests/Unit/Lint/Rules/SchemaNullableViaDeprecatedKeywordTest.php
+++ b/tests/Unit/Lint/Rules/SchemaNullableViaDeprecatedKeywordTest.php
@@ -33,9 +33,9 @@ function makeFieldForNullableTest(string $name, bool $setNullableOnRaw): FieldNo
 it('reports its id and level', function (): void {
     $rule = new SchemaNullableViaDeprecatedKeyword();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.nullable-via-deprecated-keyword')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits no finding when field raw does not use nullable keyword', function (): void {

--- a/tests/Unit/Lint/Rules/SchemaRawKeywordUnsupportedTest.php
+++ b/tests/Unit/Lint/Rules/SchemaRawKeywordUnsupportedTest.php
@@ -28,9 +28,9 @@ function rawKeywordFindings(string $method): array
 it('reports its id and level 1', function (): void {
     $rule = rawKeywordRule();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.raw-keyword-unsupported')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('flags a #[RawSchema] carrying an unsupported keyword', function (): void {

--- a/tests/Unit/Lint/Rules/SchemaRequiredWithoutPropertyTest.php
+++ b/tests/Unit/Lint/Rules/SchemaRequiredWithoutPropertyTest.php
@@ -51,9 +51,9 @@ function makeComponentForRequiredProps(string $schemaName, array $properties, ?a
 it('reports its id and level', function (): void {
     $rule = new SchemaRequiredWithoutProperty();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('schema.required-without-property')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all required properties exist', function (): void {

--- a/tests/Unit/Lint/Rules/ScopeOverlyBroadTest.php
+++ b/tests/Unit/Lint/Rules/ScopeOverlyBroadTest.php
@@ -61,8 +61,8 @@ function makeOverlyBroadSchemeContext(array $schemeTypes, array $registeredScope
 it('reports its id and level', function (): void {
     $rule = new ScopeOverlyBroad(registeredScopes: []);
 
-    expect($rule->id())->toBe('scope.overly-broad')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('scope.overly-broad')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when the only scope is the wildcard', function (): void {

--- a/tests/Unit/Lint/Rules/SecurityInvalidScopeTest.php
+++ b/tests/Unit/Lint/Rules/SecurityInvalidScopeTest.php
@@ -69,7 +69,7 @@ function makeScopeSchemeContext(array $schemeTypes, array $registeredScopes): Li
 it('reports its id and level', function (): void {
     $rule = new SecurityInvalidScope(registeredScopes: []);
 
-    expect($rule->id())->toBe('security.invalid-scope')->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('security.invalid-scope')->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when an operation references an undefined scope', function (): void {

--- a/tests/Unit/Lint/Rules/SecuritySchemeUndefinedTest.php
+++ b/tests/Unit/Lint/Rules/SecuritySchemeUndefinedTest.php
@@ -54,7 +54,7 @@ function makeSchemeUndefinedContext(array $declaredSchemes): LintContext
 it('reports its id and level', function (): void {
     $rule = new SecuritySchemeUndefined();
 
-    expect($rule->id())->toBe('security.scheme-undefined')->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('security.scheme-undefined')->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when all referenced schemes are declared', function (): void {

--- a/tests/Unit/Lint/Rules/ServerInvalidUrlTest.php
+++ b/tests/Unit/Lint/Rules/ServerInvalidUrlTest.php
@@ -30,8 +30,8 @@ function serverInvalidUrlFindings(?string $url): array
 it('has the correct rule id and level', function (): void {
     $rule = new ServerInvalidUrl();
 
-    expect($rule->id())->toBe('server.invalid-url')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('server.invalid-url')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding for an invalid URL', function (): void {

--- a/tests/Unit/Lint/Rules/ServerVariableUndeclaredTest.php
+++ b/tests/Unit/Lint/Rules/ServerVariableUndeclaredTest.php
@@ -41,8 +41,8 @@ function serverVariableUndeclaredFindings(?string $url, array $variables = []): 
 it('has the correct rule id and level', function (): void {
     $rule = new ServerVariableUndeclared();
 
-    expect($rule->id())->toBe('server.variable-undeclared')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('server.variable-undeclared')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits a finding when a template variable has no matching variables entry', function (): void {

--- a/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/SpecConfigOrphanedTest.php
@@ -74,8 +74,8 @@ function collectSpecConfigOrphanedFindings(SpecRegistry $registry, array $descri
 it('has the correct id and level', function (): void {
     $rule = new SpecConfigOrphaned(specConfigOrphanedEvaluator(), 'testing');
 
-    expect($rule->id())->toBe('spec.config-orphaned')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('spec.config-orphaned')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits no findings when the default spec matches at least one route', function (): void {

--- a/tests/Unit/Lint/Rules/SpecRouteOrphanedTest.php
+++ b/tests/Unit/Lint/Rules/SpecRouteOrphanedTest.php
@@ -69,8 +69,8 @@ function collectSpecRouteOrphanedFindings(SpecRegistry $registry, array $descrip
 it('has the correct id and level', function (): void {
     $rule = new SpecRouteOrphaned(new SpecResolver());
 
-    expect($rule->id())->toBe('spec.route-orphaned')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('spec.route-orphaned')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no findings when the descriptors list is empty', function (): void {

--- a/tests/Unit/Lint/Rules/SpecUnknownReferenceTest.php
+++ b/tests/Unit/Lint/Rules/SpecUnknownReferenceTest.php
@@ -73,9 +73,9 @@ function collectSpecUnknownReferenceFindings(SpecRegistry $registry, array $desc
 it('has the correct id and level', function (): void {
     $rule = new SpecUnknownReference(new SpecResolver());
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('spec.unknown-reference')
-        ->and($rule->severity())->toBe(Severity::Broken);
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no findings when the descriptors list is empty', function (): void {

--- a/tests/Unit/Lint/Rules/StreamingNoContentTypeTest.php
+++ b/tests/Unit/Lint/Rules/StreamingNoContentTypeTest.php
@@ -53,8 +53,8 @@ function streamingFindings(string $controllerMethod, string $routeName, ?string 
 it('has the correct rule id and level', function (): void {
     $rule = new StreamingNoContentType();
 
-    expect($rule->id())->toBe('streaming.no-content-type')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('streaming.no-content-type')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when streaming endpoint has no text/event-stream content type', function (): void {

--- a/tests/Unit/Lint/Rules/SummaryMissingTest.php
+++ b/tests/Unit/Lint/Rules/SummaryMissingTest.php
@@ -11,8 +11,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new SummaryMissing();
 
-    expect($rule->id())->toBe('summary.missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('summary.missing')
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when summary is missing', function (): void {

--- a/tests/Unit/Lint/Rules/TagDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/TagDuplicateTest.php
@@ -25,7 +25,7 @@ function makeTagDuplicateOperation(string $method): OperationNode
 it('has the correct rule id and level', function (): void {
     $rule = new TagDuplicate();
 
-    expect($rule->id())->toBe('tag.duplicate')->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('tag.duplicate')->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when a method has duplicate tags', function (): void {

--- a/tests/Unit/Lint/Rules/TagNameNamingInconsistentTest.php
+++ b/tests/Unit/Lint/Rules/TagNameNamingInconsistentTest.php
@@ -12,8 +12,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new TagNameNamingInconsistent();
 
-    expect($rule->id())->toBe('tag.name-naming-inconsistent')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('tag.name-naming-inconsistent')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('default (pascal): passes valid PascalCase tag names', function (array $tags): void {

--- a/tests/Unit/Lint/Rules/TagUndeclaredAtRootTest.php
+++ b/tests/Unit/Lint/Rules/TagUndeclaredAtRootTest.php
@@ -35,8 +35,8 @@ function tagUndeclaredAtRootContext(array $operationTags, array $rootTags = []):
 it('has the correct rule id and level', function (): void {
     $rule = new TagUndeclaredAtRoot();
 
-    expect($rule->id())->toBe('tag.undeclared-at-root')
-        ->and($rule->severity())->toBe(Severity::Inconsistent);
+    expect($rule->id)->toBe('tag.undeclared-at-root')
+        ->and($rule->severity)->toBe(Severity::Inconsistent);
 });
 
 it('emits a finding when a tag is not declared at root', function (): void {

--- a/tests/Unit/Lint/Rules/TagsNoDescriptionTest.php
+++ b/tests/Unit/Lint/Rules/TagsNoDescriptionTest.php
@@ -11,8 +11,8 @@ uses()->group('openapi', 'lint');
 it('has the correct rule id and level', function (): void {
     $rule = new TagsNoDescription();
 
-    expect($rule->id())->toBe('tags.no-description')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+    expect($rule->id)->toBe('tags.no-description')
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a tag has a missing or blank description', function (array $tagDescriptions): void {

--- a/tests/Unit/Lint/Rules/ThrowsTransitiveMissingTest.php
+++ b/tests/Unit/Lint/Rules/ThrowsTransitiveMissingTest.php
@@ -32,9 +32,9 @@ function makeTransitiveThrowsDescriptor(string $method, array $throws = []): Act
 it('has the correct rule id and level', function (): void {
     $rule = new ThrowsTransitiveMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('throws.transitive-missing')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when a controller method is missing a transitive @throws', function (): void {

--- a/tests/Unit/Lint/Rules/VisibilityAttributeNoOpTest.php
+++ b/tests/Unit/Lint/Rules/VisibilityAttributeNoOpTest.php
@@ -25,9 +25,9 @@ function visibilityNoOpFindings(VisibilityMode $mode, string $method): array
 it('has the correct rule id and level', function (): void {
     $rule = new VisibilityAttributeNoOp(new VisibilityResolver(VisibilityMode::Public));
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('visibility.attribute-no-op')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('flags an unconditional #[Expose] under public-default visibility', function (): void {

--- a/tests/Unit/Lint/Rules/WebhookDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/WebhookDescriptionMissingTest.php
@@ -44,9 +44,9 @@ function makeWebhookForDescription(string $name, ?string $description): WebhookN
 it('has the correct rule id and level', function (): void {
     $rule = new WebhookDescriptionMissing();
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('webhook.description-missing')
-        ->and($rule->severity())->toBe(Severity::Underspecified);
+        ->and($rule->severity)->toBe(Severity::Underspecified);
 });
 
 it('emits a finding when a webhook has a missing or blank description', function (?string $description): void {

--- a/tests/Unit/Lint/Rules/WebhookNameDuplicateTest.php
+++ b/tests/Unit/Lint/Rules/WebhookNameDuplicateTest.php
@@ -11,8 +11,8 @@ uses()->group('openapi', 'lint');
 it('reports its id and level', function (): void {
     $rule = new WebhookNameDuplicate();
 
-    expect($rule->id())->toBe('webhook.name-duplicate')
-        ->and($rule->severity())->toBe(Severity::Broken);
+    expect($rule->id)->toBe('webhook.name-duplicate')
+        ->and($rule->severity)->toBe(Severity::Broken);
 });
 
 it('emits no finding when webhook names are unique', function (): void {

--- a/tests/Unit/Lint/Tree/SpecTreeBuilderCompositeFieldsTest.php
+++ b/tests/Unit/Lint/Tree/SpecTreeBuilderCompositeFieldsTest.php
@@ -41,7 +41,7 @@ function compositeFieldFindings(array $properties, array $rules): array
 
     $builder = new SpecTreeBuilder();
     $api = $builder->build($document, []);
-    $index = TreeIndex::build($api, $document, array_map(static fn($r) => $r->id(), $rules), []);
+    $index = TreeIndex::build($api, $document, array_map(static fn($r) => $r->id, $rules), []);
     $context = new LintContext(api: $api, index: $index, rawSpec: $document, actionDescriptors: [], suppressions: []);
 
     return iterator_to_array(

--- a/tests/Unit/Lint/Tree/SpecTreeBuilderRefResponseDescriptionTest.php
+++ b/tests/Unit/Lint/Tree/SpecTreeBuilderRefResponseDescriptionTest.php
@@ -39,7 +39,7 @@ function refResponseDescriptionFindings(array $operationResponses, array $compon
     $rule = new ResponseDescriptionMissing();
     $builder = new SpecTreeBuilder();
     $api = $builder->build($document, []);
-    $index = TreeIndex::build($api, $document, [$rule->id()], []);
+    $index = TreeIndex::build($api, $document, [$rule->id], []);
     $context = new LintContext(api: $api, index: $index, rawSpec: $document, actionDescriptors: [], suppressions: []);
 
     return iterator_to_array(

--- a/tests/Unit/Lint/Tree/SpecTreeBuilderTopLevelCompositeTest.php
+++ b/tests/Unit/Lint/Tree/SpecTreeBuilderTopLevelCompositeTest.php
@@ -24,7 +24,7 @@ function topLevelCompositeFindings(OA\OpenApi $document, array $rules): array
 {
     $builder = new SpecTreeBuilder();
     $api = $builder->build($document, []);
-    $index = TreeIndex::build($api, $document, array_map(static fn($r) => $r->id(), $rules), []);
+    $index = TreeIndex::build($api, $document, array_map(static fn($r) => $r->id, $rules), []);
     $context = new LintContext(api: $api, index: $index, rawSpec: $document, actionDescriptors: [], suppressions: []);
 
     return iterator_to_array(

--- a/tests/Unit/Lint/Tree/SpecTreeWalkerSourceClassStampingTest.php
+++ b/tests/Unit/Lint/Tree/SpecTreeWalkerSourceClassStampingTest.php
@@ -26,23 +26,14 @@ uses()->group('openapi', 'lint');
 
 it('stamps CONTEXT_SOURCE_CLASS on findings emitted under a component schema whose source class is known', function (): void {
     $rule = new class () implements Rule, FieldRuleVisitor {
-        public function id(): string
-        {
-            return 'test.field-rule';
-        }
-        public function severity(): Severity
-        {
-            return Severity::Inconsistent;
-        }
-        public function description(): string
-        {
-            return 'test';
-        }
+        public string $id = 'test.field-rule';
+        public Severity $severity = Severity::Inconsistent;
+        public string $description = 'test';
         public function checkField(FieldNode $field, LintContext $context): iterable
         {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'fire on ' . $field->name,
             );
         }
@@ -60,7 +51,7 @@ it('stamps CONTEXT_SOURCE_CLASS on findings emitted under a component schema who
 
     $builder = new SpecTreeBuilder(componentClassMap: ['Some' => stdClass::class]);
     $api = $builder->build($document, []);
-    $index = TreeIndex::build($api, $document, [$rule->id()], []);
+    $index = TreeIndex::build($api, $document, [$rule->id], []);
     $context = new LintContext(api: $api, index: $index, rawSpec: $document, actionDescriptors: [], suppressions: []);
 
     $walker = new SpecTreeWalker([$rule]);
@@ -73,23 +64,14 @@ it('stamps CONTEXT_SOURCE_CLASS on findings emitted under a component schema who
 
 it('stamps CONTEXT_SOURCE_CLASS from the controller on operation-level findings', function (): void {
     $rule = new class () implements Rule, OperationRuleVisitor {
-        public function id(): string
-        {
-            return 'test.operation-rule';
-        }
-        public function severity(): Severity
-        {
-            return Severity::Degraded;
-        }
-        public function description(): string
-        {
-            return 'test';
-        }
+        public string $id = 'test.operation-rule';
+        public Severity $severity = Severity::Degraded;
+        public string $description = 'test';
         public function checkOperation(OperationNode $operation, LintContext $context): iterable
         {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'fire',
             );
         }
@@ -118,23 +100,14 @@ it('stamps CONTEXT_SOURCE_CLASS from the controller on operation-level findings'
 
 it('does not stamp CONTEXT_SOURCE_CLASS on operation-level findings when no controller is known', function (): void {
     $rule = new class () implements Rule, OperationRuleVisitor {
-        public function id(): string
-        {
-            return 'test.operation-rule';
-        }
-        public function severity(): Severity
-        {
-            return Severity::Degraded;
-        }
-        public function description(): string
-        {
-            return 'test';
-        }
+        public string $id = 'test.operation-rule';
+        public Severity $severity = Severity::Degraded;
+        public string $description = 'test';
         public function checkOperation(OperationNode $operation, LintContext $context): iterable
         {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'fire',
             );
         }
@@ -163,23 +136,14 @@ it('does not stamp CONTEXT_SOURCE_CLASS on operation-level findings when no cont
 
 it('stamps the controller CONTEXT_SOURCE_CLASS on response-level findings', function (): void {
     $rule = new class () implements Rule, ResponseRuleVisitor {
-        public function id(): string
-        {
-            return 'test.response-rule';
-        }
-        public function severity(): Severity
-        {
-            return Severity::Degraded;
-        }
-        public function description(): string
-        {
-            return 'test';
-        }
+        public string $id = 'test.response-rule';
+        public Severity $severity = Severity::Degraded;
+        public string $description = 'test';
         public function checkResponse(ResponseNode $response, LintContext $context): iterable
         {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'fire on ' . $response->statusCode,
             );
         }
@@ -208,23 +172,14 @@ it('stamps the controller CONTEXT_SOURCE_CLASS on response-level findings', func
 
 it('stamps each operation its own controller for response-level findings (no cross-controller bleed)', function (): void {
     $rule = new class () implements Rule, ResponseRuleVisitor {
-        public function id(): string
-        {
-            return 'test.response-rule';
-        }
-        public function severity(): Severity
-        {
-            return Severity::Degraded;
-        }
-        public function description(): string
-        {
-            return 'test';
-        }
+        public string $id = 'test.response-rule';
+        public Severity $severity = Severity::Degraded;
+        public string $description = 'test';
         public function checkResponse(ResponseNode $response, LintContext $context): iterable
         {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'fire',
             );
         }
@@ -257,23 +212,14 @@ it('stamps each operation its own controller for response-level findings (no cro
 
 it('stamps different CONTEXT_SOURCE_CLASS values for operations from different controllers', function (): void {
     $rule = new class () implements Rule, OperationRuleVisitor {
-        public function id(): string
-        {
-            return 'test.operation-rule';
-        }
-        public function severity(): Severity
-        {
-            return Severity::Degraded;
-        }
-        public function description(): string
-        {
-            return 'test';
-        }
+        public string $id = 'test.operation-rule';
+        public Severity $severity = Severity::Degraded;
+        public string $description = 'test';
         public function checkOperation(OperationNode $operation, LintContext $context): iterable
         {
             yield new Finding(
-                ruleId: $this->id(),
-                severity: $this->severity(),
+                ruleId: $this->id,
+                severity: $this->severity,
                 message: 'fire on ' . $operation->pathUri,
             );
         }

--- a/tests/Unit/Plugins/Fractal/Lint/FractalTransformerClassMissingTest.php
+++ b/tests/Unit/Plugins/Fractal/Lint/FractalTransformerClassMissingTest.php
@@ -30,9 +30,9 @@ class TransformerClassMissingController
 it('has the canonical rule metadata', function (): void {
     $rule = new FractalTransformerClassMissing();
 
-    expect($rule->id())->toBe('fractal.transformer-class-missing')
-        ->and($rule->severity())->toBe(Severity::Degraded)
-        ->and($rule->description())->toContain('transformer class');
+    expect($rule->id)->toBe('fractal.transformer-class-missing')
+        ->and($rule->severity)->toBe(Severity::Degraded)
+        ->and($rule->description)->toContain('transformer class');
 });
 
 it('flags a #[FractalResponse] naming a missing transformer class', function (): void {

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScopeTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/FieldAttributeWrongScopeTest.php
@@ -43,9 +43,9 @@ function makeWrongScopeOperation(string $method): OperationNode
 it('reports its id and level', function (): void {
     $rule = new FieldAttributeWrongScope(makeDirectOnlyScanner());
 
-    expect($rule->id())
+    expect($rule->id)
         ->toBe('field.attribute-wrong-scope')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('flags RequestField on a route parameter', function (): void {

--- a/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
+++ b/tests/Unit/Plugins/SpatieData/Lint/Rules/MultipartFileWithoutMultipartTest.php
@@ -95,8 +95,8 @@ function makeContextForMultipart(): LintContext
 it('reports its id and level', function (): void {
     $rule = new MultipartFileWithoutMultipart(makeSchemaBuilderStub([]), makeDirectScannerForMultipart());
 
-    expect($rule->id())->toBe('multipart.file-without-multipart')
-        ->and($rule->severity())->toBe(Severity::Degraded);
+    expect($rule->id)->toBe('multipart.file-without-multipart')
+        ->and($rule->severity)->toBe(Severity::Degraded);
 });
 
 it('emits a finding when a #[RequestBody] override forces a non-multipart body on a file Data class', function (): void {

--- a/tests/Unit/Plugins/SwaggerPhp/SchemaNameCollisionTest.php
+++ b/tests/Unit/Plugins/SwaggerPhp/SchemaNameCollisionTest.php
@@ -12,17 +12,17 @@ uses()->group('openapi', 'lint');
 // tests pin the stub's registration contract so its identity stays stable.
 
 it('exposes the stable rule id', function (): void {
-    expect(new SchemaNameCollision()->id())->toBe('component.schema-name-collision')
+    expect(new SchemaNameCollision()->id)->toBe('component.schema-name-collision')
         ->and(SchemaNameCollision::ID)->toBe('component.schema-name-collision');
 });
 
 it('reports a warning-level severity', function (): void {
-    expect(new SchemaNameCollision()->severity())->toBe(Severity::Degraded)
+    expect(new SchemaNameCollision()->severity)->toBe(Severity::Degraded)
         ->and(SchemaNameCollision::SEVERITY)->toBe(Severity::Degraded);
 });
 
 it('provides a non-empty description', function (): void {
-    expect(new SchemaNameCollision()->description())->not->toBe('');
+    expect(new SchemaNameCollision()->description)->not->toBe('');
 });
 
 it('exposes an actionable fix hint', function (): void {

--- a/tests/Unit/Plugins/SwaggerPhp/SwaggerPhpPluginTest.php
+++ b/tests/Unit/Plugins/SwaggerPhp/SwaggerPhpPluginTest.php
@@ -32,7 +32,7 @@ it('exposes the document-annotation rule at the migration (level-4) severity', f
         new AuthoredAnnotationScanner([], recordingLogger()),
     );
 
-    expect($rule->id())->toBe('migration.document-annotation-in-config')
-        ->and($rule->severity())->toBe(Severity::Improvable)
-        ->and($rule->severity()->value)->toBe(4);
+    expect($rule->id)->toBe('migration.document-annotation-in-config')
+        ->and($rule->severity)->toBe(Severity::Improvable)
+        ->and($rule->severity->value)->toBe(4);
 });


### PR DESCRIPTION
## Plan — migrate `Rule` metadata contract from getter methods to `{ get; }` property requirements

Closes #379. **Tier 0** (pure reflection/signature refactor; no body parsing). Behaviour-preserving
mechanical migration of the lint-rule metadata surface.

> ⚠️ **CONTROVERSIAL — human merge gate.** This changes `src/Contracts/Lint/Rule.php` (public
> extension surface) and `docs/plugin-authoring.md`. Any plugin author implementing `Rule` must
> change `id()/severity()/description()` methods to plain properties. Expect the lead to route this
> to `needs-human`, not auto-merge.

### Dependency

#378 (Severity enum) is **merged** — `Rule::severity(): Severity` is already in place. Build on
fresh `main`.

### Step 0 — Spike first (the coder runs this before touching the 103 files)

Write a throwaway `spike.php` (delete after, do NOT commit) to confirm the PHP 8.4 semantics the
issue calls out. Local PHP is 8.5.1; CI matrix is 8.4 + 8.5, so the spike must hold on **8.4**.

```php
interface R { public string $id { get; } public int $sev { get; } }
final class Leaf implements R {
    public string $id = 'x.y';     // plain readable prop — satisfies `{ get; }`?
    public int $sev = 3;
}
abstract class Base implements R {
    public int $sev = 3;           // base satisfies the shared requirement for all subclasses
    abstract public string $id { get; }   // OR leaf declares its own plain prop
}
final class Sub extends Base { public string $id = 'a.b'; }
$l = new Leaf(); var_dump($l->id, $l->sev);
```

Confirm, and record the answers as a PR comment:
- (a) **A plain readable `public T $x = …;` satisfies an interface `public T $x { get; }`
  requirement** on 8.4 — expected yes (a non-hooked property is implicitly readable+writable, which
  is a superset of `{ get; }`). Then run `vendor/bin/phpstan analyse` on the spike file under L8 to
  confirm **PHPStan level 8 is clean** with this shape (the real CI gate). If either fails, STOP and
  escalate — the whole approach (Moritz's preferred plain-mutable form) is invalidated and we'd fall
  back to `{ get => …; }` virtual-property hooks.
- (b) **A base class may satisfy the requirement on behalf of subclasses** (so `AbstractNamingRule`
  can declare `public Severity $severity = Severity::Inconsistent;` once for all 7 naming rules).
- (c) **`#[Override]` on a property** — **reviewer-verified: this is a HARD REQUIREMENT, not a
  recommendation.** `#[Override]` on a property is a **fatal compile error on PHP 8.4**
  (`Attribute "Override" cannot target property (allowed targets: method)`) and only became legal on
  8.5. Since the CI floor is 8.4, the migrated metadata properties **must NOT** carry `#[Override]`.
  Drop the attribute from the three metadata members as they convert to properties; **keep**
  `#[Override]` on the visitor methods (`checkOperation()` etc.), which stay methods. (Reviewer ran
  this on `php@8.4` and `php@8.5` to confirm.)

### Step 1 — Contract (`src/Contracts/Lint/Rule.php`)

Replace the three methods with three property requirements, keeping the existing docblocks moved
onto the properties:

```php
interface Rule
{
    /** Stable, dot-namespaced identifier (e.g. `operation.id-missing`); must be unique. */
    public string $id { get; }

    /** Severity of the findings this rule emits. Lower is more severe. */
    public Severity $severity { get; }

    /** One-line description of what the rule checks; shown by `openapi:lint --list`. */
    public string $description { get; }
}
```

### Step 2 — Leaf rules (~92 plain-leaf files)

For each `src/Lint/Rules/*.php` that implements `Rule` directly: delete the three getter methods and
add three plain typed properties with initializers near the top of the class body. Drop the now-unused
`#[Override]` and `use Override;` **only if** `Override` is no longer referenced (many rules also put
`#[Override]` on their `checkOperation()`/visitor method — keep that import/attribute). Example
(`SummaryMissing`):

```php
final class SummaryMissing implements Rule, OperationRuleVisitor
{
    public string $id = 'summary.missing';
    public Severity $severity = Severity::Underspecified;
    public string $description = 'Operation has no summary.';

    #[Override]
    public function checkOperation(...) { ... }  // unchanged
}
```

**readonly tension (issue gotcha b):** 21 leaf rules are declared `final readonly class`. A property
with an inline default **cannot** be `readonly`. Per the established move-readonly-onto-properties
pattern Moritz approved, the simplest correct move here is to **drop the class-level `readonly`** on
those 21 classes (their other state — injected scanners/config — is already `private readonly` on the
promoted ctor params, which stays valid: a non-readonly class may contain readonly properties). Do
**not** add `readonly` to the metadata props. This trades enforced immutability of rule metadata for
the conciseness Moritz asked for; acceptable for constant metadata.

### Step 3 — Abstract bases (issue gotcha d)

**`AbstractNamingRule`** (`abstract readonly class`, 7 subclasses):
- Drop class-level `readonly`.
- Replace `final public function severity(): Severity { return Severity::Inconsistent; }` with
  `public Severity $severity = Severity::Inconsistent;` (satisfies the requirement for all subclasses).
- Replace `abstract public function description(): string;` with `abstract public string $description { get; }`
  — then each of the 7 subclasses declares `public string $description = '…';` (their existing
  `description()` body becomes the initializer). Each subclass also declares `public string $id = '…';`.
- The 7 naming subclasses are `final readonly class … extends AbstractNamingRule` — drop their
  class-level `readonly` too (their `$case` is set in the ctor; it can stay `protected IdentifierCase $case`
  non-readonly on the base, or `protected readonly` on the base — keep it readonly on the base since it
  has no default and is ctor-assigned; only the metadata props block readonly).
  - **Decision to verify in spike:** can `protected readonly IdentifierCase $case` coexist in a
    non-readonly base alongside `public Severity $severity = …`? Yes — per-property readonly is
    independent of the dropped class-level modifier. Confirm in the spike, note in PR comment.

**`AbstractFieldRule`** (`abstract class`, not readonly, 4 subclasses): no `severity()`/`id()`/
`description()` on the base today — those live on each of the 4 leaf field rules, so they migrate
exactly like Step 2 leaves. The base only needs no change beyond confirming it still satisfies nothing
itself (it's abstract; subclasses provide the props).

### Step 4 — Call sites (`->id()` / `->severity()` / `->description()` → property reads)

Mechanical rename across the lint subsystem. Confirmed sites:
- `src/Lint/RuleRegistry.php` (4×: `$rule->id()`, `$rule->severity()`)
- `src/Lint/RuleCatalogRenderer.php` (3×: `id`, `severity`, `description`)
- `src/Lint/LintRunner.php` (4×: `$rule->id()`, `$rule->severity()`)
- `src/Lint/Fix/FixRunner.php` (1×: `$rule->id()` — leaves `$rule->fixer()`, a method, untouched)
- Every rule's own `new Finding(ruleId: $this->id(), severity: $this->severity(), …)` →
  `ruleId: $this->id, severity: $this->severity`.

**Discipline:** rename ONLY method calls on a `Rule` instance. Do **not** touch `$node->id()`,
`$operation->severity`, `Finding::$severity`, `Severity->value`, etc. Grep-then-review each hit;
`$rule->fixer()` (a method on the separate fixer interface) stays a method call.

Suggested mechanical pass: `grep -rn '\$rule->\(id\|severity\|description\)()' src/ tests/` and edit
each, plus the in-rule `$this->id()/$this->severity()/$this->description()` sites (also grep-confirmed).
A scripted sed is acceptable for `$this->id()` → `$this->id` etc. **within `src/Lint/Rules/`** since
those are unambiguous, but review the diff.

### Tests

Behaviour-preserving — the existing lint suite is the oracle. No new behaviour, so the "failing test
first" is really "the suite must stay green before and after".

1. Run `composer test` on `main` first (baseline green), then after the migration.
2. **Targeted assertions to add/confirm** in the lint contract tests (find the existing test that
   exercises `RuleRegistry`/`RuleCatalogRenderer`):
   - A rule's `$rule->id`, `$rule->severity`, `$rule->description` are readable and equal the old
     getter values for a representative sample (one plain leaf, one naming subclass, one field
     subclass) — proves the property form is wired the same.
   - `openapi:lint --list` output (RuleCatalogRenderer) is unchanged. The existing oracle is
     `tests/Feature/Lint/RuleCatalogRendererTest.php` (reviewer-located); note it asserts on **row
     shape / sort order / "every rule id present"**, not a byte-exact snapshot, so it catches a
     dropped or renamed metadata accessor but won't flag pure whitespace. It must stay green.
   - `severity_overrides` config path still resolves (`effectiveLevelFor($rule->id, …)`).
3. Edge: confirm at least one naming subclass and one field subclass instantiate (they have DI
   ctors) and expose all three props — covers the abstract-base-provides-`$severity` path.
4. `vendor/bin/pint --test` and `composer lint` (PHPStan L8) must both be clean — PHPStan L8 over the
   property form is the real risk surface flagged in the spike.

### Docs & changelog

- `docs/plugin-authoring.md`: **no getter-method `Rule` example currently exists in docs** (verified
  by reviewer — the page only references `Contracts\Lint\Rule` by name at lines 44 and 206, and no
  page under `docs/` shows a concrete `id()/severity()/description()` body). So there is nothing to
  *rewrite*; instead, **add** a short concrete example (≈10 lines) under the "write lint rules" step
  showing the property-requirement shape — `public string $id = '…';` etc. — so plugin authors know
  how to declare metadata after the contract change. The existing prose ("implementing
  `Contracts\Lint\Rule` plus the visitor interfaces") stays accurate and unchanged. This is still
  the public-surface change that makes the PR controversial.
- `CHANGELOG.md [Unreleased]`: a `Changed` entry — "Lint `Rule` contract now declares `id`,
  `severity`, `description` as readable property requirements instead of getter methods; rule
  implementations declare them as plain typed properties." (No back-compat/migration framing — package
  is pre-1.0.)

### Out of scope

The visitor interfaces (`OperationRule` etc.) and `fixer()` are untouched — only the three metadata
accessors move. No new config key, no stage-order change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
