### PR TITLE
feat(cli): diagnose installed-but-disabled plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ All notable changes to this project are documented here.
 - A `FormRequest` type-hinted on a GET/HEAD action now surfaces its `rules()` as query parameters (wire notation) instead of a request body, matching the inline `validate()` behaviour and avoiding a discouraged GET request body; the same FormRequest on POST/PUT/PATCH still emits a request body, and DELETE is unchanged (no body, no query params). Unreadable `rules()` degrades to no parameters with a generation-log note. (#417)
 - Response schemas derived from Eloquent models now mark the primary key (`getKeyName()`), the timestamp columns (`created_at` / `updated_at`), and the soft-delete column (`deleted_at`, when the model uses `SoftDeletes`) `readOnly: true`; these are server-managed and a client never sets them. Nothing else gains the keyword, and an authored `readOnly` is never overwritten. (#419)
 - Inferred response headers (Tier-0): a `201` response gets a `Location` header (`string`, `uri-reference`), and `throttle` middleware adds `X-RateLimit-Limit` / `X-RateLimit-Remaining` (`integer`) to the success response. An authored `#[ResponseHeader]` of the same name wins. (#420)
+- `openapi:generate` emits an advisory hint on stderr when an integration package (`league/fractal`, `spatie/laravel-fractal`, `spatie/laravel-query-builder`) is installed but its plugin is not enabled, pointing at the `config/openapi.php` line that would let it infer schemas and parameters. Advisory only: never auto-enables, never pollutes the `--output=-` document. (#444)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -17,6 +17,15 @@ package or convention. Six plugins ship with the package:
 Plugins are listed in `config/openapi.plugins` and resolved from the
 container, in declaration order, after Core registers.
 
+### Installed-but-disabled hints
+
+When an integration package (`league/fractal` / `spatie/laravel-fractal`,
+`spatie/laravel-query-builder`) is installed but its plugin is not enabled,
+`openapi:generate` prints a one-line advisory on stderr pointing you at the
+config line that would let it infer schemas and parameters from that package.
+The hint is advisory only: nothing is ever auto-enabled, and the document
+written to stdout under `--output=-` stays untouched.
+
 To write your own, see [Plugin authoring](plugin-authoring.md).
 
 ## SpatieData

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
+use Radiergummi\OpenApi\Support\Diagnostics\PluginHintInspector;
 use Radiergummi\OpenApi\Support\Generator\OpenApiGenerationOrchestrator;
 use Radiergummi\OpenApi\Support\Inclusion\InclusionEvaluator;
 use Radiergummi\OpenApi\Support\Routing\RouteIntrospector;
@@ -17,16 +20,21 @@ use Radiergummi\OpenApi\Support\Spec\SpecRegistry;
 use ReflectionException;
 use RuntimeException;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\TypeInfo\Exception\UnsupportedException;
 use Throwable;
 use UnexpectedValueException;
 
 use function app;
+use function array_filter;
+use function array_values;
+use function config;
 use function count;
 use function dirname;
 use function file_put_contents;
 use function fwrite;
 use function in_array;
+use function is_string;
 use function is_writable;
 use function realpath;
 
@@ -59,6 +67,7 @@ class GenerateCommand extends Command
         SpecRegistry $registry,
         InclusionEvaluator $evaluator,
         RouteIntrospector $introspector,
+        PluginHintInspector $pluginHints,
     ): int {
         $specName = $this->argument('spec');
         $outputOverride = $this->option('output');
@@ -83,6 +92,8 @@ class GenerateCommand extends Command
         if ($explain) {
             $this->emitExplain($evaluator, $introspector, $registry->all());
         }
+
+        $this->emitPluginHints($pluginHints);
 
         foreach ($targets as $spec) {
             $document = $orchestrator->generateOne($spec->name, app()->environment());
@@ -113,6 +124,44 @@ class GenerateCommand extends Command
     }
 
     // region Private helpers
+
+    /**
+     * Prints an advisory once per applicable integration package, on stderr so the document a
+     * subsequent `--output=-` writes to stdout stays parseable. Advisory only: never auto-enables.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function emitPluginHints(PluginHintInspector $pluginHints): void
+    {
+        $enabledPlugins = array_values(array_filter(
+            (array) config('openapi.plugins', []),
+            static fn(mixed $plugin): bool => is_string($plugin),
+        ));
+
+        $hints = $pluginHints->hints($enabledPlugins);
+
+        if ($hints === []) {
+            return;
+        }
+
+        $components = new Factory($this->errorOutput());
+
+        foreach ($hints as $hint) {
+            $components->warn($hint);
+        }
+    }
+
+    /**
+     * Wraps the command's error stream in an {@see OutputStyle} so console-component output lands on
+     * stderr. Falls back to the regular output when no separate error stream is available.
+     */
+    private function errorOutput(): OutputStyle
+    {
+        $output = $this->output->getOutput();
+        $errorStream = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+
+        return new OutputStyle($this->input, $errorStream);
+    }
 
     /**
      * @param list<SpecDefinition> $specs

--- a/src/OpenApiServiceProvider.php
+++ b/src/OpenApiServiceProvider.php
@@ -33,9 +33,12 @@ use Radiergummi\OpenApi\Plugins\Core\Envelopes\NoneEnvelope;
 use Radiergummi\OpenApi\Plugins\Core\Envelopes\Rfc7807Envelope;
 use Radiergummi\OpenApi\Plugins\Core\Resolvers\PaginatorResponseResolver;
 use Radiergummi\OpenApi\Plugins\Core\Support\PaginatorSchemaFactory;
+use Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin;
 use Radiergummi\OpenApi\Plugins\Fractal\Resolvers\TransformerRefSchemaResolver;
 use Radiergummi\OpenApi\Plugins\Fractal\Support\SchemaFromTransformer;
+use Radiergummi\OpenApi\Plugins\QueryBuilder\QueryBuilderPlugin;
 use Radiergummi\OpenApi\Registry\OpenApiRegistry;
+use Radiergummi\OpenApi\Support\Diagnostics\PluginHintInspector;
 use Radiergummi\OpenApi\Support\Extraction\FakerExampleSynthesiser;
 use Radiergummi\OpenApi\Support\Generator\BaselineRegistration;
 use Radiergummi\OpenApi\Support\Generator\ComponentSchemaRegistry;
@@ -173,7 +176,33 @@ class OpenApiServiceProvider extends ServiceProvider
         $this->registerApiResourcesPlugin();
         $this->registerFractalPlugin();
         $this->registerSwaggerPhpPlugin();
+        $this->registerPluginHints();
         $this->registerGenerator();
+    }
+
+    /**
+     * Binds the installed-but-disabled plugin diagnostic.
+     *
+     * The package-to-plugin map lives here because this is the glue layer permitted to name plugin
+     * classes; {@see PluginHintInspector} itself stays plugin-agnostic.
+     */
+    private function registerPluginHints(): void
+    {
+        $this->app->scoped(
+            PluginHintInspector::class,
+            static fn(): PluginHintInspector => new PluginHintInspector([
+                [
+                    'markers' => ['League\Fractal\Manager', 'Spatie\Fractal\Fractal'],
+                    'package' => 'league/fractal',
+                    'plugin' => FractalPlugin::class,
+                ],
+                [
+                    'markers' => ['Spatie\QueryBuilder\QueryBuilder'],
+                    'package' => 'spatie/laravel-query-builder',
+                    'plugin' => QueryBuilderPlugin::class,
+                ],
+            ]),
+        );
     }
 
     /**

--- a/src/Support/Diagnostics/PluginHintInspector.php
+++ b/src/Support/Diagnostics/PluginHintInspector.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\Diagnostics;
+
+use function class_exists;
+use function in_array;
+use function sprintf;
+use function strrchr;
+use function substr;
+
+/**
+ * Detects integration packages that are installed but whose plugin is not enabled.
+ *
+ * Plugin-agnostic by design: the package-to-plugin map is supplied by the caller (the Laravel
+ * service provider, the only layer allowed to name plugin classes), so this class references no
+ * plugin class itself.
+ *
+ * @internal
+ *
+ * @phpstan-type IntegrationEntry array{markers: list<string>, package: string, plugin: class-string}
+ */
+final class PluginHintInspector
+{
+    /**
+     * @var list<IntegrationEntry>
+     */
+    private array $integrationMap;
+
+    /**
+     * @var callable(string): bool
+     */
+    private $classExistsCheck;
+
+    /**
+     * @param list<IntegrationEntry>     $integrationMap   one entry per known integration package
+     * @param null|callable(string):bool $classExistsCheck overridable for deterministic testing,
+     *                                                     since all integration packages are
+     *                                                     installed in the test environment
+     */
+    public function __construct(array $integrationMap, ?callable $classExistsCheck = null)
+    {
+        $this->integrationMap = $integrationMap;
+        $this->classExistsCheck = $classExistsCheck ?? static fn(string $class): bool => class_exists($class);
+    }
+
+    /**
+     * Returns one advisory message per integration package that is installed but whose plugin is
+     * absent from the enabled plugin list. Deduplicated by plugin class.
+     *
+     * @param list<string> $enabledPlugins the configured plugin class-strings (`openapi.plugins`)
+     *
+     * @return list<string>
+     */
+    public function hints(array $enabledPlugins): array
+    {
+        $hints = [];
+        $seenPlugins = [];
+
+        foreach ($this->integrationMap as $entry) {
+            if (in_array($entry['plugin'], $seenPlugins, true)) {
+                continue;
+            }
+
+            if (in_array($entry['plugin'], $enabledPlugins, true)) {
+                continue;
+            }
+
+            if (!$this->anyMarkerPresent($entry['markers'])) {
+                continue;
+            }
+
+            $seenPlugins[] = $entry['plugin'];
+            $hints[] = $this->message($entry['package'], $entry['plugin']);
+        }
+
+        return $hints;
+    }
+
+    /**
+     * @param list<string> $markers
+     */
+    private function anyMarkerPresent(array $markers): bool
+    {
+        foreach ($markers as $marker) {
+            if (($this->classExistsCheck)($marker)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function message(string $package, string $pluginClass): string
+    {
+        $shortName = substr((string) strrchr($pluginClass, '\\'), 1) ?: $pluginClass;
+
+        return sprintf(
+            '%s is installed but %s is not enabled. Add it to the \'plugins\' array in '
+            . 'config/openapi.php to infer response schemas and parameters from it.',
+            $package,
+            $shortName,
+        );
+    }
+}

--- a/tests/Unit/Console/GenerateCommandTest.php
+++ b/tests/Unit/Console/GenerateCommandTest.php
@@ -285,3 +285,47 @@ it('still writes a valid document when --no-validate is passed', function (): vo
 
     @unlink($path);
 });
+
+it('hints when an installed integration package has its plugin disabled', function (): void {
+    // The stock plugin list leaves Fractal and QueryBuilder off, while both packages are installed
+    // in the test environment, so the advisory should name them.
+    config(['openapi.output_path' => generateCommandTmpPath()]);
+
+    $this->artisan('openapi:generate')
+        ->expectsOutputToContain('league/fractal')
+        ->expectsOutputToContain('spatie/laravel-query-builder')
+        ->assertExitCode(Command::SUCCESS);
+});
+
+it('does not hint for an integration whose plugin is enabled', function (): void {
+    config([
+        'openapi.output_path' => generateCommandTmpPath(),
+        'openapi.plugins' => [Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin::class],
+    ]);
+    app()->forgetScopedInstances();
+
+    $this->artisan('openapi:generate')
+        ->doesntExpectOutputToContain('league/fractal')
+        ->assertExitCode(Command::SUCCESS);
+});
+
+it('emits the plugin hint without polluting the stdout document under --output=-', function (): void {
+    // The hint renders to the error stream, so it never lands in the document a real CLI run writes
+    // to stdout. The PendingCommand harness wraps a single buffer, so the captured output carries
+    // the advisory (proving it was emitted) while the canonical document, generated here to a file,
+    // must stay valid YAML beginning with the OpenAPI marker and never contain the hint text.
+    config(['openapi.output_path' => generateCommandTmpPath()]);
+    $this->artisan('openapi:generate', ['--output' => '-'])
+        ->expectsOutputToContain('league/fractal')
+        ->assertExitCode(Command::SUCCESS);
+
+    $documentPath = generateCommandTmpPath();
+    config(['openapi.output_path' => $documentPath]);
+    app()->forgetScopedInstances();
+    $this->artisan('openapi:generate')->assertExitCode(Command::SUCCESS);
+
+    expect(file_get_contents($documentPath))->toStartWith('openapi:')
+        ->and(file_get_contents($documentPath))->not->toContain('league/fractal is installed');
+
+    @unlink($documentPath);
+});

--- a/tests/Unit/Support/Diagnostics/PluginHintInspectorTest.php
+++ b/tests/Unit/Support/Diagnostics/PluginHintInspectorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Radiergummi\OpenApi\Plugins\Fractal\FractalPlugin;
+use Radiergummi\OpenApi\Plugins\QueryBuilder\QueryBuilderPlugin;
+use Radiergummi\OpenApi\Support\Diagnostics\PluginHintInspector;
+
+uses()->group('openapi');
+
+/**
+ * @param array<string, true> $presentClasses classes the fake check should report as existing
+ */
+function pluginHintInspector(array $integrationMap, array $presentClasses): PluginHintInspector
+{
+    return new PluginHintInspector(
+        $integrationMap,
+        static fn(string $class): bool => isset($presentClasses[$class]),
+    );
+}
+
+/**
+ * @return list<array{markers: list<string>, package: string, plugin: class-string}>
+ */
+function fractalAndQueryBuilderMap(): array
+{
+    return [
+        [
+            'markers' => ['League\Fractal\Manager', 'Spatie\Fractal\Fractal'],
+            'package' => 'league/fractal',
+            'plugin' => FractalPlugin::class,
+        ],
+        [
+            'markers' => ['Spatie\QueryBuilder\QueryBuilder'],
+            'package' => 'spatie/laravel-query-builder',
+            'plugin' => QueryBuilderPlugin::class,
+        ],
+    ];
+}
+
+it('emits a hint when an integration package is installed but its plugin is disabled', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        ['League\Fractal\Manager' => true],
+    )->hints([]);
+
+    expect($hints)->toHaveCount(1)
+        ->and($hints[0])->toContain('league/fractal')
+        ->and($hints[0])->toContain('FractalPlugin');
+});
+
+it('emits no hint when the plugin is already enabled', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        ['League\Fractal\Manager' => true],
+    )->hints([FractalPlugin::class]);
+
+    expect($hints)->toBe([]);
+});
+
+it('emits no hint when the package is absent', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        [],
+    )->hints([]);
+
+    expect($hints)->toBe([]);
+});
+
+it('treats any of the marker classes as proof the package is installed', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        ['Spatie\Fractal\Fractal' => true],
+    )->hints([]);
+
+    expect($hints)->toHaveCount(1)
+        ->and($hints[0])->toContain('league/fractal');
+});
+
+it('emits a single hint when both marker classes for one plugin are present', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        ['League\Fractal\Manager' => true, 'Spatie\Fractal\Fractal' => true],
+    )->hints([]);
+
+    expect($hints)->toHaveCount(1);
+});
+
+it('emits a hint for the query-builder integration', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        ['Spatie\QueryBuilder\QueryBuilder' => true],
+    )->hints([]);
+
+    expect($hints)->toHaveCount(1)
+        ->and($hints[0])->toContain('spatie/laravel-query-builder')
+        ->and($hints[0])->toContain('QueryBuilderPlugin');
+});
+
+it('emits one hint per installed-but-disabled integration', function (): void {
+    $hints = pluginHintInspector(
+        fractalAndQueryBuilderMap(),
+        [
+            'League\Fractal\Manager' => true,
+            'Spatie\QueryBuilder\QueryBuilder' => true,
+        ],
+    )->hints([]);
+
+    expect($hints)->toHaveCount(2)
+        ->and($hints[0])->toContain('league/fractal')
+        ->and($hints[1])->toContain('spatie/laravel-query-builder');
+});


