### PR TITLE
feat(lint): operation.action-method-missing — flag routes whose action method does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable changes to this project are documented here.
 - Inferred response headers (Tier-0): a `201` response gets a `Location` header (`string`, `uri-reference`), and `throttle` middleware adds `X-RateLimit-Limit` / `X-RateLimit-Remaining` (`integer`) to the success response. An authored `#[ResponseHeader]` of the same name wins. (#420)
 - `openapi:generate` emits an advisory hint on stderr when an integration package (`league/fractal`, `spatie/laravel-fractal`, `spatie/laravel-query-builder`) is installed but its plugin is not enabled, pointing at the `config/openapi.php` line that would let it infer schemas and parameters. Advisory only: never auto-enables, never pollutes the `--output=-` document. (#444)
 - Inferred array query parameters (`ids[]` from a scalar-list validation rule) now carry `style: form` and `explode: true`, matching PHP's `name[]` repeated-pair wire format and removing the ambiguous serialisation that tripped the library's own `parameter.query-array-no-explode` lint rule. Scalar query parameters and explicit `#[QueryParam]` arrays are unchanged. (#454)
+- New `operation.action-method-missing` lint rule (level 1) flags routes whose action resolves to a controller method that does not exist (e.g. an over-registered resourceful route): the operation is documented but would fault at runtime. Skips closures and routes whose controller class is itself absent. (#448)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -601,6 +601,7 @@ is enabled.
 | `header.invalid-name` | 1 | Header name contains invalid characters. |
 | `link.invalid-operation` | 1 | Link references an operationId that doesn't exist in the document. |
 | `multipart.file-without-multipart` | 1 | Data class carries a file property but a #[RequestBody] override forces a non-multipart body — the spec contradicts the code. |
+| `operation.action-method-missing` | 1 | Route action resolves to a controller method that does not exist; the operation is documented but would fault at runtime. |
 | `operation.id-invalid-chars` | 1 | operationId is not a codegen-safe identifier. |
 | `operation.id-missing` | 1 | Operation has no operationId. |
 | `operation.security-missing` | 1 | Route enforces auth middleware but the operation declares no security, implying the endpoint is public. |

--- a/src/Lint/LintRouteFilter.php
+++ b/src/Lint/LintRouteFilter.php
@@ -7,6 +7,7 @@ namespace Radiergummi\OpenApi\Lint;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Support\Str;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use ReflectionClass;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\ProcessStartFailedException;
@@ -18,6 +19,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function base_path;
+use function class_exists;
 use function config_path;
 use function explode;
 use function fnmatch;
@@ -111,7 +113,10 @@ class LintRouteFilter
     private static function isVendorOrUnresolvable(ActionDescriptor $descriptor): bool
     {
         if ($descriptor->controller === null && $descriptor->method === null) {
-            return true;
+            // The introspector nulls both reflectors when the action method does not exist on an
+            // otherwise-resolvable first-party controller. Keep those so the missing-method lint
+            // rule can flag them; still drop closures (no controller class) and vendor controllers.
+            return self::isVendorOrUnresolvableMissingMethod($descriptor);
         }
 
         $file = $descriptor->method?->getFileName()
@@ -122,6 +127,23 @@ class LintRouteFilter
         }
 
         return str_contains($file, '/vendor/');
+    }
+
+    /**
+     * Whether a both-reflectors-null descriptor is a closure/vendor route rather than a first-party
+     * controller with a missing action method.
+     */
+    private static function isVendorOrUnresolvableMissingMethod(ActionDescriptor $descriptor): bool
+    {
+        $controllerClass = $descriptor->route->getControllerClass();
+
+        if ($controllerClass === null || !class_exists($controllerClass)) {
+            return true;
+        }
+
+        $file = new ReflectionClass($controllerClass)->getFileName();
+
+        return $file === false || str_contains($file, '/vendor/');
     }
 
     /**

--- a/src/Lint/LintRouteFilter.php
+++ b/src/Lint/LintRouteFilter.php
@@ -42,6 +42,11 @@ class LintRouteFilter
     /**
      * Apply --uri glob, --path, and --diff filters. A config change widens scope to all routes.
      *
+     * Drops closures, vendor controllers, and first-party routes whose action method does not
+     * exist: the tree-walk scope mirrors the generated document, which never emits an operation
+     * for a missing-method route. {@see filterForRouteRules()} keeps the latter so the
+     * missing-method lint rule can still flag them.
+     *
      * @param list<ActionDescriptor> $descriptors
      * @param list<string>           $files       Explicit source files (`--path`), absolute or base-relative.
      * @param ?DiffScope             $diff        The `--diff` scope, or null when not requested.
@@ -56,8 +61,54 @@ class LintRouteFilter
      */
     public function filter(array $descriptors, ?string $uriGlob, array $files, ?DiffScope $diff): array
     {
-        $descriptors = $this->dropClosureAndVendorRoutes($descriptors);
+        return $this->narrow(
+            $this->dropClosureAndVendorRoutes($descriptors, keepMissingMethod: false),
+            $uriGlob,
+            $files,
+            $diff,
+        );
+    }
 
+    /**
+     * The same scope narrowing as {@see filter()}, but keeping first-party missing-method routes so
+     * the per-route lint pass can flag them. These routes are deliberately excluded from the
+     * tree-walk scope (no operation is generated for them), so they must not re-enter it.
+     *
+     * @param list<ActionDescriptor> $descriptors
+     * @param list<string>           $files
+     *
+     * @return list<ActionDescriptor>
+     *
+     * @throws LogicException
+     * @throws ProcessSignaledException
+     * @throws ProcessStartFailedException
+     * @throws ProcessTimedOutException
+     * @throws RuntimeException
+     */
+    public function filterForRouteRules(array $descriptors, ?string $uriGlob, array $files, ?DiffScope $diff): array
+    {
+        return $this->narrow(
+            $this->dropClosureAndVendorRoutes($descriptors, keepMissingMethod: true),
+            $uriGlob,
+            $files,
+            $diff,
+        );
+    }
+
+    /**
+     * @param list<ActionDescriptor> $descriptors
+     * @param list<string>           $files
+     *
+     * @return list<ActionDescriptor>
+     *
+     * @throws LogicException
+     * @throws ProcessSignaledException
+     * @throws ProcessStartFailedException
+     * @throws ProcessTimedOutException
+     * @throws RuntimeException
+     */
+    private function narrow(array $descriptors, ?string $uriGlob, array $files, ?DiffScope $diff): array
+    {
         if (is_string($uriGlob) && $uriGlob !== '') {
             $descriptors = array_values(
                 array_filter(
@@ -96,26 +147,32 @@ class LintRouteFilter
      *
      * @return list<ActionDescriptor>
      */
-    private function dropClosureAndVendorRoutes(array $descriptors): array
+    private function dropClosureAndVendorRoutes(array $descriptors, bool $keepMissingMethod): array
     {
         return array_values(
             array_filter(
                 $descriptors,
                 static fn(ActionDescriptor $descriptor): bool
-                    => !self::isVendorOrUnresolvable($descriptor),
+                    => !self::isVendorOrUnresolvable($descriptor, $keepMissingMethod),
             ),
         );
     }
 
     /**
      * True for closure routes (no controller), unresolvable source files, and vendor controllers.
+     *
+     * When `$keepMissingMethod` is set, a both-reflectors-null descriptor for an existing
+     * first-party controller (the introspector nulls both reflectors when the action method does
+     * not exist) is retained so the missing-method lint rule can flag it; closures and vendor
+     * controllers are still dropped.
      */
-    private static function isVendorOrUnresolvable(ActionDescriptor $descriptor): bool
+    private static function isVendorOrUnresolvable(ActionDescriptor $descriptor, bool $keepMissingMethod): bool
     {
         if ($descriptor->controller === null && $descriptor->method === null) {
-            // The introspector nulls both reflectors when the action method does not exist on an
-            // otherwise-resolvable first-party controller. Keep those so the missing-method lint
-            // rule can flag them; still drop closures (no controller class) and vendor controllers.
+            if (!$keepMissingMethod) {
+                return true;
+            }
+
             return self::isVendorOrUnresolvableMissingMethod($descriptor);
         }
 

--- a/src/Lint/LintRunner.php
+++ b/src/Lint/LintRunner.php
@@ -147,7 +147,23 @@ final readonly class LintRunner
     ): LintResult {
         // region Descriptor collection + path/diff filtering
 
-        $descriptors = $this->collectDescriptors($options);
+        $globalFiltered = $this->collectGlobalFiltered();
+
+        // Tree-walk scope mirrors the generated document, which never emits an operation for a
+        // missing-method route. The per-route lint pass needs those routes, so it runs over a
+        // superset that keeps them; re-admitting them to the tree walk would draw spurious findings.
+        $descriptors = $this->routeFilter->filter(
+            descriptors: $globalFiltered,
+            uriGlob: $options->uriGlob,
+            files: $options->files,
+            diff: $options->diff,
+        );
+        $routeRuleDescriptors = $this->routeFilter->filterForRouteRules(
+            descriptors: $globalFiltered,
+            uriGlob: $options->uriGlob,
+            files: $options->files,
+            diff: $options->diff,
+        );
 
         // Stage-emitted findings bypass the tree-walk path restriction, so they need a URI gate.
         $allowedRouteUris = null;
@@ -157,8 +173,17 @@ final readonly class LintRunner
         $allowedSchemaClasses = [];
         $allComponentClasses = [];
 
+        // Tree-walk path scope: the dead-routes-dropped set, so tree-walk rules never see an
+        // operation the generator emitted for a missing-method route. Null when unscoped.
+        $treeWalkUris = null;
+
         if ($options->isScoped) {
-            $allowedRouteUris = self::descriptorUriSet($descriptors);
+            $treeWalkUris = self::descriptorUriSet($descriptors);
+
+            // The route-rule set is a superset that keeps missing-method routes. Gating findings by
+            // its URIs lets per-route findings on those routes survive; their operations are still
+            // excluded from the tree walk via $treeWalkUris, so no tree-walk finding leaks through.
+            $allowedRouteUris = self::descriptorUriSet($routeRuleDescriptors);
         }
 
         // endregion
@@ -254,6 +279,8 @@ final readonly class LintRunner
             $operations = $this->walkSpec(
                 $document,
                 $descriptors,
+                $routeRuleDescriptors,
+                $treeWalkUris,
                 $rules,
                 $specSuppressions,
                 $specLocal,
@@ -308,19 +335,14 @@ final readonly class LintRunner
     }
 
     /**
-     * Discovers routes, drops global-filter rejects, then applies --path/--files/--diff narrowing.
+     * Discovers routes and drops global-filter rejects, before --path/--files/--diff narrowing.
      *
      * @return list<ActionDescriptor>
      *
-     * @throws LogicException
-     * @throws ProcessRuntimeException
-     * @throws ProcessSignaledException
-     * @throws ProcessStartFailedException
-     * @throws ProcessTimedOutException
      * @throws ReflectionException
      * @throws UnexpectedValueException
      */
-    private function collectDescriptors(LintOptions $options): array
+    private function collectGlobalFiltered(): array
     {
         $descriptors = [];
 
@@ -332,12 +354,7 @@ final readonly class LintRunner
             $descriptors[] = $descriptor;
         }
 
-        return $this->routeFilter->filter(
-            descriptors: $descriptors,
-            uriGlob: $options->uriGlob,
-            files: $options->files,
-            diff: $options->diff,
-        );
+        return $descriptors;
     }
 
     /**
@@ -599,8 +616,14 @@ final readonly class LintRunner
     /**
      * Runs the tree walk, RouteRule pass, and MetaSuppressionStale for one spec.
      *
+     * The RouteRule pass runs over `$routeRuleDescriptors`, which (unlike the tree-walk
+     * `$descriptors`) keeps first-party missing-method routes so they can be flagged without
+     * re-entering the tree-walk scope and drawing spurious operation/response findings.
+     *
      * @param list<Rule>                  $rules
-     * @param list<ActionDescriptor>      $descriptors
+     * @param list<ActionDescriptor>      $descriptors          Tree-walk scope (mirrors the document).
+     * @param list<ActionDescriptor>      $routeRuleDescriptors Per-route pass scope (superset).
+     * @param null|array<string, true>    $treeWalkUris         In-scope tree-walk URIs; null = unscoped.
      * @param list<SuppressionDirective>  $suppressions
      * @param list<string>                $only
      * @param list<string>                $skip
@@ -613,6 +636,8 @@ final readonly class LintRunner
     private function walkSpec(
         OA\OpenApi $document,
         array $descriptors,
+        array $routeRuleDescriptors,
+        ?array $treeWalkUris,
         array $rules,
         array $suppressions,
         ArrayFindingsCollector $specLocal,
@@ -631,9 +656,16 @@ final readonly class LintRunner
             MetaSuppressionStale::ID,
         ];
 
-        // Restrict to the allowed set so rules don't fire on routes excluded by --path/--diff.
-        if ($descriptors !== [] && is_array($document->paths)) {
-            $document->paths = self::inScopePathItems($document, self::descriptorUriSet($descriptors));
+        // Restrict to the allowed set so rules don't fire on routes excluded by --uri/--path/--diff,
+        // including missing-method routes: the per-route pass handles those, but the tree walk must
+        // not see the operations the generator still emits for them. A scoped run narrows even to an
+        // empty set (nothing left to walk); an unscoped run narrows to its discovered routes.
+        if (is_array($document->paths)) {
+            if ($treeWalkUris !== null) {
+                $document->paths = self::inScopePathItems($document, $treeWalkUris);
+            } elseif ($descriptors !== []) {
+                $document->paths = self::inScopePathItems($document, self::descriptorUriSet($descriptors));
+            }
         }
 
         $treeBuilder = new SpecTreeBuilder(
@@ -680,7 +712,7 @@ final readonly class LintRunner
         );
 
         if ($routeRules !== []) {
-            foreach ($descriptors as $descriptor) {
+            foreach ($routeRuleDescriptors as $descriptor) {
                 $defaults = FindingLocation::fromDescriptor($descriptor);
 
                 foreach ($routeRules as $rule) {

--- a/src/Lint/Rules/ActionMethodMissing.php
+++ b/src/Lint/Rules/ActionMethodMissing.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Lint\Rules;
+
+use Override;
+use Radiergummi\OpenApi\Contracts\Lint\Rule;
+use Radiergummi\OpenApi\Contracts\Lint\Severity;
+use Radiergummi\OpenApi\Lint\Finding;
+use Radiergummi\OpenApi\Lint\LintContext;
+use Radiergummi\OpenApi\Lint\Visitors\RouteRule;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use ReflectionClass;
+
+use function class_exists;
+use function sprintf;
+
+/**
+ * Reports routes whose action resolves to a controller method that does not exist. Resourceful
+ * route registration (e.g. `Route::apiResource()`) registers all seven actions, but a controller
+ * may implement only a few; the remaining routes point at missing methods and would fault at
+ * runtime, yet are documented as valid operations. Deterministic reflection, no body parsing.
+ *
+ * Closures are skipped (no controller method to reflect), as are routes whose controller class
+ * does not exist (a different defect, outside this rule's scope).
+ */
+final class ActionMethodMissing implements Rule, RouteRule
+{
+    public string $id = self::ID;
+    public Severity $severity = Severity::Degraded;
+    public string $description = 'Route action resolves to a controller method that does not exist; the operation is documented but would fault at runtime.';
+
+    public const string ID = 'operation.action-method-missing';
+
+    /**
+     * @return iterable<Finding>
+     */
+    #[Override]
+    public function checkRoute(ActionDescriptor $descriptor, LintContext $context): iterable
+    {
+        $controllerClass = $descriptor->route->getControllerClass();
+
+        // Closure routes have no controller class to reflect.
+        if ($controllerClass === null || !class_exists($controllerClass)) {
+            return;
+        }
+
+        $reflection = new ReflectionClass($controllerClass);
+        $actionMethod = $descriptor->route->getActionMethod();
+
+        // An invocable controller registers the class name as its action; reflect __invoke().
+        $methodName = $actionMethod === $controllerClass ? '__invoke' : $actionMethod;
+
+        if ($reflection->hasMethod($methodName)) {
+            return;
+        }
+
+        yield new Finding(
+            ruleId: $this->id,
+            severity: $this->severity,
+            message: sprintf(
+                '%s::%s() does not exist; the route points at a missing method and would fault at runtime.',
+                $reflection->getShortName(),
+                $methodName,
+            ),
+            fixHint: 'Implement the method, or stop registering the route (e.g. limit apiResource() with only:/except:).',
+        );
+    }
+}

--- a/src/Support/Generator/BaselineRegistration.php
+++ b/src/Support/Generator/BaselineRegistration.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Container\Container;
 use Radiergummi\OpenApi\Contracts\Lint\Rule;
 use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseResolver;
 use Radiergummi\OpenApi\Contracts\Registry\Plugin;
+use Radiergummi\OpenApi\Lint\Rules\ActionMethodMissing;
 use Radiergummi\OpenApi\Lint\Rules\ActionMissingReturnType;
 use Radiergummi\OpenApi\Lint\Rules\ComponentNameNamingInconsistent;
 use Radiergummi\OpenApi\Lint\Rules\ComponentOrphaned;
@@ -235,6 +236,7 @@ final class BaselineRegistration
 
         HideExposeConflict::class,
         VisibilityAttributeNoOp::class,
+        ActionMethodMissing::class,
 
         SpecUnknownReference::class,
         SpecRouteOrphaned::class,

--- a/tests/Feature/Lint/ActionMethodMissingTest.php
+++ b/tests/Feature/Lint/ActionMethodMissingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\ActionMethodController;
+
+uses()->group('openapi', 'lint');
+
+beforeEach(function (): void {
+    // Mirrors an over-registered resourceful route: the controller has `index` but not `destroy`.
+    Route::get('lint-fixtures/action-method/present', [ActionMethodController::class, 'index'])
+        ->name('lint.action-method.present');
+    Route::delete('lint-fixtures/action-method/missing', [ActionMethodController::class, 'destroy'])
+        ->name('lint.action-method.missing');
+});
+
+it('flags a route whose controller method does not exist', function (): void {
+    $this->artisan('openapi:lint', [
+        '--level' => 1,
+        '--only' => 'operation.action-method-missing',
+        '--uri' => 'lint-fixtures/action-method/missing',
+        '--format' => 'json',
+    ])->assertExitCode(1);
+});
+
+it('does not flag a route whose controller method exists', function (): void {
+    $this->artisan('openapi:lint', [
+        '--level' => 1,
+        '--only' => 'operation.action-method-missing',
+        '--uri' => 'lint-fixtures/action-method/present',
+        '--format' => 'json',
+    ])->assertExitCode(0);
+});

--- a/tests/Feature/Lint/ActionMethodMissingTest.php
+++ b/tests/Feature/Lint/ActionMethodMissingTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Radiergummi\OpenApi\Lint\LintOptions;
+use Radiergummi\OpenApi\Lint\LintRunner;
 use Radiergummi\OpenApi\Tests\Fixtures\Lint\ActionMethodController;
 
 uses()->group('openapi', 'lint');
@@ -31,4 +33,21 @@ it('does not flag a route whose controller method exists', function (): void {
         '--uri' => 'lint-fixtures/action-method/present',
         '--format' => 'json',
     ])->assertExitCode(0);
+});
+
+it('does not draw tree-walk findings onto the dead route', function (): void {
+    // The route is intentionally excluded from the tree-walk scope: the generator emits no
+    // operation for a missing-method route, so tree-walk rules (e.g. response.no-error) must not
+    // fire on it. Linting the missing route at the default level must surface exactly this rule.
+    $result = app(LintRunner::class)->run(new LintOptions(
+        level: 1,
+        uriGlob: 'lint-fixtures/action-method/missing',
+    ));
+
+    $ruleIds = array_values(array_map(
+        static fn($finding): string => $finding->ruleId,
+        $result->findings,
+    ));
+
+    expect($ruleIds)->toBe(['operation.action-method-missing']);
 });

--- a/tests/Fixtures/Lint/ActionMethodController.php
+++ b/tests/Fixtures/Lint/ActionMethodController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;
+
+final class ActionMethodController
+{
+    public function index(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Lint/InvokableActionController.php
+++ b/tests/Fixtures/Lint/InvokableActionController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures\Lint;
+
+final class InvokableActionController
+{
+    public function __invoke(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Lint/LintRouteFilterTest.php
+++ b/tests/Unit/Lint/LintRouteFilterTest.php
@@ -280,7 +280,7 @@ it('unions --path files with --diff changes', function (): void {
 
 // region missing-method routes
 
-it('keeps a first-party route whose action method does not exist', function (): void {
+it('keeps a first-party missing-method route for the route-rule pass but not the tree walk', function (): void {
     $action = CleanController::class . '@nonexistentMethod';
 
     // Mirrors RouteIntrospector degrading both reflectors to null for a missing method.
@@ -292,17 +292,25 @@ it('keeps a first-party route whose action method does not exist', function (): 
         description: null,
     );
 
-    $filtered = makeStubFilter(defaultRef: null, diffFiles: [])->filter(
+    $filter = makeStubFilter(defaultRef: null, diffFiles: []);
+
+    // The tree-walk scope drops it (the generator emits no operation for it); the route-rule scope
+    // keeps it so the missing-method lint rule can flag it.
+    expect($filter->filter(
         descriptors: [$descriptor],
         uriGlob: null,
         files: [],
         diff: null,
-    );
-
-    expect($filtered)->toHaveCount(1);
+    ))->toBe([])
+        ->and($filter->filterForRouteRules(
+            descriptors: [$descriptor],
+            uriGlob: null,
+            files: [],
+            diff: null,
+        ))->toHaveCount(1);
 });
 
-it('still drops a closure route', function (): void {
+it('drops a closure route from both the tree-walk and the route-rule scope', function (): void {
     $descriptor = new ActionDescriptor(
         route: new Route(['GET'], 'closure', ['uses' => static fn(): array => []]),
         controller: null,
@@ -312,14 +320,20 @@ it('still drops a closure route', function (): void {
         closure: new ReflectionFunction(static fn(): array => []),
     );
 
-    $filtered = makeStubFilter(defaultRef: null, diffFiles: [])->filter(
+    $filter = makeStubFilter(defaultRef: null, diffFiles: []);
+
+    expect($filter->filter(
         descriptors: [$descriptor],
         uriGlob: null,
         files: [],
         diff: null,
-    );
-
-    expect($filtered)->toBe([]);
+    ))->toBe([])
+        ->and($filter->filterForRouteRules(
+            descriptors: [$descriptor],
+            uriGlob: null,
+            files: [],
+            diff: null,
+        ))->toBe([]);
 });
 
 // endregion

--- a/tests/Unit/Lint/LintRouteFilterTest.php
+++ b/tests/Unit/Lint/LintRouteFilterTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Routing\Route;
 use Illuminate\Support\Str;
 use Radiergummi\OpenApi\Lint\DiffMode;
 use Radiergummi\OpenApi\Lint\DiffScope;
 use Radiergummi\OpenApi\Lint\LintRouteFilter;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Tests\Fixtures\Lint\BrokenController;
 use Radiergummi\OpenApi\Tests\Fixtures\Lint\CleanController;
 use Radiergummi\OpenApi\Tests\Support\ActionDescriptorFactory;
@@ -272,6 +274,52 @@ it('unions --path files with --diff changes', function (): void {
     );
 
     expect($filtered)->toHaveCount(2);
+});
+
+// endregion
+
+// region missing-method routes
+
+it('keeps a first-party route whose action method does not exist', function (): void {
+    $action = CleanController::class . '@nonexistentMethod';
+
+    // Mirrors RouteIntrospector degrading both reflectors to null for a missing method.
+    $descriptor = new ActionDescriptor(
+        route: new Route(['GET'], 'clean/missing', ['uses' => $action, 'controller' => $action]),
+        controller: null,
+        method: null,
+        summary: null,
+        description: null,
+    );
+
+    $filtered = makeStubFilter(defaultRef: null, diffFiles: [])->filter(
+        descriptors: [$descriptor],
+        uriGlob: null,
+        files: [],
+        diff: null,
+    );
+
+    expect($filtered)->toHaveCount(1);
+});
+
+it('still drops a closure route', function (): void {
+    $descriptor = new ActionDescriptor(
+        route: new Route(['GET'], 'closure', ['uses' => static fn(): array => []]),
+        controller: null,
+        method: null,
+        summary: null,
+        description: null,
+        closure: new ReflectionFunction(static fn(): array => []),
+    );
+
+    $filtered = makeStubFilter(defaultRef: null, diffFiles: [])->filter(
+        descriptors: [$descriptor],
+        uriGlob: null,
+        files: [],
+        diff: null,
+    );
+
+    expect($filtered)->toBe([]);
 });
 
 // endregion

--- a/tests/Unit/Lint/Rules/ActionMethodMissingTest.php
+++ b/tests/Unit/Lint/Rules/ActionMethodMissingTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Routing\Route;
+use Radiergummi\OpenApi\Contracts\Lint\Severity;
+use Radiergummi\OpenApi\Lint\Rules\ActionMethodMissing;
+use Radiergummi\OpenApi\Routing\ActionDescriptor;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\ActionMethodController;
+use Radiergummi\OpenApi\Tests\Fixtures\Lint\InvokableActionController;
+use Radiergummi\OpenApi\Tests\Support\OperationNodeFactory;
+
+uses()->group('openapi', 'lint');
+
+/**
+ * Builds a descriptor mirroring what RouteIntrospector produces for a controller action: the raw
+ * Route carries the action string, while controller/method reflectors are null whenever the method
+ * does not exist (the introspector degrades rather than throwing).
+ */
+function actionMethodDescriptor(string $action, ?ReflectionClass $controller = null, ?ReflectionMethod $method = null): ActionDescriptor
+{
+    return new ActionDescriptor(
+        route: new Route(['GET'], '/__test__', ['uses' => $action, 'controller' => $action]),
+        controller: $controller,
+        method: $method,
+        summary: null,
+        description: null,
+    );
+}
+
+function actionMethodFindings(ActionDescriptor $descriptor): array
+{
+    return iterator_to_array(
+        new ActionMethodMissing()->checkRoute($descriptor, OperationNodeFactory::emptyContext()),
+    );
+}
+
+it('has the correct rule id and severity', function (): void {
+    $rule = new ActionMethodMissing();
+
+    expect($rule->id)
+        ->toBe('operation.action-method-missing')
+        ->and($rule->severity)->toBe(Severity::Degraded);
+});
+
+it('flags a route whose controller method does not exist', function (): void {
+    $descriptor = actionMethodDescriptor(ActionMethodController::class . '@destroy');
+
+    expect(actionMethodFindings($descriptor))->toEmitFinding(
+        ruleId: 'operation.action-method-missing',
+        messageContains: 'ActionMethodController::destroy()',
+    );
+});
+
+it('does not flag a route whose controller method exists', function (): void {
+    $descriptor = actionMethodDescriptor(
+        ActionMethodController::class . '@index',
+        new ReflectionClass(ActionMethodController::class),
+        new ReflectionMethod(ActionMethodController::class, 'index'),
+    );
+
+    expect(actionMethodFindings($descriptor))->toBe([]);
+});
+
+it('does not flag an invokable controller that implements __invoke', function (): void {
+    $descriptor = actionMethodDescriptor(
+        InvokableActionController::class,
+        new ReflectionClass(InvokableActionController::class),
+        new ReflectionMethod(InvokableActionController::class, '__invoke'),
+    );
+
+    expect(actionMethodFindings($descriptor))->toBe([]);
+});
+
+it('emits exactly one finding for a missing method', function (): void {
+    $descriptor = actionMethodDescriptor(ActionMethodController::class . '@store');
+
+    expect(actionMethodFindings($descriptor))->toHaveCount(1);
+});
+
+it('does not flag a closure route', function (): void {
+    $descriptor = new ActionDescriptor(
+        route: new Route(['GET'], '/__test__', ['uses' => static fn(): array => []]),
+        controller: null,
+        method: null,
+        summary: null,
+        description: null,
+        closure: new ReflectionFunction(static fn(): array => []),
+    );
+
+    expect(actionMethodFindings($descriptor))->toBe([]);
+});
+
+it('does not flag a route whose controller class does not exist', function (): void {
+    $action = 'App\\Http\\Controllers\\NonexistentController@index';
+
+    $descriptor = actionMethodDescriptor($action);
+
+    expect(actionMethodFindings($descriptor))->toBe([]);
+});


### PR DESCRIPTION
## Fast-path scope — `operation.action-method-missing` lint rule

Closes #448

Adds a lint rule that flags operations whose route action resolves to a controller
method that **does not exist** (via reflection). Deterministic Tier-0, no body parsing.

### Resolved open questions (author leans adopted)
- **Severity:** `warning` (advisory) — it's the consumer app's bug, not a doc-authoring error.
- **Generation behaviour:** keep emitting the operation faithfully (mirror the route table);
  do **not** silently drop the route. The lint warning is the signal.
- **Scope:** non-closure controller actions only. Resolve `Controller@method` and `__invoke`
  for invokable controllers; skip closures (no method to reflect).

### Shape
- New rule `src/Lint/Rules/<...>.php` with stable ID `operation.action-method-missing`,
  default severity `warning`, implementing the operation-visitor interface.
- Resolve the action from the route/operation; reflect the controller; flag a missing method.
- Register in the baseline lint rules (`BaselineRegistration`).
- Tests: missing method → finding; existing method → none; `__invoke` controller present/absent;
  closure route → skipped (no false positive).
- `docs/linting.md` catalog row (hand-maintained, between the markers).
- `CHANGELOG.md [Unreleased]` entry (own line at end of section).

Coder implements directly against this branch (fast-path). The exact rule class name,
visitor interface, and action-resolution helper to reuse are the coder's call after reading
the existing `src/Lint/Rules/` rules and `SpecTreeBuilder`/`SpecTreeWalker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)