### PR TITLE
feat(#413): three-way response-coverage metric (substantive · correctly-empty · genuinely-missing)

### DIFF
--- a/tests/Tools/SurveyMetricsTest.php
+++ b/tests/Tools/SurveyMetricsTest.php
@@ -66,6 +66,64 @@ it('counts only substantive 2xx into responseSchemas, contentless ops into docum
         ->and($m['completenessPercent'])->toBe(66.7);
 });
 
+it('omits responseCoverage when no classification is supplied', function (): void {
+    $spec = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/spec.json'), true);
+    $run = ['generateExit' => 0, 'lintExit' => 0, 'generateStderr' => false, 'bootOutcome' => 'booted'];
+
+    $m = surveyMetrics($spec, ['findings' => []], $run, '/api');
+
+    expect($m)->not->toHaveKey('responseCoverage');
+});
+
+it('splits in-prefix ops into substantive / correctly-empty / genuinely-missing with a classification', function (): void {
+    // Three in-prefix ops: one substantive, one genuinely no-content (void), one that returns a
+    // body the generator could not resolve (empty-schema 200). The contentless vs give-up split
+    // can only come from the action source shape, not the spec.
+    $spec = ['paths' => [
+        '/api/show/{id}' => ['get' => ['responses' => ['200' => ['content' => [
+            'application/json' => ['schema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]]],
+        ]]]]],
+        '/api/destroy/{id}' => ['delete' => ['responses' => ['204' => []]]],
+        '/api/dynamic' => ['get' => ['responses' => ['200' => ['content' => [
+            'application/json' => ['schema' => ['type' => 'object']],
+        ]]]]],
+    ]];
+
+    $run = ['generateExit' => 0, 'lintExit' => 0, 'generateStderr' => false, 'bootOutcome' => 'booted'];
+
+    $classification = [
+        ['uri' => '/api/show/{id}', 'verb' => 'get', 'shape' => 'resource::make', 'returnType' => 'JsonResource'],
+        ['uri' => '/api/destroy/{id}', 'verb' => 'delete', 'shape' => 'no return (void-like)', 'returnType' => 'void'],
+        ['uri' => '/api/dynamic', 'verb' => 'get', 'shape' => 'response()->json(<non-literal>)', 'returnType' => 'JsonResponse'],
+    ];
+
+    $m = surveyMetrics($spec, ['findings' => []], $run, '/api', null, $classification);
+
+    expect($m['responseCoverage']['substantive'])->toBe(1)
+        ->and($m['responseCoverage']['correctlyEmpty'])->toBe(1)
+        ->and($m['responseCoverage']['genuinelyMissing'])->toBe(1)
+        ->and($m['responseCoverage']['genuinelyMissingByShape'])->toBe(['response()->json(<non-literal>)' => 1])
+        // The three buckets partition apiOperations exactly.
+        ->and($m['responseCoverage']['substantive'] + $m['responseCoverage']['correctlyEmpty'] + $m['responseCoverage']['genuinelyMissing'])
+        ->toBe($m['apiOperations']);
+});
+
+it('counts a non-substantive op with no classification record as genuinely-missing (conservative)', function (): void {
+    $spec = ['paths' => [
+        '/api/mystery' => ['get' => ['responses' => ['200' => ['content' => [
+            'application/json' => ['schema' => ['type' => 'object']],
+        ]]]]],
+    ]];
+    $run = ['generateExit' => 0, 'lintExit' => 0, 'generateStderr' => false, 'bootOutcome' => 'booted'];
+
+    // Classification supplied but missing this op's record.
+    $m = surveyMetrics($spec, ['findings' => []], $run, '/api', null, []);
+
+    expect($m['responseCoverage']['genuinelyMissing'])->toBe(1)
+        ->and($m['responseCoverage']['correctlyEmpty'])->toBe(0)
+        ->and($m['responseCoverage']['genuinelyMissingByShape'])->toBe(['unclassified' => 1]);
+});
+
 it('adds coverage when a published spec is supplied', function (): void {
     $spec = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/spec.json'), true);
     $lint = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/lint.json'), true);

--- a/tests/Tools/SurveySynthesizeTest.php
+++ b/tests/Tools/SurveySynthesizeTest.php
@@ -280,3 +280,51 @@ it('embeds the provenance manifest verbatim in both candidates', function (): vo
             ->and($candidate)->toContain('1111111111111111111111111111111111111111'); // Alpha pinnedSha
     }
 });
+
+it('rolls up the three-way responseCoverage across classified apps in the internal candidate', function (): void {
+    $results = [
+        ['name' => 'Alpha', 'metrics' => [
+            'apiOperations' => 10,
+            'responseCoverage' => [
+                'substantive' => 6,
+                'correctlyEmpty' => 1,
+                'genuinelyMissing' => 3,
+                'genuinelyMissingByShape' => ['response()->json(<non-literal>)' => 2, 'multiple returns' => 1],
+            ],
+        ]],
+        ['name' => 'Beta', 'metrics' => [
+            'apiOperations' => 4,
+            'responseCoverage' => [
+                'substantive' => 2,
+                'correctlyEmpty' => 0,
+                'genuinelyMissing' => 2,
+                'genuinelyMissingByShape' => ['multiple returns' => 2],
+            ],
+        ]],
+        // An app with no classification must not break the rollup.
+        ['name' => 'Gamma', 'metrics' => ['apiOperations' => 5]],
+    ];
+
+    $synthesis = surveySynthesize($results, ['apps' => []], []);
+
+    expect($synthesis['responseCoverage'])->toBe([
+        'appCount' => 2,
+        'substantive' => 8,
+        'correctlyEmpty' => 1,
+        'genuinelyMissing' => 5,
+        // arsort by count: 'multiple returns' (3) outranks the json shape (2).
+        'genuinelyMissingByShape' => ['multiple returns' => 3, 'response()->json(<non-literal>)' => 2],
+    ]);
+
+    $internal = surveyRenderInternalCandidate($synthesis);
+    expect($internal)->toContain('## Response coverage (three-way, honest denominator)')
+        ->toContain('**8 substantive · 1 correctly-empty · 5 genuinely-missing**');
+});
+
+it('omits the responseCoverage section when no app carries a classification', function (): void {
+    [$results, $manifest, $lifts] = surveyFixtureInputs();
+    $synthesis = surveySynthesize($results, $manifest, $lifts);
+
+    expect($synthesis['responseCoverage'])->toBeNull()
+        ->and(surveyRenderInternalCandidate($synthesis))->not->toContain('Response coverage (three-way');
+});

--- a/tools/survey/classify.php
+++ b/tools/survey/classify.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Per-route action return-shape classifier (app-context, deterministic).
+ *
+ * Boots a consumer app, enumerates its routes under an API prefix, reflects each controller action,
+ * and labels the action's return EXPRESSION with a source-shape string. This is the signal the
+ * generated spec cannot carry: whether an empty 2xx is *correctly* empty (a void/no-content action)
+ * or a *give-up* empty (the action returns a body the generator could not resolve). metrics.php joins
+ * these shapes with the spec's substantive-ness to produce the three-way responseCoverage breakdown
+ * (#413). It does NOT decide substantive-ness — only the source shape.
+ *
+ * Emits a JSON array of {uri, verb, action, returnType, shape} records to stdout.
+ *
+ * Usage: php classify.php <repo-dir> [--prefix=/api] > classify.json
+ *   <repo-dir> is the consumer app root (must have vendor/ + bootstrap/app.php).
+ */
+
+use Illuminate\Routing\Route;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Closure as ClosureExpr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_ as NewExpr;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+
+$repoDir = $argv[1] ?? null;
+$prefix = '/api';
+
+foreach (array_slice($argv, 2) as $arg) {
+    if (str_starts_with($arg, '--prefix=')) {
+        $prefix = substr($arg, 9);
+    }
+}
+
+if ($repoDir === null || !is_dir($repoDir)) {
+    fwrite(STDERR, "usage: classify.php <repo-dir> [--prefix=/api]\n");
+    exit(2);
+}
+
+require $repoDir . '/vendor/autoload.php';
+
+/** @var Illuminate\Foundation\Application $app */
+$app = require $repoDir . '/bootstrap/app.php';
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$router = $app->make('router');
+$parser = (new ParserFactory())->createForHostVersion();
+$nodeFinder = new NodeFinder();
+
+/** @var array<string, null|list<Stmt>> $fileAst */
+$fileAst = [];
+
+/**
+ * Parse a file once.
+ *
+ * @return null|list<Stmt>
+ */
+$astFor = function (string $file) use ($parser, &$fileAst): ?array {
+    if (array_key_exists($file, $fileAst)) {
+        return $fileAst[$file];
+    }
+
+    try {
+        $code = @file_get_contents($file);
+        $fileAst[$file] = $code === false ? null : $parser->parse($code);
+    } catch (Throwable) {
+        $fileAst[$file] = null;
+    }
+
+    return $fileAst[$file];
+};
+
+/** Find the ClassMethod node for a ReflectionMethod (the overload whose line range contains it). */
+$methodNode = function (ReflectionMethod $method) use ($astFor, $nodeFinder): ?ClassMethod {
+    $file = $method->getDeclaringClass()->getFileName();
+
+    if ($file === false) {
+        return null;
+    }
+
+    $ast = $astFor($file);
+
+    if ($ast === null) {
+        return null;
+    }
+
+    $candidates = $nodeFinder->find($ast, static fn(Node $n): bool => $n instanceof ClassMethod
+        && $n->name->toString() === $method->getName());
+    $start = $method->getStartLine();
+
+    foreach ($candidates as $candidate) {
+        if ($candidate->getStartLine() <= $start && $candidate->getEndLine() >= $start) {
+            return $candidate;
+        }
+    }
+
+    return $candidates[0] ?? null;
+};
+
+/**
+ * Method-level returns, skipping nested closures/classes.
+ *
+ * @param list<Node> $statements
+ *
+ * @return list<Return_>
+ */
+$methodReturns = function (array $statements) use (&$methodReturns): array {
+    $found = [];
+    $walk = function (Node $node) use (&$walk, &$found): void {
+        if ($node instanceof ClosureExpr || $node instanceof ArrowFunction || $node instanceof ClassLike) {
+            return;
+        }
+
+        if ($node instanceof Return_) {
+            $found[] = $node;
+        }
+
+        foreach ($node->getSubNodeNames() as $sub) {
+            $children = $node->{$sub};
+
+            foreach (is_array($children) ? $children : [$children] as $child) {
+                if ($child instanceof Node) {
+                    $walk($child);
+                }
+            }
+        }
+    };
+
+    foreach ($statements as $statement) {
+        $walk($statement);
+    }
+
+    return $found;
+};
+
+$shortName = static fn(?string $fqcn): ?string => $fqcn === null
+    ? null
+    : (($pos = strrpos($fqcn, '\\')) === false ? $fqcn : substr($fqcn, $pos + 1));
+
+/** Peel resource-preserving `->additional(...)` wrappers. */
+$unwrapChain = static function (Expr $expr): Expr {
+    while ($expr instanceof MethodCall
+        && $expr->name instanceof Identifier
+        && strtolower($expr->name->toString()) === 'additional') {
+        $expr = $expr->var;
+    }
+
+    return $expr;
+};
+
+/** Label a return expression with a source-shape string (mirrors the library's reader whitelist). */
+$classifyExpr = function (Expr $expr) use ($unwrapChain, $shortName): string {
+    $expr = $unwrapChain($expr);
+
+    if ($expr instanceof StaticCall && $expr->name instanceof Identifier) {
+        $method = strtolower($expr->name->toString());
+        $class = $expr->class instanceof Name ? $expr->class->toString() : '<dynamic>';
+
+        if ($method === 'collection') {
+            return 'resource::collection';
+        }
+
+        if ($method === 'make' || $method === 'collect') {
+            return 'resource::' . $method;
+        }
+
+        return 'static-call:' . $shortName($class) . '::' . $method;
+    }
+
+    if ($expr instanceof NewExpr) {
+        return $expr->class instanceof Name ? 'new ' . $shortName($expr->class->toString()) . '(...)' : 'new <dynamic>';
+    }
+
+    if ($expr instanceof MethodCall && $expr->name instanceof Identifier) {
+        $method = strtolower($expr->name->toString());
+
+        if ($method === 'toresource' || $method === 'toresourcecollection') {
+            return '->' . $expr->name->toString() . '()';
+        }
+
+        if ($method === 'json') {
+            $arg = $expr->getArgs()[0]->value ?? null;
+
+            return $arg instanceof Expr\Array_ ? 'response()->json([array literal])' : 'response()->json(<non-literal>)';
+        }
+
+        if ($method === 'nocontent') {
+            return 'response()->noContent()';
+        }
+
+        return '->' . $method . '() chain';
+    }
+
+    if ($expr instanceof Expr\Array_) {
+        return 'array literal';
+    }
+
+    if ($expr instanceof Expr\Ternary || $expr instanceof Expr\Match_) {
+        return 'conditional/ternary';
+    }
+
+    if ($expr instanceof Variable) {
+        return 'variable (unresolved)';
+    }
+
+    if ($expr instanceof Expr\ConstFetch && in_array(strtolower($expr->name->toString()), ['null', 'true', 'false'], true)) {
+        return 'scalar literal (' . strtolower($expr->name->toString()) . ')';
+    }
+
+    if ($expr instanceof Node\Scalar) {
+        return 'scalar literal';
+    }
+
+    return 'other (' . (new ReflectionClass($expr))->getShortName() . ')';
+};
+
+/**
+ * Resolve `return $var;` to its single unconditional assignment, mirroring the reader.
+ *
+ * @param list<Stmt> $statements
+ */
+$resolveVarExpr = function (Variable $var, array $statements) use ($nodeFinder): ?Expr {
+    if (!is_string($var->name)) {
+        return null;
+    }
+
+    $name = $var->name;
+    $topLevel = [];
+
+    foreach ($statements as $statement) {
+        if ($statement instanceof Stmt\Expression && $statement->expr instanceof Assign
+            && $statement->expr->var instanceof Variable && $statement->expr->var->name === $name) {
+            $topLevel[] = $statement->expr;
+        }
+    }
+
+    $all = $nodeFinder->find($statements, static fn(Node $n): bool => $n instanceof Assign
+        && $n->var instanceof Variable && $n->var->name === $name);
+
+    return count($topLevel) === 1 && count($all) === 1 ? $topLevel[0]->expr : null;
+};
+
+$records = [];
+
+foreach ($router->getRoutes() as $route) {
+    /** @var Route $route */
+    $uri = '/' . ltrim($route->uri(), '/');
+
+    if ($prefix !== '' && !str_starts_with($uri, rtrim($prefix, '/'))) {
+        continue;
+    }
+
+    $action = $route->getActionName();
+
+    foreach ($route->methods() as $verb) {
+        $verb = strtolower($verb);
+
+        if (!in_array($verb, ['get', 'post', 'put', 'patch', 'delete'], true)) {
+            continue;
+        }
+
+        $record = ['uri' => $uri, 'verb' => $verb, 'action' => $action, 'returnType' => '', 'shape' => null];
+
+        if ($action === 'Closure' || !str_contains($action, '@')) {
+            $record['shape'] = 'closure/invokable-or-unknown';
+            $records[] = $record;
+
+            continue;
+        }
+
+        [$class, $methodName] = explode('@', $action, 2);
+
+        try {
+            $method = new ReflectionMethod($class, $methodName);
+        } catch (Throwable) {
+            $record['shape'] = 'reflection-failed';
+            $records[] = $record;
+
+            continue;
+        }
+
+        $returnType = $method->getReturnType();
+        $record['returnType'] = $returnType === null ? '' : (string) $returnType;
+
+        $node = $methodNode($method);
+
+        if ($node === null || $node->stmts === null) {
+            $record['shape'] = strtolower($record['returnType']) === 'void' ? 'void/no-body' : 'no-body (abstract/interface)';
+            $records[] = $record;
+
+            continue;
+        }
+
+        $returns = $methodReturns($node->stmts);
+
+        if ($returns === []) {
+            $record['shape'] = 'no return (void-like)';
+            $records[] = $record;
+
+            continue;
+        }
+
+        $topReturn = null;
+
+        foreach ($node->stmts as $statement) {
+            if ($statement instanceof Return_) {
+                $topReturn = $statement;
+
+                break;
+            }
+        }
+
+        if ($topReturn === null) {
+            $record['shape'] = 'conditional returns only';
+            $records[] = $record;
+
+            continue;
+        }
+
+        if (count($returns) > 1) {
+            $record['shape'] = 'multiple returns';
+            $records[] = $record;
+
+            continue;
+        }
+
+        $expr = $topReturn->expr;
+
+        if ($expr === null) {
+            $record['shape'] = 'return; (void)';
+            $records[] = $record;
+
+            continue;
+        }
+
+        if ($expr instanceof Variable) {
+            $resolved = $resolveVarExpr($expr, $node->stmts);
+            $record['shape'] = $resolved === null
+                ? 'variable (not single-assigned)'
+                : $classifyExpr($resolved) . ' (via $var)';
+            $records[] = $record;
+
+            continue;
+        }
+
+        $record['shape'] = $classifyExpr($expr);
+        $records[] = $record;
+    }
+}
+
+echo json_encode($records, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";

--- a/tools/survey/completeness.php
+++ b/tools/survey/completeness.php
@@ -18,10 +18,13 @@ declare(strict_types=1);
 
 $specPath = $argv[1] ?? null;
 $prefix = '/api';
+$classifyPath = null;
 
 foreach (array_slice($argv, 2) as $a) {
     if (str_starts_with($a, '--prefix=')) {
         $prefix = substr($a, 9);
+    } elseif (str_starts_with($a, '--classify=')) {
+        $classifyPath = substr($a, 11);
     }
 }
 
@@ -170,6 +173,24 @@ foreach (($spec['paths'] ?? []) as $path => $ms) {
     }
 }
 printf("%s ops: %d  complete: %d (%.1f%%)  missing-response: %d  missing-body: %d  no-security: %d\n", $prefix, $tot, $complete, $tot ? 100 * $complete / $tot : 0, $noResp, $noBody, $noSec);
+
+// Honest three-way response coverage, when an action classification (classify.php) is supplied.
+if ($classifyPath !== null && is_file($classifyPath)) {
+    require_once __DIR__ . '/metrics.php';
+    $classification = json_decode((string) file_get_contents($classifyPath), true) ?: [];
+    $run = ['generateExit' => 0, 'lintExit' => 0, 'generateStderr' => false, 'bootOutcome' => 'booted'];
+    $coverage = surveyMetrics($spec, ['findings' => []], $run, $prefix, null, $classification)['responseCoverage'];
+    printf(
+        "response coverage: substantive: %d  correctly-empty: %d  genuinely-missing: %d\n",
+        $coverage['substantive'],
+        $coverage['correctlyEmpty'],
+        $coverage['genuinelyMissing'],
+    );
+
+    foreach ($coverage['genuinelyMissingByShape'] as $shape => $count) {
+        printf("  genuinely-missing %4d  %s\n", $count, $shape);
+    }
+}
 
 foreach ($rows as $r) {
     echo $r . "\n";

--- a/tools/survey/methodology.md
+++ b/tools/survey/methodology.md
@@ -119,6 +119,17 @@ and prefix yields identical output.
 | `crash.bootOutcome` | Bootstrap outcome written by the bootstrap script: `ok`, `blocked-compat`, or `unknown`. |
 | `crash.routesIntrospected` | Number of routes seen by the generator, if captured; `null` otherwise. |
 | `coverage` | Only present when the corpus entry provides a `publishedSpec`. Compares path×method keys (with `{param}` collapsed to `{}`) between the generated spec and the published one. Contains: `publishedOps` (keys in their spec), `ours` (keys in our spec), `intersection` (keys present in both), `covPercent` (`round(100 × intersection / publishedOps, 1)`). |
+| `responseCoverage` | Only present when the app dir has a `classify.json` (from `classify.php`). The honest three-way split of `apiOperations`, since neither `responseSchemas` (pessimistic: counts a correct empty 2xx as a miss) nor `completenessPercent` (optimistic: credits a give-up empty 2xx as complete) is right. Contains `substantive` (a real payload — today's `responseSchemas`), `correctlyEmpty` (the action is genuinely no-content: `void`/`never`, `return;`, `return null;`, `response()->noContent()`), `genuinelyMissing` (the action returns a body the generator emitted empty/thin), and `genuinelyMissingByShape` (a rollup of the give-up shapes). The three counts partition `apiOperations` exactly; `genuinelyMissing` is the real denominator to size response-inference levers against. An op with no classification record counts conservatively as `genuinelyMissing` under the `unclassified` shape. |
+
+### `classify.php` (action source-shape classifier)
+
+The correctly-empty vs give-up-empty split is not in the spec — it needs the action's return shape.
+`classify.php <repo-dir> [--prefix=/api]` boots the consumer app, reflects each in-prefix action, and
+AST-classifies its return expression into a source-shape string, emitting `classify.json` (one record
+per route: `{uri, verb, action, returnType, shape}`). `metrics.php` reads `classify.json` from the app
+dir when present and joins it with spec substantive-ness; `completeness.php --classify=<classify.json>`
+prints the same three-way line. The classifier mirrors the library's reader whitelist — it labels
+refused shapes too, but never decides substantive-ness itself.
 
 ## The short version (a new app)
 

--- a/tools/survey/metrics.php
+++ b/tools/survey/metrics.php
@@ -73,6 +73,58 @@ function survey_substantive(mixed $schema, array $components, array $seen = []):
     return is_array($type) && array_intersect($type, $scalars) !== [];
 }
 
+/**
+ * Whether an action's source shape means a 2xx is *correctly* empty (no body is the right answer),
+ * as opposed to a give-up empty (the action returns a body the generator could not resolve).
+ */
+function survey_isNoContentShape(string $shape, string $returnType): bool
+{
+    $returnType = strtolower(ltrim($returnType, '?'));
+
+    if ($returnType === 'void' || $returnType === 'never') {
+        return true;
+    }
+
+    $noContent = [
+        'response()->noContent()',
+        'return; (void)',
+        'no return (void-like)',
+        'void/no-body',
+    ];
+
+    return in_array($shape, $noContent, true) || str_starts_with($shape, 'scalar literal (null)');
+}
+
+/**
+ * Index classification records (from classify.php) by normalised "VERB /path" key, collapsing
+ * path parameters to {} so they join the spec's operation keys.
+ *
+ * @param list<array<string, mixed>> $classification
+ *
+ * @return array<string, array{shape: string, returnType: string}>
+ */
+function survey_classificationIndex(array $classification): array
+{
+    $index = [];
+
+    foreach ($classification as $record) {
+        $uri = (string) ($record['uri'] ?? '');
+        $verb = strtoupper((string) ($record['verb'] ?? ''));
+
+        if ($uri === '' || $verb === '') {
+            continue;
+        }
+
+        $key = $verb . ' ' . preg_replace('/\{[^}]+\}/', '{}', $uri);
+        $index[$key] = [
+            'shape' => (string) ($record['shape'] ?? 'unclassified'),
+            'returnType' => (string) ($record['returnType'] ?? ''),
+        ];
+    }
+
+    return $index;
+}
+
 /** Count properties of a request-body schema, following one $ref hop. */
 function survey_requestPropertyCount(array $schema, array $components): int
 {
@@ -110,7 +162,7 @@ function survey_operationKeys(array $spec): array
 /**
  * @param array{generateExit:int,lintExit:int,generateStderr:bool,bootOutcome:string,routesIntrospected?:int} $run
  */
-function surveyMetrics(array $spec, array $lint, array $run, string $apiPrefix = '/api', ?array $published = null): array
+function surveyMetrics(array $spec, array $lint, array $run, string $apiPrefix = '/api', ?array $published = null, ?array $classification = null): array
 {
     $components = $spec['components']['schemas'] ?? [];
     $verbs = ['get', 'post', 'put', 'patch', 'delete'];
@@ -124,6 +176,14 @@ function surveyMetrics(array $spec, array $lint, array $run, string $apiPrefix =
     $requestBodies = 0;
     $maxRequestProperties = 0;
     $complete = 0;
+
+    // Three-way response coverage (only when an action classification is supplied — the
+    // correctly-empty vs give-up-empty split needs the action's return shape, not the spec).
+    $classificationIndex = $classification !== null ? survey_classificationIndex($classification) : null;
+    $covSubstantive = 0;
+    $covCorrectlyEmpty = 0;
+    $covGenuinelyMissing = 0;
+    $covByShape = [];
 
     foreach (($spec['paths'] ?? []) as $path => $methods) {
         if (!is_array($methods)) {
@@ -203,8 +263,27 @@ function surveyMetrics(array $spec, array $lint, array $run, string $apiPrefix =
             if ($hasCompleteResponse && (!in_array($method, $bodyVerbs, true) || $hasBody)) {
                 $complete++;
             }
+
+            if ($classificationIndex !== null) {
+                if ($hasSubstantiveResponse) {
+                    $covSubstantive++;
+                } else {
+                    $normPath = preg_replace('/\{[^}]+\}/', '{}', (string) $path);
+                    $record = $classificationIndex[strtoupper($method) . ' ' . $normPath] ?? null;
+
+                    if ($record !== null && survey_isNoContentShape($record['shape'], $record['returnType'])) {
+                        $covCorrectlyEmpty++;
+                    } else {
+                        $covGenuinelyMissing++;
+                        $shape = $record['shape'] ?? 'unclassified';
+                        $covByShape[$shape] = ($covByShape[$shape] ?? 0) + 1;
+                    }
+                }
+            }
         }
     }
+
+    ksort($covByShape);
 
     $byRule = [];
     $byLevel = [];
@@ -239,6 +318,15 @@ function surveyMetrics(array $spec, array $lint, array $run, string $apiPrefix =
             'routesIntrospected' => $run['routesIntrospected'] ?? null,
         ],
     ];
+
+    if ($classificationIndex !== null) {
+        $metrics['responseCoverage'] = [
+            'substantive' => $covSubstantive,
+            'correctlyEmpty' => $covCorrectlyEmpty,
+            'genuinelyMissing' => $covGenuinelyMissing,
+            'genuinelyMissingByShape' => $covByShape,
+        ];
+    }
 
     if ($published !== null) {
         $ours = survey_operationKeys($spec);
@@ -315,6 +403,11 @@ if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__F
         'generateExit' => -1, 'lintExit' => -1, 'generateStderr' => true, 'bootOutcome' => 'unknown',
     ];
 
+    // Optional action classification (classify.php output) enables the three-way responseCoverage block.
+    $classification = is_file("$appDir/classify.json")
+        ? (json_decode((string) file_get_contents("$appDir/classify.json"), true) ?: null)
+        : null;
+
     $published = null;
 
     if ($publishedPath !== null && is_file($publishedPath)) {
@@ -341,5 +434,5 @@ if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__F
         }
     }
 
-    echo json_encode(surveyMetrics($spec, $lint, $run, $prefix, $published), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    echo json_encode(surveyMetrics($spec, $lint, $run, $prefix, $published, $classification), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
 }

--- a/tools/survey/synthesize.php
+++ b/tools/survey/synthesize.php
@@ -108,6 +108,14 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
     $cleanRuns = 0;
     $byRuleTotals = [];
 
+    // Three-way response coverage (#413) rides along only for apps whose run captured a
+    // classify.json; rolled up across just those apps so the denominator is honest.
+    $coverageApps = 0;
+    $coverageSubstantive = 0;
+    $coverageCorrectlyEmpty = 0;
+    $coverageGenuinelyMissing = 0;
+    $coverageByShape = [];
+
     foreach ($results as $entry) {
         $name = (string) ($entry['name'] ?? '');
         $metrics = is_array($entry['metrics'] ?? null) ? $entry['metrics'] : [];
@@ -152,6 +160,19 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
             $app['coverage'] = $metrics['coverage'];
         }
 
+        if (is_array($metrics['responseCoverage'] ?? null)) {
+            $coverage = $metrics['responseCoverage'];
+            $app['responseCoverage'] = $coverage;
+            $coverageApps++;
+            $coverageSubstantive += (int) ($coverage['substantive'] ?? 0);
+            $coverageCorrectlyEmpty += (int) ($coverage['correctlyEmpty'] ?? 0);
+            $coverageGenuinelyMissing += (int) ($coverage['genuinelyMissing'] ?? 0);
+
+            foreach ((array) ($coverage['genuinelyMissingByShape'] ?? []) as $shape => $count) {
+                $coverageByShape[(string) $shape] = ($coverageByShape[(string) $shape] ?? 0) + (int) $count;
+            }
+        }
+
         $apps[] = $app;
     }
 
@@ -172,12 +193,21 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
         ];
     }
 
+    arsort($coverageByShape);
+
     return [
         'provenance' => [
             'generatedAt' => (string) ($manifest['generatedAt'] ?? ''),
             'libraryCommit' => (string) ($manifest['libraryCommit'] ?? ''),
             'apps' => $provenanceApps,
         ],
+        'responseCoverage' => $coverageApps > 0 ? [
+            'appCount' => $coverageApps,
+            'substantive' => $coverageSubstantive,
+            'correctlyEmpty' => $coverageCorrectlyEmpty,
+            'genuinelyMissing' => $coverageGenuinelyMissing,
+            'genuinelyMissingByShape' => $coverageByShape,
+        ] : null,
         'corpus' => [
             'appCount' => count($apps),
             'cleanRuns' => $cleanRuns,
@@ -434,6 +464,29 @@ function surveyRenderInternalCandidate(array $synthesis): string
 
     if (!$anyCoverage) {
         $out[] = '| _no app pinned a published spec_ | | | | |';
+    }
+
+    // Three-way response coverage rolls up only when at least one app's run captured a classify.json.
+    if (is_array($synthesis['responseCoverage'] ?? null)) {
+        $coverage = $synthesis['responseCoverage'];
+        $out[] = '';
+        $out[] = '## Response coverage (three-way, honest denominator)';
+        $out[] = '';
+        $out[] = sprintf(
+            'Across %d classified app(s): **%d substantive · %d correctly-empty · %d genuinely-missing**. '
+            . '`genuinely-missing` is the real denominator to size response-inference levers against.',
+            (int) $coverage['appCount'],
+            (int) $coverage['substantive'],
+            (int) $coverage['correctlyEmpty'],
+            (int) $coverage['genuinelyMissing'],
+        );
+        $out[] = '';
+        $out[] = '| Genuinely-missing shape | Count |';
+        $out[] = '|---|--:|';
+
+        foreach ($coverage['genuinelyMissingByShape'] as $shape => $count) {
+            $out[] = sprintf('| `%s` | %d |', $shape, (int) $count);
+        }
     }
 
     $out[] = '';


### PR DESCRIPTION
Closes #413.

## Plan

The survey's two headline numbers each lie in opposite directions: `responseSchemas/apiOperations`
is pessimistic (counts a correct empty 2xx as a miss); `completenessPercent` is optimistic (credits a
give-up empty 2xx as complete). Split each in-prefix operation into three honest buckets.

The "correctly-empty vs returns-a-body" signal is **not in the spec** — it needs the action's return
shape. So:

1. **`tools/survey/classify.php` (new, app-context)** — a lean productionisation of the ADR-#412 spike
   (`analyze-routes.php`): boots the consumer app, reflects each in-prefix action, AST-classifies its
   return expression into a source-shape string, emits `classify.json` (one record per route).
2. **`surveyMetrics()` (pure) gains an optional `$classification` arg** — joins the source shapes with
   the spec's substantive-ness it already computes, and emits a `responseCoverage` block:
   `{substantive, correctlyEmpty, genuinelyMissing, genuinelyMissingByShape}`. The three buckets sum to
   `apiOperations`; `genuinelyMissing` is the real denominator to size future levers against. Emitted
   only when a classification is supplied; `completenessPercent` is kept untouched for continuity.
3. **`metrics.php` CLI** loads `classify.json` from the app dir when present.
4. **`completeness.php`** surfaces the three-way summary line when given `--classify=<classify.json>`.

Bucketing (per in-prefix op): substantive (spec) → substantive; else if the action's shape/return-type
is no-content (`void`/`never`, `return;`, `response()->noContent()`, `return null;`) → correctly-empty;
else → genuinely-missing (rolled up by shape; unmatched shapes count conservatively as genuinely-missing).

Harness-only — the library is not modified.

## Verify
- New tests in `tests/Tools/SurveyMetricsTest.php` for the three-way split + the no-classification path.
- `composer test`, `vendor/bin/pint --test`, `composer lint` green.

## Follow-up (separate)
Re-baseline the 11-app corpus on current main and use `genuinely-missing` to size levers (#411, #427).