### PR TITLE
fix(lint): share URI-placeholder extraction with the generator; fix {param:field} mishandling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to this project are documented here.
 - `--path` / `--diff` no longer leak findings for out-of-scope routes (#50).
 - `ValidationRulesToSchema` maps additional rules (`multiple_of`, Email/Exists/Unique/NotIn objects, wildcard keys) it previously dropped (#83).
 - ApiResources: actions that return an API Resource without declaring a return type (relying on convention or a third-party doc attribute) now resolve their response schema via the return-expression reader, instead of emitting no content; the refusal notice is suppressed on the untyped path to avoid a notice per non-resource action. (#391)
+- `path.parameter-undeclared` no longer false-positives on custom-key route bindings (`{param:field}`); URI-placeholder extraction is now shared between the generator and the linter. (#426)
 
 ### Documentation
 - README refreshed for the current feature set (Tier-1 method-body inference, SwaggerPhp plugin) and trimmed to a gentle overview that defers detail to `docs/`.

--- a/src/Lint/Rules/PathParameterUndeclared.php
+++ b/src/Lint/Rules/PathParameterUndeclared.php
@@ -12,11 +12,10 @@ use Radiergummi\OpenApi\Lint\LintContext;
 use Radiergummi\OpenApi\Lint\Tree\OperationNode;
 use Radiergummi\OpenApi\Lint\Tree\ParameterNode;
 use Radiergummi\OpenApi\Lint\Visitors\OperationRule as OperationRuleVisitor;
+use Radiergummi\OpenApi\Support\Routing\UriPlaceholderExtractor;
 
 use function array_map;
 use function in_array;
-use function ltrim;
-use function preg_match_all;
 use function sprintf;
 
 /**
@@ -72,16 +71,9 @@ final class PathParameterUndeclared implements Rule, OperationRuleVisitor
      */
     private function extractPlaceholders(string $pathUri): array
     {
-        if (preg_match_all("/\{([^?}]+)\??}/", $pathUri, $matches)) {
-            return array_map(
-                static fn(string $name): string => ltrim($name, '+#./;?&=,!@|'),
-                $matches[1],
-            );
-        }
-
-        return [];
+        return array_map(
+            static fn(array $placeholder): string => $placeholder[0],
+            UriPlaceholderExtractor::extract($pathUri),
+        );
     }
-
-
-
 }

--- a/src/Routing/ActionDescriptor.php
+++ b/src/Routing/ActionDescriptor.php
@@ -6,6 +6,7 @@ namespace Radiergummi\OpenApi\Routing;
 
 use Illuminate\Routing\Route;
 use Radiergummi\OpenApi\Enums\HttpMethod;
+use Radiergummi\OpenApi\Support\Routing\UriPlaceholderExtractor;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionFunction;
@@ -14,10 +15,7 @@ use ReflectionMethod;
 use ReflectionParameter;
 
 use function array_keys;
-use function explode;
 use function is_a;
-use function ltrim;
-use function preg_match_all;
 use function str_contains;
 
 /**
@@ -204,31 +202,11 @@ final class ActionDescriptor
     /**
      * Extracts every URI placeholder from the route template as `[bareName, optional]`.
      *
-     * The bare name strips both the binding-prefix characters Laravel allows (e.g. `{+slug}`) and a
-     * `{param:field}` custom-key suffix: the URI template variable is `param`, and Laravel keys its
-     * `wheres`/binding metadata on that bare name, so emitting or looking up `param:field` would be
-     * wrong on both counts.
-     *
      * @return list<array{string, bool}>
      */
     public function uriPlaceholders(): array
     {
-        if (preg_match_all('/\{([^?}]+)(\??)}/', $this->route->uri(), $matches) === 0) {
-            return [];
-        }
-
-        $placeholders = [];
-
-        foreach ($matches[1] as $index => $raw) {
-            $name = ltrim($raw, '+#./;?&=,!@|');
-            $bareName = str_contains($name, ':')
-                ? explode(':', $name, 2)[0]
-                : $name;
-
-            $placeholders[] = [$bareName, $matches[2][$index] === '?'];
-        }
-
-        return $placeholders;
+        return UriPlaceholderExtractor::extract($this->route->uri());
     }
 
     /**

--- a/src/Support/Routing/UriPlaceholderExtractor.php
+++ b/src/Support/Routing/UriPlaceholderExtractor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Routing;
+
+use function explode;
+use function ltrim;
+use function preg_match_all;
+use function str_contains;
+
+/**
+ * Extracts URI template placeholders from a route URI, shared by the generator and the linter.
+ *
+ * @internal
+ */
+final class UriPlaceholderExtractor
+{
+    /**
+     * Extracts every URI placeholder from the route template as `[bareName, optional]`.
+     *
+     * The bare name strips both the binding-prefix characters Laravel allows (e.g. `{+slug}`) and a
+     * `{param:field}` custom-key suffix: the URI template variable is `param`, and Laravel keys its
+     * `wheres`/binding metadata on that bare name, so emitting or looking up `param:field` would be
+     * wrong on both counts.
+     *
+     * @return list<array{string, bool}>
+     */
+    public static function extract(string $uri): array
+    {
+        if (preg_match_all('/\{([^?}]+)(\??)}/', $uri, $matches) === 0) {
+            return [];
+        }
+
+        $placeholders = [];
+
+        foreach ($matches[1] as $index => $raw) {
+            $name = ltrim($raw, '+#./;?&=,!@|');
+            $bareName = str_contains($name, ':')
+                ? explode(':', $name, 2)[0]
+                : $name;
+
+            $placeholders[] = [$bareName, $matches[2][$index] === '?'];
+        }
+
+        return $placeholders;
+    }
+}

--- a/tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php
+++ b/tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php
@@ -31,7 +31,27 @@ it('emits no finding when all placeholders are declared as path parameters', fun
     'single placeholder declared'      => ['/users/{userId}', ['userId']],
     'RFC 6570 operator-prefixed name'  => ['/files/{+path}', ['path']],
     'no placeholders at all'           => ['/users', []],
+    'custom-key binding {param:field}' => ['/members/{member:slug}', ['member']],
+    'custom-key + optional'            => ['/members/{member:slug?}', ['member']],
+    'operator prefix + custom key'     => ['/files/{+path:disk}', ['path']],
 ]);
+
+it('reports an undeclared custom-key placeholder under its bare name', function (): void {
+    $operation = OperationNodeFactory::makeOperation(
+        pathUri: '/members/{member:slug}',
+        parameters: [],
+        responses: [],
+    );
+
+    $findings = iterator_to_array(
+        new PathParameterUndeclared()->checkOperation($operation, OperationNodeFactory::emptyContext()),
+    );
+
+    expect($findings)
+        ->toHaveCount(1)
+        ->and($findings[0]->message)->toContain('"{member}"')
+        ->and($findings[0]->fixHint)->toContain('name="member"');
+});
 
 it('emits a finding for an undeclared path placeholder', function (): void {
     $operation = OperationNodeFactory::makeOperation(

--- a/tests/Unit/Support/Routing/UriPlaceholderExtractorTest.php
+++ b/tests/Unit/Support/Routing/UriPlaceholderExtractorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Support\Routing\UriPlaceholderExtractor;
+
+uses()->group('openapi', 'routing');
+
+it('extracts placeholders as [bareName, optional] pairs', function (string $uri, array $expected): void {
+    expect(UriPlaceholderExtractor::extract($uri))->toBe($expected);
+})->with([
+    'plain'                        => ['/users/{id}', [['id', false]]],
+    'optional'                     => ['/users/{id?}', [['id', true]]],
+    'operator prefix'              => ['/files/{+path}', [['path', false]]],
+    'custom key'                   => ['/members/{member:slug}', [['member', false]]],
+    'custom key + optional'        => ['/members/{member:slug?}', [['member', true]]],
+    'operator prefix + custom key' => ['/files/{+path:disk}', [['path', false]]],
+    'no placeholders'              => ['/users', []],
+    'multiple preserve order'      => [
+        '/users/{userId}/posts/{postId}',
+        [['userId', false], ['postId', false]],
+    ],
+]);


### PR DESCRIPTION
Closes #426

## Implementation plan — share URI-placeholder extraction + fix the linter's `{param:field}` mishandling

### The bug (verified)

`ActionDescriptor::uriPlaceholders()` (`src/Routing/ActionDescriptor.php:214`) is correct: it
`ltrim`s RFC-6570 operator prefixes **and** strips a `{param:field}` custom-key suffix
(`explode(':', $name, 2)[0]`), returning the bare URI variable name + an optional flag.

`PathParameterUndeclared::extractPlaceholders()` (`src/Lint/Rules/PathParameterUndeclared.php:73`)
duplicates the extraction but **only `ltrim`s the prefix** — it never strips `:field`. So for a
`{member:slug}` segment it yields `member:slug`, compares it against the declared `member`
parameter, never matches, and emits a **false `path.parameter-undeclared` "Broken" finding**.

Confirmed the linter genuinely sees the raw form: `PathsStage::normalisePath()`
(`src/Support/Generator/Stages/PathsStage.php:149`) only prepends a leading slash — it does **not**
strip `:field` — so the OpenAPI path key (and thus `OperationNode->pathUri`) retains
`/members/{member:slug}` while the declared parameter is correctly `member`. The mismatch is real.

### Tier

Not an inference change — a **refactor + bugfix**. No tier ladder involved. (Branch typed `fix/`.)

### Approach

Extract one shared utility that both the generator and the linter consume, made **behaviorally
identical to the generator's (correct) extractor**, then delete the two divergent copies. The
generator returns `[bareName, optional]`; the linter wants names only — so the shared utility
returns the richer `list<array{string, bool}>` and the linter projects column 0.

The utility lives in `src/Support/Routing/` (alongside the existing `UriParameterResolver`,
`RouteModelBinding`, etc.). `src/Support/` may not depend on plugins (it doesn't here) and the linter
(`src/Lint/`) and routing (`src/Routing/`) may both depend on `src/Support/` — placement is clean.

### Files

**Create** `src/Support/Routing/UriPlaceholderExtractor.php`:
- A `final readonly` class (or a final class with a single `public static` method — pick the
  instance-method form if it needs no state, matching the codebase's no-speculative-DI lean; a pure
  `public static function extract(string $uri): array` is the lightest fit and needs no container
  wiring for either consumer). **Decision: a stateless static method**, since both call sites already
  have the URI string in hand and neither needs DI. Lift the generator's exact logic:
  ```php
  /** @return list<array{string, bool}> [bareName, optional] per placeholder */
  public static function extract(string $uri): array
  ```
  matching the regex `/\{([^?}]+)(\??)}/`, the `ltrim($raw, '+#./;?&=,!@|')` prefix strip, and the
  `:`-suffix strip. Carry over the explanatory docblock from `uriPlaceholders()` verbatim (it already
  documents *why* both strips are needed).
  - **[reviewer] regex note:** adopting the generator's `/\{([^?}]+)(\??)}/` is behavior-preserving
    for the linter's *matching* set — its old regex `/\{([^?}]+)\??}/` has the identical `[^?}]+`
    name capture, so the same placeholders are matched. The only behavior that changes is the
    post-match processing (the linter now also gets the `:field` strip it was missing). No new
    placeholders start or stop being recognized.

**Modify** `src/Routing/ActionDescriptor.php`:
- `uriPlaceholders()` delegates: `return UriPlaceholderExtractor::extract($this->route->uri());`.
- Keep the method (it's the public surface `OperationBuilder` consumes via `[$name, $optional]`); the
  regex/loop move into the utility. The method docblock stays (or shrinks to a one-liner pointing at
  the utility). **No public-signature change** — same name, same return shape.

**Modify** `src/Lint/Rules/PathParameterUndeclared.php`:
- Replace the private `extractPlaceholders()` body with
  `array_map(static fn(array $p): string => $p[0], UriPlaceholderExtractor::extract($pathUri))`
  (names only). Drop the now-unused `ltrim` / `preg_match_all` imports; add the utility import.
  Remove the trailing blank lines (lines 84-87) only because they're inside the method block I'm
  editing — no unrelated cleanup.

No change to `OperationBuilder` (it already destructures `[$name, $optional]`, unchanged), no
contract change, no config key, no stage-order change.

### Public-signature check (lead asked)

No public signature changes. `ActionDescriptor::uriPlaceholders()` keeps its name and
`list<array{string, bool}>` return; `OperationBuilder` is untouched. The new utility is a new
`@internal` class, not a modification of an existing public one. → **not a human-gate item** on the
signature axis. (Still `area:core` + generation-touching → survey gate applies, see below.)

### Tests (the bug-reproducing test comes first — TDD)

**`tests/Unit/Lint/Rules/PathParameterUndeclaredTest.php`** — add to the existing
"emits no finding when all placeholders are declared" `->with()` dataset (it already uses
`pathUri` + `names`):
- **`custom-key binding {param:field}`** → `['/members/{member:slug}', ['member']]` — **this is the
  bug reproducer**: currently emits a false finding, must emit none.
- **custom-key + optional** → `['/members/{member:slug?}', ['member']]` (proves the `?` and `:field`
  compose).
- **operator-prefixed + custom-key** → `['/files/{+path:disk}', ['path']]` (both strips at once).
- Add one **positive** case proving a genuinely-undeclared custom-key segment *still* reports under
  the bare name: `/members/{member:slug}` with **no** declared parameter → one finding whose message
  contains `member` (not `member:slug`).

**`tests/Unit/Support/Routing/UriPlaceholderExtractorTest.php`** (new) — unit-test the utility
directly so its contract is locked independent of either consumer:
- plain `{id}` → `[['id', false]]`; optional `{id?}` → `[['id', true]]`;
- operator prefix `{+path}` → `[['path', false]]`;
- custom key `{member:slug}` → `[['member', false]]`; custom-key + optional `{member:slug?}` →
  `[['member', true]]`;
- multiple segments in one URI preserve order;
- no placeholders → `[]`;
- a `:`-bearing name with an operator prefix `{+path:disk}` → `[['path', false]]` (strip order).

**Regression guard:** the existing `ActionDescriptorTest` and `CustomKeyBindingTest` /
`UnsignaturedPathParameterTest` must stay green (they pin `uriPlaceholders()` / generated-parameter
naming, proving the delegation is behavior-preserving on the generator side).

### Docs & CHANGELOG

- No `docs/` page documents the placeholder-extraction internals or this lint rule's edge behavior
  beyond the catalog row, so **no docs page change** (the `path.parameter-undeclared` catalog row in
  `docs/linting.md` is unchanged — same id, same meaning). If the reviewer's docs-gap duty disagrees,
  a one-line note in the rule catalog is the most that's warranted.
- `CHANGELOG.md [Unreleased] → Fixed`: "`path.parameter-undeclared` no longer false-positives on
  custom-key route bindings (`{param:field}`); URI-placeholder extraction is now shared between the
  generator and the linter." Reference `#426`. (Add a `### Fixed` subsection if absent under
  `[Unreleased]`.)

### Out of scope (surgical boundary)

- The OpenAPI **path key** still emits `/members/{member:slug}` (raw) while declaring a `member`
  parameter — normalizing the path string itself to `{member}` is a **separate** concern (would
  change generated output / snapshots and is not what this issue asks). Flagged, not done.
- `resolveUriParameters()` in `ActionDescriptor` (signature-binding match) is untouched — it keys off
  exact `{name}` / `{name?}` substring presence, a different mechanism, not part of this bug.

### Human-gate flags for the lead

- **Low controversy:** no contracts/config/stage-order/public-signature change; a new `@internal`
  utility + two delegations + a bugfix.
- `area:core` and the change touches the generator's `uriPlaceholders()` path → **survey gate
  applies**. Expectation: **zero spec diff** across the corpus (the generator already used the correct
  logic; only the linter behavior changes), so a flat Layer-A survey is the success signal. Worth a
  glance that no corpus app's generated paths shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
