### PR TITLE
feat(params): set explode/style on inferred array query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ All notable changes to this project are documented here.
 - Response schemas derived from Eloquent models now mark the primary key (`getKeyName()`), the timestamp columns (`created_at` / `updated_at`), and the soft-delete column (`deleted_at`, when the model uses `SoftDeletes`) `readOnly: true`; these are server-managed and a client never sets them. Nothing else gains the keyword, and an authored `readOnly` is never overwritten. (#419)
 - Inferred response headers (Tier-0): a `201` response gets a `Location` header (`string`, `uri-reference`), and `throttle` middleware adds `X-RateLimit-Limit` / `X-RateLimit-Remaining` (`integer`) to the success response. An authored `#[ResponseHeader]` of the same name wins. (#420)
 - `openapi:generate` emits an advisory hint on stderr when an integration package (`league/fractal`, `spatie/laravel-fractal`, `spatie/laravel-query-builder`) is installed but its plugin is not enabled, pointing at the `config/openapi.php` line that would let it infer schemas and parameters. Advisory only: never auto-enables, never pollutes the `--output=-` document. (#444)
+- Inferred array query parameters (`ids[]` from a scalar-list validation rule) now carry `style: form` and `explode: true`, matching PHP's `name[]` repeated-pair wire format and removing the ambiguous serialisation that tripped the library's own `parameter.query-array-no-explode` lint rule. Scalar query parameters and explicit `#[QueryParam]` arrays are unchanged. (#454)
 
 ## [0.1.0] - 2026-05-18
 

--- a/docs/auto-derivation.md
+++ b/docs/auto-derivation.md
@@ -439,7 +439,8 @@ describe query parameters rather than a request body: each key becomes a
 parameter with its rule-derived schema, `required` from the rules, and a
 trailing `//` comment as its description. Nested keys map to the query-string
 wire format — `filter.name` → `filter[name]`, a scalar list (`ids` + `ids.*`)
-→ a repeatable `ids[]` with an array schema. An array of *objects*
+→ a repeatable `ids[]` with an array schema, emitted with `style: form` and
+`explode: true` (PHP's `name[]` repeated-pair wire format). An array of *objects*
 (`rows.*.price`) or a bare `*` rule has no honest parameter-name
 representation; those keys are dropped with a generation-log note.
 

--- a/src/Plugins/Core/Resolvers/CoreQueryParameterResolver.php
+++ b/src/Plugins/Core/Resolvers/CoreQueryParameterResolver.php
@@ -407,11 +407,17 @@ final readonly class CoreQueryParameterResolver implements QueryParameterResolve
             $schema = new OA\Schema([]);
             $descriptor->applyTo($schema);
 
-            $parameters[$name] = $this->parameter(
-                $name,
-                $schema,
-                required: $ancestorsRequired && $descriptor->required === true,
-            );
+            // A repeated `name[]` parameter is form-style with explode: each value is its own
+            // `name[]=…` pair. Declaring it removes the serialization ambiguity flagged by the
+            // parameter.query-array-no-explode lint rule.
+            $parameters[$name] = new OA\Parameter([
+                'name' => $name,
+                'in' => 'query',
+                'required' => $ancestorsRequired && $descriptor->required === true,
+                'style' => 'form',
+                'explode' => true,
+                'schema' => $schema,
+            ]);
 
             return;
         }

--- a/tests/Feature/FormRequestQueryParameterTest.php
+++ b/tests/Feature/FormRequestQueryParameterTest.php
@@ -47,7 +47,23 @@ it('surfaces a GET FormRequest as query parameters in wire notation with no requ
         ->and($parameters['page']['schema']['type'])->toBe('integer')
         ->and($parameters['filter[name]']['required'])->toBeFalse()
         ->and($parameters['ids[]']['schema']['type'])->toBe('array')
-        ->and($parameters['ids[]']['schema']['items']['type'])->toBe('integer');
+        ->and($parameters['ids[]']['schema']['items']['type'])->toBe('integer')
+        ->and($parameters['ids[]']['style'])->toBe('form')
+        ->and($parameters['ids[]']['explode'])->toBeTrue()
+        // A scalar query parameter carries no serialization keywords.
+        ->and($parameters['term'])->not->toHaveKeys(['style', 'explode'])
+        ->and($parameters['page'])->not->toHaveKeys(['style', 'explode']);
+});
+
+it('does not flag its own inferred array query parameter as missing explode', function (): void {
+    Route::get('/oa-fixture/fr-explode', [SearchController::class, 'index']);
+
+    $this->artisan('openapi:lint', [
+        '--level' => 1,
+        '--only' => 'parameter.query-array-no-explode',
+        '--uri' => 'oa-fixture/fr-explode',
+        '--format' => 'json',
+    ])->assertExitCode(0);
 });
 
 it('still emits a request body for the same FormRequest on POST', function (): void {

--- a/tests/Fixtures/QueryAccessorFixtureController.php
+++ b/tests/Fixtures/QueryAccessorFixtureController.php
@@ -179,6 +179,12 @@ class QueryAccessorFixtureController extends Controller
         return new JsonResponse([$request->query('per_page')]);
     }
 
+    #[QueryParam('ids', type: 'array')]
+    public function arrayAttributeParam(Request $request): JsonResponse
+    {
+        return new JsonResponse([$request->query('ids')]);
+    }
+
     // endregion
 
     // region GET inline-validate hand-off
@@ -202,6 +208,16 @@ class QueryAccessorFixtureController extends Controller
             'ids.*' => 'integer',
             'rows' => 'array',
             'rows.*.price' => 'required|numeric',
+        ]);
+
+        return new JsonResponse($validated);
+    }
+
+    public function enumArraySearch(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'tags' => 'array',
+            'tags.*' => 'nullable|in:red,green,blue',
         ]);
 
         return new JsonResponse($validated);