### PR DESCRIPTION
## Implementation plan — diagnose installed-but-disabled plugins

Closes #444

### Goal

When a known integration package is installed but its plugin is **absent** from the active plugin
list, emit a one-line advisory hint during `openapi:generate`. Advisory only: never auto-enables a
plugin, never mutates the host app (respects the spec-only scope boundary).

### Tier

**Tier-0.** Detection is pure reflection: `class_exists()` on a package marker class + a membership
check against the configured plugin list. No body parsing, no runtime mutation. This is the lowest
tier that captures the idiom; nothing higher is warranted.

### Resolved open questions

- **Surface location → generate-time note.** The generate command already emits diagnostics through
  the Laravel console `$this->components->*` helpers (`info` on success, `error` on failure) and the
  `--explain` flag writes per-route lines to STDERR. The hint follows this existing pattern:
  `$this->components->warn(...)` (or `->info`, matching tone — see "Surface" below), printed once per
  applicable package **before** the per-spec generation loop in `GenerateCommand::handle()`. **No new
  `openapi:doctor` command** — rejected per the issue's lean and the lead's instruction.
- **Suppressibility → not built.** The existing generate diagnostics (`components->info/error`,
  `--explain`) have **no** suppression flag or config toggle. Per "lean minimal — only add suppression
  if the existing diagnostic notes already have one", we add none. Noted as a possible follow-up
  (`--no-plugin-hints` / `openapi.plugin_hints` config) if it ever proves noisy. **Flagged for the
  lead** only as a deliberate non-decision, not controversial.

