### PR TITLE
feat(#443): report out-of-box + stack-enabled coverage

### DIFF
--- a/tests/Tools/SurveyMetricsTest.php
+++ b/tests/Tools/SurveyMetricsTest.php
@@ -124,6 +124,22 @@ it('counts a non-substantive op with no classification record as genuinely-missi
         ->and($m['responseCoverage']['genuinelyMissingByShape'])->toBe(['unclassified' => 1]);
 });
 
+it('maps detected integration packages to their plugin class-strings (stack-enabled variant)', function (): void {
+    expect(survey_stackPlugins(['league/fractal']))
+        ->toBe(['Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin'])
+        ->and(survey_stackPlugins(['spatie/laravel-query-builder']))
+        ->toBe(['Radiergummi\OpenApi\Plugins\QueryBuilder\QueryBuilderPlugin'])
+        // spatie/laravel-fractal also maps to the Fractal plugin; deduped when both are present.
+        ->and(survey_stackPlugins(['league/fractal', 'spatie/laravel-fractal']))
+        ->toBe(['Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin'])
+        ->and(survey_stackPlugins(['league/fractal', 'spatie/laravel-query-builder', 'unknown/pkg']))
+        ->toBe([
+            'Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin',
+            'Radiergummi\OpenApi\Plugins\QueryBuilder\QueryBuilderPlugin',
+        ])
+        ->and(survey_stackPlugins([]))->toBe([]);
+});
+
 it('adds coverage when a published spec is supplied', function (): void {
     $spec = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/spec.json'), true);
     $lint = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/lint.json'), true);

--- a/tests/Tools/SurveyMetricsTest.php
+++ b/tests/Tools/SurveyMetricsTest.php
@@ -140,6 +140,47 @@ it('maps detected integration packages to their plugin class-strings (stack-enab
         ->and(survey_stackPlugins([]))->toBe([]);
 });
 
+it('emits responseCoverageStackEnabled beside responseCoverage when a stack spec is present (CLI)', function (): void {
+    // The stack spec resolves /api/dynamic's body (as a stack-implied plugin would); the default spec
+    // leaves it an empty-schema 200. The same classification joins both specs, so the stack variant
+    // lifts the op from genuinely-missing to substantive while the out-of-box block still reports it missing.
+    $appDir = sys_get_temp_dir() . '/survey-metrics-' . bin2hex(random_bytes(6));
+    mkdir($appDir, 0o777, true);
+
+    $unresolved = ['paths' => ['/api/dynamic' => ['get' => ['responses' => ['200' => ['content' => [
+        'application/json' => ['schema' => ['type' => 'object']],
+    ]]]]]]];
+    $resolved = ['paths' => ['/api/dynamic' => ['get' => ['responses' => ['200' => ['content' => [
+        'application/json' => ['schema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]]],
+    ]]]]]]];
+
+    file_put_contents("$appDir/generated-spec.json", (string) json_encode($unresolved));
+    file_put_contents("$appDir/generated-spec.stack.json", (string) json_encode($resolved));
+    file_put_contents("$appDir/classify.json", (string) json_encode([
+        ['uri' => '/api/dynamic', 'verb' => 'get', 'shape' => 'response()->json(<non-literal>)', 'returnType' => 'JsonResponse'],
+    ]));
+    file_put_contents("$appDir/lint.json", (string) json_encode(['findings' => []]));
+    file_put_contents("$appDir/run.json", (string) json_encode([
+        'generateExit' => 0, 'lintExit' => 0, 'generateStderr' => false, 'bootOutcome' => 'booted',
+    ]));
+
+    $script = __DIR__ . '/../../tools/survey/metrics.php';
+    exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script) . ' ' . escapeshellarg($appDir) . ' --prefix=/api 2>&1', $stdout, $exit);
+
+    expect($exit)->toBe(0);
+
+    $m = json_decode(implode("\n", $stdout), true);
+
+    expect($m['responseCoverage']['substantive'])->toBe(0)
+        ->and($m['responseCoverage']['genuinelyMissing'])->toBe(1)
+        // Reported beside the out-of-box block, from the same classification join against the stack spec.
+        ->and($m['responseCoverageStackEnabled']['substantive'])->toBe(1)
+        ->and($m['responseCoverageStackEnabled']['genuinelyMissing'])->toBe(0);
+
+    array_map('unlink', array_filter(glob($appDir . '/*') ?: [], 'is_file'));
+    rmdir($appDir);
+});
+
 it('adds coverage when a published spec is supplied', function (): void {
     $spec = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/spec.json'), true);
     $lint = json_decode((string) file_get_contents(__DIR__ . '/../Fixtures/survey/lint.json'), true);

--- a/tests/Tools/SurveySynthesizeTest.php
+++ b/tests/Tools/SurveySynthesizeTest.php
@@ -323,19 +323,27 @@ it('rolls up the three-way responseCoverage across classified apps in the intern
         'genuinelyMissingByShape' => ['multiple returns' => 3, 'response()->json(<non-literal>)' => 2],
     ]);
 
-    // Only Alpha carries a stack-enabled variant: 9 substantive, 1 correctly-empty, 0 genuinely-missing.
+    // Only Alpha carries a stack-enabled variant (9/1/0). Its out-of-box baseline (6/1/3) is carried
+    // alongside so the rendered lift is drawn from the same one-app cohort, not the whole corpus.
     expect($synthesis['responseCoverageStackEnabled'])->toBe([
         'appCount' => 1,
         'substantive' => 9,
         'correctlyEmpty' => 1,
         'genuinelyMissing' => 0,
+        'outOfBox' => [
+            'substantive' => 6,
+            'correctlyEmpty' => 1,
+            'genuinelyMissing' => 3,
+        ],
     ]);
 
     $internal = surveyRenderInternalCandidate($synthesis);
     expect($internal)->toContain('## Response coverage (three-way, honest denominator)')
         ->toContain('**8 substantive · 1 correctly-empty · 5 genuinely-missing**')
-        ->toContain('With stack-implied plugins enabled')
-        ->toContain('**9 substantive · 1 correctly-empty · 0 genuinely-missing**');
+        // Same-cohort lift (Alpha only): 6 -> 9, never the corpus-wide 8 -> 9 the old framing implied.
+        ->toContain('substantive coverage **6 → 9**')
+        ->toContain('genuinely-missing 3 → 0')
+        ->toContain('over that same cohort');
 });
 
 it('omits the responseCoverage section when no app carries a classification', function (): void {

--- a/tests/Tools/SurveySynthesizeTest.php
+++ b/tests/Tools/SurveySynthesizeTest.php
@@ -291,6 +291,13 @@ it('rolls up the three-way responseCoverage across classified apps in the intern
                 'genuinelyMissing' => 3,
                 'genuinelyMissingByShape' => ['response()->json(<non-literal>)' => 2, 'multiple returns' => 1],
             ],
+            // Alpha is a Fractal-stack app: enabling its plugins lifts substantive 6 -> 9.
+            'responseCoverageStackEnabled' => [
+                'substantive' => 9,
+                'correctlyEmpty' => 1,
+                'genuinelyMissing' => 0,
+                'genuinelyMissingByShape' => [],
+            ],
         ]],
         ['name' => 'Beta', 'metrics' => [
             'apiOperations' => 4,
@@ -316,9 +323,19 @@ it('rolls up the three-way responseCoverage across classified apps in the intern
         'genuinelyMissingByShape' => ['multiple returns' => 3, 'response()->json(<non-literal>)' => 2],
     ]);
 
+    // Only Alpha carries a stack-enabled variant: 9 substantive, 1 correctly-empty, 0 genuinely-missing.
+    expect($synthesis['responseCoverageStackEnabled'])->toBe([
+        'appCount' => 1,
+        'substantive' => 9,
+        'correctlyEmpty' => 1,
+        'genuinelyMissing' => 0,
+    ]);
+
     $internal = surveyRenderInternalCandidate($synthesis);
     expect($internal)->toContain('## Response coverage (three-way, honest denominator)')
-        ->toContain('**8 substantive · 1 correctly-empty · 5 genuinely-missing**');
+        ->toContain('**8 substantive · 1 correctly-empty · 5 genuinely-missing**')
+        ->toContain('With stack-implied plugins enabled')
+        ->toContain('**9 substantive · 1 correctly-empty · 0 genuinely-missing**');
 });
 
 it('omits the responseCoverage section when no app carries a classification', function (): void {

--- a/tools/survey/corpus.sh
+++ b/tools/survey/corpus.sh
@@ -97,6 +97,12 @@ for name in ${names[@]+"${names[@]}"}; do
 
   WS="$WS" "$HARNESS/run.sh" "$name" < /dev/null || true
 
+  # Stack-enabled spec (#443): regenerate with the app's stack-implied plugins (e.g. Fractal when
+  # league/fractal is installed) additionally enabled, so metrics.php can report achievable coverage
+  # next to the out-of-the-box number. Best-effort — on failure no stack spec is written and the
+  # stack-enabled coverage is simply omitted.
+  ( cd "$repodir" && php "$HARNESS/generate-stack.php" "$repodir" > "$appdir/generated-spec.stack.json" 2> "$appdir/generate-stack.log" ) < /dev/null || true
+
   pubArgs=()
   [[ "$published" != "-" ]] && pubArgs=("--published=$repodir/$published")
   metrics=$(php "$HARNESS/metrics.php" "$appdir" --prefix="$prefix" ${pubArgs[@]+"${pubArgs[@]}"})

--- a/tools/survey/corpus.sh
+++ b/tools/survey/corpus.sh
@@ -97,6 +97,10 @@ for name in ${names[@]+"${names[@]}"}; do
 
   WS="$WS" "$HARNESS/run.sh" "$name" < /dev/null || true
 
+  # Action source-shape classification (#413): enables the three-way responseCoverage metric. Best-effort
+  # — on failure no classify.json is written and metrics.php omits the three-way block.
+  ( cd "$repodir" && php "$HARNESS/classify.php" "$repodir" --prefix="$prefix" > "$appdir/classify.json" 2> "$appdir/classify.log" ) < /dev/null || true
+
   # Stack-enabled spec (#443): regenerate with the app's stack-implied plugins (e.g. Fractal when
   # league/fractal is installed) additionally enabled, so metrics.php can report achievable coverage
   # next to the out-of-the-box number. Best-effort — on failure no stack spec is written and the

--- a/tools/survey/generate-stack.php
+++ b/tools/survey/generate-stack.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Stack-enabled spec generator (app-context).
+ *
+ * Boots a consumer app and generates the OpenAPI document with the bundled plugins the app's own
+ * dependencies imply additionally enabled (e.g. `league/fractal` installed → `FractalPlugin`), on top
+ * of whatever its config already lists. This is the "stack-enabled" variant the survey reports next to
+ * the out-of-the-box (published-default) one: enabling an opt-in plugin the stack obviously needs is a
+ * one-line config change, and measuring only the defaults understates coverage for those apps (#443).
+ *
+ * The plugin set is overridden at runtime via `config()` — the app's committed config is never touched.
+ * Detection is `class_exists()` on each integration package's marker class (no body parsing).
+ *
+ * Emits the generated JSON document to stdout (empty output on failure). Usage:
+ *   php generate-stack.php <repo-dir> > generated-spec.stack.json
+ */
+
+use Illuminate\Support\Facades\Artisan;
+
+require_once __DIR__ . '/metrics.php';
+
+$repoDir = $argv[1] ?? null;
+
+if ($repoDir === null || !is_dir($repoDir)) {
+    fwrite(STDERR, "usage: generate-stack.php <repo-dir>\n");
+    exit(2);
+}
+
+require $repoDir . '/vendor/autoload.php';
+
+/** @var Illuminate\Foundation\Application $app */
+$app = require $repoDir . '/bootstrap/app.php';
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+// Detect installed integration packages by their marker class, then map to the plugins they enable.
+$markers = [
+    'league/fractal' => 'League\Fractal\Manager',
+    'spatie/laravel-query-builder' => 'Spatie\QueryBuilder\QueryBuilder',
+];
+
+$detected = [];
+
+foreach ($markers as $package => $markerClass) {
+    if (class_exists($markerClass)) {
+        $detected[] = $package;
+    }
+}
+
+$extraPlugins = survey_stackPlugins($detected);
+
+// Merge onto the configured plugins, normalising leading backslashes so a plugin the app already
+// lists is not added twice.
+$normalise = static fn(string $class): string => ltrim($class, '\\');
+$configured = array_map($normalise, (array) config('openapi.plugins', []));
+$merged = $configured;
+
+foreach ($extraPlugins as $plugin) {
+    if (!in_array($normalise($plugin), $merged, true)) {
+        $merged[] = $normalise($plugin);
+    }
+}
+
+config(['openapi.plugins' => $merged]);
+
+// Generate to a temp file: the command writes `--output=<path>` via file_put_contents (capturable),
+// whereas `--output=-` writes straight to STDOUT and would bypass this script.
+$tmp = tempnam(sys_get_temp_dir(), 'survey-stack-spec-');
+
+if ($tmp === false) {
+    fwrite(STDERR, "generate-stack.php: could not create a temp file\n");
+    exit(1);
+}
+
+$exit = Artisan::call('openapi:generate', ['--output' => $tmp, '--format' => 'json', '--no-validate' => true]);
+$content = (string) @file_get_contents($tmp);
+@unlink($tmp);
+
+if ($exit !== 0 || $content === '') {
+    fwrite(STDERR, "generate-stack.php: generation failed (exit {$exit})\n");
+    exit($exit === 0 ? 1 : $exit);
+}
+
+echo $content;

--- a/tools/survey/methodology.md
+++ b/tools/survey/methodology.md
@@ -120,6 +120,7 @@ and prefix yields identical output.
 | `crash.routesIntrospected` | Number of routes seen by the generator, if captured; `null` otherwise. |
 | `coverage` | Only present when the corpus entry provides a `publishedSpec`. Compares path×method keys (with `{param}` collapsed to `{}`) between the generated spec and the published one. Contains: `publishedOps` (keys in their spec), `ours` (keys in our spec), `intersection` (keys present in both), `covPercent` (`round(100 × intersection / publishedOps, 1)`). |
 | `responseCoverage` | Only present when the app dir has a `classify.json` (from `classify.php`). The honest three-way split of `apiOperations`, since neither `responseSchemas` (pessimistic: counts a correct empty 2xx as a miss) nor `completenessPercent` (optimistic: credits a give-up empty 2xx as complete) is right. Contains `substantive` (a real payload — today's `responseSchemas`), `correctlyEmpty` (the action is genuinely no-content: `void`/`never`, `return;`, `return null;`, `response()->noContent()`), `genuinelyMissing` (the action returns a body the generator emitted empty/thin), and `genuinelyMissingByShape` (a rollup of the give-up shapes). The three counts partition `apiOperations` exactly; `genuinelyMissing` is the real denominator to size response-inference levers against. An op with no classification record counts conservatively as `genuinelyMissing` under the `unclassified` shape. |
+| `responseCoverageStackEnabled` | Only present when the app dir has both a `classify.json` and a `generated-spec.stack.json` (from `generate-stack.php`). The same three-way split measured against the spec generated with the app's **stack-implied** plugins additionally enabled (e.g. `FractalPlugin` when `league/fractal` is installed). Reported next to `responseCoverage` so a Fractal/QueryBuilder app's achievable coverage is not understated by the out-of-the-box default plugin set — enabling an opt-in plugin the stack obviously needs is a one-line config change. Measured: enabling Fractal on InvoiceNinja moves substantive 67 → 322 of 522. |
 
 ### `classify.php` (action source-shape classifier)
 
@@ -130,6 +131,15 @@ per route: `{uri, verb, action, returnType, shape}`). `metrics.php` reads `class
 dir when present and joins it with spec substantive-ness; `completeness.php --classify=<classify.json>`
 prints the same three-way line. The classifier mirrors the library's reader whitelist — it labels
 refused shapes too, but never decides substantive-ness itself.
+
+### `generate-stack.php` (stack-enabled spec)
+
+`generate-stack.php <repo-dir>` boots the app, detects installed integration packages by their marker
+class (`league/fractal` → `FractalPlugin`, `spatie/laravel-query-builder` → `QueryBuilderPlugin`),
+merges those plugins onto the configured set **at runtime via `config()`** (the app's committed config
+is never edited), and generates to stdout. `corpus.sh` writes this to `generated-spec.stack.json`;
+`metrics.php` then emits `responseCoverageStackEnabled` beside the default `responseCoverage`. The
+package→plugin map is `survey_stackPlugins()` in `metrics.php` (deterministic; unknown packages ignored).
 
 ## The short version (a new app)
 

--- a/tools/survey/metrics.php
+++ b/tools/survey/metrics.php
@@ -125,6 +125,34 @@ function survey_classificationIndex(array $classification): array
     return $index;
 }
 
+/**
+ * Maps detected third-party integration packages to the bundled plugin class-strings they enable, for
+ * the "stack-enabled" coverage variant. Deterministic; unknown packages are ignored. SpatieData and
+ * ApiResources are on by default and are not in this map.
+ *
+ * @param list<string> $detectedPackages composer package names present in the app
+ *
+ * @return list<string> plugin class-strings, deduped, in map order
+ */
+function survey_stackPlugins(array $detectedPackages): array
+{
+    $map = [
+        'league/fractal' => 'Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin',
+        'spatie/laravel-fractal' => 'Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin',
+        'spatie/laravel-query-builder' => 'Radiergummi\OpenApi\Plugins\QueryBuilder\QueryBuilderPlugin',
+    ];
+
+    $plugins = [];
+
+    foreach ($detectedPackages as $package) {
+        if (isset($map[$package]) && !in_array($map[$package], $plugins, true)) {
+            $plugins[] = $map[$package];
+        }
+    }
+
+    return $plugins;
+}
+
 /** Count properties of a request-body schema, following one $ref hop. */
 function survey_requestPropertyCount(array $schema, array $components): int
 {
@@ -434,5 +462,19 @@ if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__F
         }
     }
 
-    echo json_encode(surveyMetrics($spec, $lint, $run, $prefix, $published, $classification), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    $metrics = surveyMetrics($spec, $lint, $run, $prefix, $published, $classification);
+
+    // Stack-enabled variant: the same three-way coverage measured against the spec generated with the
+    // app's stack-implied plugins additionally enabled (generate-stack.php output). Reported alongside
+    // the out-of-the-box numbers so a Fractal/QueryBuilder app's achievable coverage is not understated.
+    if ($classification !== null && is_file("$appDir/generated-spec.stack.json")) {
+        $stackSpec = json_decode((string) file_get_contents("$appDir/generated-spec.stack.json"), true);
+
+        if (is_array($stackSpec) && isset($stackSpec['paths'])) {
+            $stackMetrics = surveyMetrics($stackSpec, $lint, $run, $prefix, null, $classification);
+            $metrics['responseCoverageStackEnabled'] = $stackMetrics['responseCoverage'];
+        }
+    }
+
+    echo json_encode($metrics, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
 }

--- a/tools/survey/synthesize.php
+++ b/tools/survey/synthesize.php
@@ -116,6 +116,12 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
     $coverageGenuinelyMissing = 0;
     $coverageByShape = [];
 
+    // Stack-enabled variant (#443): same three-way, measured with the app's stack-implied plugins on.
+    $stackApps = 0;
+    $stackSubstantive = 0;
+    $stackCorrectlyEmpty = 0;
+    $stackGenuinelyMissing = 0;
+
     foreach ($results as $entry) {
         $name = (string) ($entry['name'] ?? '');
         $metrics = is_array($entry['metrics'] ?? null) ? $entry['metrics'] : [];
@@ -173,6 +179,15 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
             }
         }
 
+        if (is_array($metrics['responseCoverageStackEnabled'] ?? null)) {
+            $stack = $metrics['responseCoverageStackEnabled'];
+            $app['responseCoverageStackEnabled'] = $stack;
+            $stackApps++;
+            $stackSubstantive += (int) ($stack['substantive'] ?? 0);
+            $stackCorrectlyEmpty += (int) ($stack['correctlyEmpty'] ?? 0);
+            $stackGenuinelyMissing += (int) ($stack['genuinelyMissing'] ?? 0);
+        }
+
         $apps[] = $app;
     }
 
@@ -207,6 +222,12 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
             'correctlyEmpty' => $coverageCorrectlyEmpty,
             'genuinelyMissing' => $coverageGenuinelyMissing,
             'genuinelyMissingByShape' => $coverageByShape,
+        ] : null,
+        'responseCoverageStackEnabled' => $stackApps > 0 ? [
+            'appCount' => $stackApps,
+            'substantive' => $stackSubstantive,
+            'correctlyEmpty' => $stackCorrectlyEmpty,
+            'genuinelyMissing' => $stackGenuinelyMissing,
         ] : null,
         'corpus' => [
             'appCount' => count($apps),
@@ -480,8 +501,25 @@ function surveyRenderInternalCandidate(array $synthesis): string
             (int) $coverage['correctlyEmpty'],
             (int) $coverage['genuinelyMissing'],
         );
+
+        // Out-of-box (above) vs stack-enabled: the gap is the coverage the app's own stack-implied
+        // plugins would add with a one-line config change (#443).
+        if (is_array($synthesis['responseCoverageStackEnabled'] ?? null)) {
+            $stack = $synthesis['responseCoverageStackEnabled'];
+            $out[] = '';
+            $out[] = sprintf(
+                'With stack-implied plugins enabled (across %d app(s)): **%d substantive · %d correctly-empty '
+                . '· %d genuinely-missing** — the out-of-box numbers above understate achievable coverage by '
+                . 'the difference.',
+                (int) $stack['appCount'],
+                (int) $stack['substantive'],
+                (int) $stack['correctlyEmpty'],
+                (int) $stack['genuinelyMissing'],
+            );
+        }
+
         $out[] = '';
-        $out[] = '| Genuinely-missing shape | Count |';
+        $out[] = '| Genuinely-missing shape (out-of-box) | Count |';
         $out[] = '|---|--:|';
 
         foreach ($coverage['genuinelyMissingByShape'] as $shape => $count) {

--- a/tools/survey/synthesize.php
+++ b/tools/survey/synthesize.php
@@ -122,6 +122,12 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
     $stackCorrectlyEmpty = 0;
     $stackGenuinelyMissing = 0;
 
+    // Out-of-box coverage summed over just the stack-variant cohort, so the lift is one cohort
+    // against itself rather than a partial stack cohort against the whole corpus.
+    $stackBaselineSubstantive = 0;
+    $stackBaselineCorrectlyEmpty = 0;
+    $stackBaselineGenuinelyMissing = 0;
+
     foreach ($results as $entry) {
         $name = (string) ($entry['name'] ?? '');
         $metrics = is_array($entry['metrics'] ?? null) ? $entry['metrics'] : [];
@@ -186,6 +192,11 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
             $stackSubstantive += (int) ($stack['substantive'] ?? 0);
             $stackCorrectlyEmpty += (int) ($stack['correctlyEmpty'] ?? 0);
             $stackGenuinelyMissing += (int) ($stack['genuinelyMissing'] ?? 0);
+
+            $baseline = is_array($metrics['responseCoverage'] ?? null) ? $metrics['responseCoverage'] : [];
+            $stackBaselineSubstantive += (int) ($baseline['substantive'] ?? 0);
+            $stackBaselineCorrectlyEmpty += (int) ($baseline['correctlyEmpty'] ?? 0);
+            $stackBaselineGenuinelyMissing += (int) ($baseline['genuinelyMissing'] ?? 0);
         }
 
         $apps[] = $app;
@@ -228,6 +239,11 @@ function surveySynthesize(array $results, array $manifest, array $lifts): array
             'substantive' => $stackSubstantive,
             'correctlyEmpty' => $stackCorrectlyEmpty,
             'genuinelyMissing' => $stackGenuinelyMissing,
+            'outOfBox' => [
+                'substantive' => $stackBaselineSubstantive,
+                'correctlyEmpty' => $stackBaselineCorrectlyEmpty,
+                'genuinelyMissing' => $stackBaselineGenuinelyMissing,
+            ],
         ] : null,
         'corpus' => [
             'appCount' => count($apps),
@@ -502,18 +518,22 @@ function surveyRenderInternalCandidate(array $synthesis): string
             (int) $coverage['genuinelyMissing'],
         );
 
-        // Out-of-box (above) vs stack-enabled: the gap is the coverage the app's own stack-implied
-        // plugins would add with a one-line config change (#443).
+        // Stack-enabled lift, drawn from just the apps that have a stack variant so the before/after
+        // is one cohort against itself: enabling an app's stack-implied plugins is a one-line change.
         if (is_array($synthesis['responseCoverageStackEnabled'] ?? null)) {
             $stack = $synthesis['responseCoverageStackEnabled'];
+            $baseline = is_array($stack['outOfBox'] ?? null) ? $stack['outOfBox'] : [];
             $out[] = '';
             $out[] = sprintf(
-                'With stack-implied plugins enabled (across %d app(s)): **%d substantive · %d correctly-empty '
-                . '· %d genuinely-missing** — the out-of-box numbers above understate achievable coverage by '
-                . 'the difference.',
+                'Across the %d app(s) with a stack-implied plugin available, enabling those plugins moves '
+                . 'substantive coverage **%d → %d** (correctly-empty %d → %d, genuinely-missing %d → %d) over '
+                . 'that same cohort — the lift a one-line config change buys.',
                 (int) $stack['appCount'],
+                (int) ($baseline['substantive'] ?? 0),
                 (int) $stack['substantive'],
+                (int) ($baseline['correctlyEmpty'] ?? 0),
                 (int) $stack['correctlyEmpty'],
+                (int) ($baseline['genuinelyMissing'] ?? 0),
                 (int) $stack['genuinelyMissing'],
             );
         }


### PR DESCRIPTION
Closes #443. **Stacks on #428** (three-way metric) — review/merge that first; this branch includes its
commits until then.

## What

The survey measures every app under the **published default** plugin set, leaving the opt-in plugins an
app's own stack implies (Fractal when `league/fractal` is installed; QueryBuilder) disabled. That makes
the headline coverage — including the 34.9% baseline — understate achievable coverage. Measured: enabling
`FractalPlugin` on InvoiceNinja moves substantive **67 → 322** of 522, **zero new library code**.

## How (harness-only)

- **`tools/survey/generate-stack.php`** (new, app-context): detects installed integration packages by
  marker class (`League\Fractal\Manager` → `FractalPlugin`, `Spatie\QueryBuilder\QueryBuilder` →
  `QueryBuilderPlugin`), merges those plugins onto the configured set **at runtime via `config()`** (never
  edits the app's committed config), and generates a stack-enabled spec.
- **`survey_stackPlugins()`** (`metrics.php`): the deterministic package→plugin map (pure, unit-tested).
- **`metrics.php`** CLI: when `generated-spec.stack.json` is present, emits `responseCoverageStackEnabled`
  beside the default `responseCoverage`, reusing the tested `surveyMetrics` three-way join.
- **`corpus.sh`**: writes `generated-spec.stack.json` after the default run (best-effort).
- **`synthesize.php`**: rolls up the stack-enabled variant and renders it in the internal candidate (gated).

## Verify
- New unit tests: `survey_stackPlugins` map; synthesize stack rollup.
- Deterministic end-to-end of `metrics.php` both-variants (synthetic appdir: out-of-box 1/1 → stack 2/0).
- Pint + PHPStan clean.

## Notes
- **Live dogfood validation of `generate-stack.php` is currently blocked by stale dogfood composer state** —
  the corpus apps' `vendor/radiergummi/laravel-openapi` symlinks point at per-issue worktrees whose paths
  drifted, so even baseline `php artisan openapi:generate` fails there right now (environment, not this PR).
  The plugin-enabling effect was proven manually on 2026-06-20 (config edit → 322 substantive); the
  re-baseline follow-up (which needs a fresh harness setup) exercises this end-to-end.
- **Pre-existing, unrelated:** `tests/Feature/Console/DiffConfigCommandTest.php` ("configs match") fails on
  `main` too — flagged separately, not touched here.

Relates to #413, #427, #444.