--- a/tests/Unit/Core/Resolvers/CoreQueryParameterResolverTest.php
+++ b/tests/Unit/Core/Resolvers/CoreQueryParameterResolverTest.php
@@ -273,6 +273,16 @@ it('emits an open (untyped) schema for a #[QueryParam] without an explicit type'
     expect($perPage?->schema->type)->not->toBe(['string', 'null']);
 });
 
+it('does not add style/explode to a #[QueryParam] array — the explicit attribute wins untouched', function (): void {
+    $parameters = makeCoreQueryParameterResolver()
+        ->resolveQueryParameters(makeQueryAccessorDescriptor('arrayAttributeParam'));
+
+    $identifiers = queryParameterNamed($parameters, 'ids');
+
+    expect($identifiers?->style)->toBe(Generator::UNDEFINED)
+        ->and($identifiers?->explode)->toBe(Generator::UNDEFINED);
+});
+
 // endregion
 
 // region GET inline-validate hand-off
@@ -327,14 +337,32 @@ it('maps nested and array rule keys to wire notation and drops object arrays wit
     expect(queryParameterNames($parameters))->toBe(['filter[name]', 'ids[]'])
         ->and($filterName?->required)->toBeTrue()
         ->and($filterName?->schema->type)->toBe('string')
+        // A scalar query parameter carries no serialization keywords (both stay UNDEFINED).
+        ->and($filterName?->style)->toBe(Generator::UNDEFINED)
+        ->and($filterName?->explode)->toBe(Generator::UNDEFINED)
         ->and($identifiers?->required)->toBeFalse()
         ->and($identifiers?->schema->type)->toBe('array')
         ->and($identifiers?->schema->items->type)->toBe('integer')
+        // An inferred array query parameter is emitted as a repeated `name[]` (form/explode).
+        ->and($identifiers?->style)->toBe('form')
+        ->and($identifiers?->explode)->toBeTrue()
         ->and(array_any(
             $logger->records,
             static fn(array $record): bool => str_contains($record['message'], 'rows')
                 && str_contains($record['message'], 'cannot be expressed as query parameters'),
         ))->toBeTrue();
+});
+
+it('keeps style/explode on an array parameter independent of nullable/enum item rules', function (): void {
+    $parameters = makeCoreQueryParameterResolver()
+        ->resolveQueryParameters(makeQueryAccessorDescriptor('enumArraySearch'));
+
+    $tags = queryParameterNamed($parameters, 'tags[]');
+
+    expect($tags?->schema->type)->toBe('array')
+        ->and($tags?->schema->items->enum)->toBe(['red', 'green', 'blue'])
+        ->and($tags?->style)->toBe('form')
+        ->and($tags?->explode)->toBeTrue();
 });
 
 it('degrades dynamic rules on a GET route with a generation-log note', function (): void {


### PR DESCRIPTION
Closes #454

## Implementation plan — #454: explode/style on inferred array query parameters

### Goal

When the generator infers an **array** query parameter it currently emits
`schema: {type: array}` but leaves `explode`/`style` unset, so serialization is
ambiguous and the library's own `parameter.query-array-no-explode` lint rule fires
on its own output (19 findings across 4 corpus apps in the #413 re-baseline). Set
`style: form, explode: true` on inferred array query parameters — the form-array
default, and exactly what a PHP `name[]` repeated-array parameter means on the wire.

### Tier

**Tier-0.** No body parsing is added. The array-ness is already known from the
rule→schema mapping (`FieldDescriptor->type === 'array'`); we only attach the
correct OpenAPI serialization keywords to a parameter the resolver already builds.
The serialization of a `name[]` param is determinable from its shape — no dataflow.

### Where inferred array query params come from (verified)

There is exactly **one** code path that produces an inferred array query parameter:
`CoreQueryParameterResolver::flattenField()`'s array branch
(`src/Plugins/Core/Resolvers/CoreQueryParameterResolver.php:391-417`). It builds the
`name[]` parameter for both the inline-`validate()` source and the `FormRequest`
source (both call `flattenField`).

Confirmed **not** in scope:
- **Accessor reads** (`accessorParameters`, line 142-150) can only yield
  `string|integer|boolean` (`RequestQueryAccessorReader::ACCESSOR_TYPES` —
  `query/input/string/integer/boolean`), never `array`. No change needed.
- **`#[QueryParam]` attributes** (`attributeParameters`, line 462-475) are the
  explicit escape hatch — issue says "an explicit `#[QueryParam]` choice still
  wins". The attribute does **not** currently expose `style`/`explode`, and the
  issue does **not** ask to add them. Leave the attribute path untouched (an
  attribute-built array param without explode is the author's stated choice; the
  lint rule flagging it is then correct/honest). **No `#[QueryParam]` change.**
- **PaginationQueryParameterResolver** and the **QueryBuilder plugin** already set
  `style: form, explode: false` explicitly (`QueryBuilderParameterResolver.php:182-183`)
  — out of scope, and they prove the swagger-php model accepts these keys.

### swagger-php model boundary (verified)

`OpenApi\Annotations\Parameter` models both `style` and `explode` as native
properties (`php -r` reflection check: both `YES`). The QueryBuilder resolver
already ships `'style' => 'form', 'explode' => false` in the `OA\Parameter`
constructor array and passes the 5.8 CI job, so this shape is safe on swagger-php
5.8 and 6.x alike. We set the keys on the **Parameter**, not inside the Schema
(style/explode are parameter-level serialization keywords, not JSON-Schema).

### The change

`CoreQueryParameterResolver::flattenField()`, array branch only. The branch
currently does:

```php
$parameters[$name] = $this->parameter(
    $name,
    $schema,
    required: $ancestorsRequired && $descriptor->required === true,
);
```

It calls the private `parameter()` helper (line 164-172) which builds a plain
`OA\Parameter` with name/in/required/schema. Plan:

Set `style: 'form', explode: true` on the `OA\Parameter` built in the array branch
(line 410). **Reviewer preference (non-blocking):** set the two keys **directly on
that branch's `OA\Parameter`**, rather than threading `?string $style = null,
?bool $explode = null` through the shared `parameter()` helper — the helper has 3
other callers (lines 149, 426, plus the scalar branch) that would never pass them,
and the `#[QueryParam]` path (line 474) doesn't use the helper at all. Keeping the
change inside the one branch that needs it leaves the scalar call sites literally
untouched. (Threading the helper signature is also correct and byte-identical if the
coder prefers it; verified an `OA\Parameter` without these keys serializes them as
`Generator::UNDEFINED`, i.e. omitted.)

### Files to modify

- `src/Plugins/Core/Resolvers/CoreQueryParameterResolver.php` — the array branch
  (line 410); the `parameter()` helper only if the coder takes the threading option.

No new files. No `Contracts\` change. No config key. No public-signature change
(`parameter()` is `private`).

### Tests (TDD — failing test first)

Existing coverage to extend: `tests/Unit/Core/Resolvers/CoreQueryParameterResolverTest.php`
already has `it('maps nested and array rule keys to wire notation ...')` (line 319)
asserting on the `ids[]` parameter — extend it (or add a sibling `it`) to assert the
new keys. Branches/edge cases to cover:

1. **Inferred array via inline `validate()`** (`ids` + `ids.*`) → the `ids[]`
   parameter has `style === 'form'` and `explode === true` (in addition to the
   existing `schema->type === 'array'`, `items->type === 'integer'` assertions).
2. **Inferred array via FormRequest** `rules()` on a GET action → same `style`/
   `explode` on the emitted `name[]` param (use the existing FormRequest query
   fixture / `tests/Feature/FormRequestQueryParameterTest.php`).
3. **Scalar param unchanged** — a non-array inferred query param (e.g. `filter[name]`,
   or a plain `page` accessor read) has `style === null` **and** `explode === null`
   (regression guard: prove the scalar path didn't pick up the keys).
4. **Nullable array / enum-array** — an array param whose items carry `nullable`/an
   `enum` still gets `style: form, explode: true` (the keys are independent of the
   item schema; one assertion to lock the interaction).
5. **`#[QueryParam]`-supplied array is untouched** — an explicit attribute array
   param does **not** gain `style`/`explode` from this change (proves the override
   path is the author's responsibility, matching the acceptance criterion).
6. **Self-lint no longer fires** — a feature/integration test that generates a spec
   for a controller with an inferred array query param and runs the lint pipeline,
   asserting `parameter.query-array-no-explode` produces **zero** findings on the
   generator's own output. (This is the issue's headline acceptance criterion; place
   it where the lint-over-generated-spec harness already lives, or add a focused
   `tests/Feature` test if none fits.)

### Observable behaviour → docs + CHANGELOG

- **docs/auto-derivation.md:442** — the sentence "a scalar list (`ids` + `ids.*`)
  → a repeatable `ids[]` with an array schema" should be extended to note the param
  is emitted with `style: form, explode: true` (PHP's `name[]` repeated-array wire
  format). One-clause edit.
- **CHANGELOG.md `[Unreleased]`** — add a line under the appropriate subsection
  (likely **Changed** or **Fixed**, since it changes emitted output and stops a
  self-lint finding): "Inferred array query parameters now carry `style: form,
  explode: true`, matching PHP's `name[]` wire format and removing the ambiguous
  serialization that tripped the library's own `parameter.query-array-no-explode`
  rule. (#454)".

### Survey gate (generation-affecting, area:params)

Expected, intended spec deltas the lead should expect from the survey:
- Inferred array query params across corpus apps gain `style: form` + `explode: true`
  (e.g. Lychee `GET /api/v2/Album::photos` `tag_ids[]`).
- `parameter.query-array-no-explode` findings drop by ~19 across the 4 affected apps
  (the rule stops firing on inferred output).
- **No** path/operation/schema count changes; **no** scalar-param changes. Any
  delta beyond "array query params gain style/explode + fewer lint findings" is a
  regression.

### Controversy flags

**None.** No `Contracts\` change, no stage-order change, no config key, no public
signature change (the only touched method is `private`). The chosen defaults
(`style: form, explode: true`) are the OpenAPI form-array default and match what
the QueryBuilder/Pagination resolvers already do, so they are consistent in-tree.
Straightforward auto-merge candidate once gates are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