### The package → plugin map (single source of truth, tiny and explicit)

Confirmed marker classes (all loadable in the test env; verified via the project autoloader):

| Marker class (any-of)                                            | Package                          | Plugin class             |
|-----------------------------------------------------------------|----------------------------------|--------------------------|
| `League\Fractal\Manager`                                         | `league/fractal`                 | `FractalPlugin::class`   |
| `Spatie\Fractal\Fractal`                                         | `spatie/laravel-fractal`         | `FractalPlugin::class`   |
| `Spatie\QueryBuilder\QueryBuilder`                              | `spatie/laravel-query-builder`   | `QueryBuilderPlugin::class` |

Scope stays exactly to the two integrations the issue names. Fortify/SwaggerPhp are **out of scope**
for this map (Fortify documents a fixed contract table rather than recovering otherwise-lost coverage;
SwaggerPhp harvesting is a different opt-in axis). The map is a single private constant — adding a row
later is a one-line change. Note `spatie/laravel-fractal` depends on `league/fractal`, so a single
hint per plugin (deduplicated by plugin class) is correct even when both markers are present.

### Detection logic & testability seam

All three optional packages are **installed in the dev/test environment**, so the "package absent →
no hint" branch cannot be exercised by uninstalling. To keep all branches deterministically testable
at Tier-0 without touching composer, the inspector exposes an injectable class-existence check:

- New class `Radiergummi\OpenApi\Support\Diagnostics\PluginHintInspector` (`@internal`).
  - Holds the `package → (marker classes, plugin class)` map as a private constant.
  - `__construct(?callable $classExistsCheck = null)` — defaults to `class_exists(...)`; tests pass a
    fake to simulate present/absent packages.
  - `public function hints(array $enabledPlugins): list<PluginHint>` — for each map entry, if **any**
    marker class "exists" **and** the plugin class is **not** in `$enabledPlugins`, produce one
    `PluginHint` (package name + plugin class + message). Deduplicate by plugin class.
- Small value object `PluginHint` (package, pluginClass, message) — or return a `list<string>` of
  pre-formatted messages if a VO feels heavy; coder's call, lean toward the plain `list<string>` since
  there is one consumer. **Flag to coder:** keep it minimal, no VO unless the command needs the parts.

`PluginHintInspector` lives in `src/Support/Diagnostics/` (plugin-agnostic infrastructure belongs in
`Support\`, per the conventions; it references plugin class-strings only as map values, which is the
same pattern `BaselineRegistration`/the provider already use — no `Support → plugin` code dependency,
just string identifiers and the third-party marker FQCNs as `class_exists` arguments).

The `enabledPlugins` argument is `config('openapi.plugins', [])` (Core is always on and never in the
map, so no need to prepend `CorePlugin`). Compare with `in_array($pluginClass, $enabledPlugins, true)`.

### Surface in GenerateCommand

In `GenerateCommand::handle()`, after the format/target validation and **before** the `foreach
($targets ...)` generation loop, resolve `PluginHintInspector` (constructor-inject it like the other
collaborators, or `app()` it) and print each hint once:

```
$this->components->warn(
    "league/fractal is installed but FractalPlugin is not enabled — enable it in "
    . "config/openapi.php (the 'plugins' array) to infer response schemas from your transformers.",
);
```

Use `components->warn` (advisory, not an error; not mixed into the success `info` line). Printed once
per generate invocation regardless of how many specs are targeted (it is app-level, not spec-level).
Message text per package is generated from the map (package name + plugin short-name + a fixed
"enable it in config/openapi.php" tail).

### Files

- **Create** `src/Support/Diagnostics/PluginHintInspector.php` — the map + detection (`@internal`).
- **Modify** `src/Console/GenerateCommand.php` — inject the inspector, emit hints before the loop.
- **Create** `tests/Unit/Support/Diagnostics/PluginHintInspectorTest.php` — the detection branches.
- **Modify** `tests/Unit/Console/GenerateCommandTest.php` — assert the hint surfaces end-to-end.
- **Modify** `docs/plugins.md` — a short "Installed-but-disabled hints" note.
- **Modify** `CHANGELOG.md` `[Unreleased] → Added`.

### Tests (TDD — failing tests first)

Unit (`PluginHintInspectorTest`, drives all branches via the injected `classExistsCheck`):
1. **Installed + disabled = hint.** `league/fractal` marker "present", `FractalPlugin` not in the
   plugin list → exactly one hint naming `league/fractal` + `FractalPlugin`.
2. **Installed + enabled = no hint.** marker "present", `FractalPlugin` **in** the plugin list → no
   hint.
3. **Absent = no hint.** marker "absent" (fake returns false), plugin not listed → no hint.
4. **Either Fractal marker triggers it.** `spatie/laravel-fractal` marker present (league marker
   absent), `FractalPlugin` disabled → one hint (proves the any-of marker set).
5. **Dedup.** both Fractal markers present, plugin disabled → still exactly **one** Fractal hint.
6. **QueryBuilder branch.** `Spatie\QueryBuilder\QueryBuilder` present, `QueryBuilderPlugin` disabled
   → one hint naming `spatie/laravel-query-builder` + `QueryBuilderPlugin`.
7. **Multiple.** Fractal + QueryBuilder both installed-and-disabled → two distinct hints.

Feature/console (`GenerateCommandTest`, real `class_exists` — packages are installed in the suite):
8. **Default config (Fractal/QB disabled) surfaces the hint.** With the stock plugin list (Fractal
   and QueryBuilder commented out), `openapi:generate` output contains the `league/fractal` and
   `spatie/laravel-query-builder` hints; exit code unchanged (`SUCCESS`).
9. **Enabling the plugin silences its hint.** `config(['openapi.plugins' => [..., FractalPlugin::class]])`
   → no `league/fractal` hint in output; generate still succeeds. (Asserts the membership check wins
   over class presence — the core acceptance criterion.)

(The "package absent" case is covered deterministically at the unit level, not the feature level,
since the suite cannot uninstall packages.)

### Docs & CHANGELOG

- `docs/plugins.md`: a short subsection near the optional-plugin enable instructions explaining that
  `openapi:generate` emits an advisory when an integration package is installed but its plugin is off,
  and that it is advisory only (never auto-enabled). No new config key to document.
- `CHANGELOG.md` `[Unreleased] → Added`:
  `openapi:generate` emits an advisory hint when an integration package (`league/fractal`,
  `spatie/laravel-fractal`, `spatie/laravel-query-builder`) is installed but its plugin is not
  enabled — advisory only, never auto-enables. (#444)

### Controversy / human-gate notes

- **No `src/Contracts/**` changes, no stage-order changes, no public signature changes, no new config
  key.** Should qualify for the fast-path (`area:cli`, well under the mechanical-size bar in spirit
  though it adds a new support class + tests).
- **Deliberate non-decisions flagged for the lead:** (a) no suppression flag (matches existing
  no-suppression diagnostics; follow-up if noisy); (b) map intentionally limited to the two issue-named
  integrations; (c) hint uses `components->warn` not STDERR `--explain`-style, since it is a
  config-level advisory not a per-route decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)