### PR TITLE
fix(survey): resolve metrics.php autoloader from the main checkout when run from a worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to this project are documented here.
 - `ValidationRulesToSchema` maps additional rules (`multiple_of`, Email/Exists/Unique/NotIn objects, wildcard keys) it previously dropped (#83).
 - ApiResources: actions that return an API Resource without declaring a return type (relying on convention or a third-party doc attribute) now resolve their response schema via the return-expression reader, instead of emitting no content; the refusal notice is suppressed on the untyped path to avoid a notice per non-resource action. (#391)
 - `path.parameter-undeclared` no longer false-positives on custom-key route bindings (`{param:field}`); URI-placeholder extraction is now shared between the generator and the linter. (#426)
+- Survey tooling: `tools/survey/metrics.php` resolves its Composer autoloader from the main checkout when run from a git worktree (which has no `vendor/` of its own), so parsing a YAML published spec no longer fatals and false-FAILs those apps. (#468)
 
 ### Documentation
 - README refreshed for the current feature set (Tier-1 method-body inference, SwaggerPhp plugin) and trimmed to a gentle overview that defers detail to `docs/`.

--- a/tests/Tools/SurveyMetricsTest.php
+++ b/tests/Tools/SurveyMetricsTest.php
@@ -82,3 +82,8 @@ it('adds coverage when a published spec is supplied', function (): void {
         ->and($m['coverage']['intersection'])->toBe(1)
         ->and($m['coverage']['covPercent'])->toBe(50.0);
 });
+
+it('picks the first existing file from the autoloader candidate list', function (): void {
+    expect(survey_firstExistingFile(['/no/such/file', __FILE__, '/another/missing']))->toBe(__FILE__)
+        ->and(survey_firstExistingFile(['/no/such/file', '/also/missing']))->toBeNull();
+});

--- a/tools/survey/metrics.php
+++ b/tools/survey/metrics.php
@@ -255,6 +255,41 @@ function surveyMetrics(array $spec, array $lint, array $run, string $apiPrefix =
     return $metrics;
 }
 
+/** First existing path from an ordered candidate list, or null when none exist. */
+function survey_firstExistingFile(array $candidates): ?string
+{
+    foreach ($candidates as $candidate) {
+        if (is_file($candidate)) {
+            return $candidate;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Locate a Composer autoloader.
+ *
+ * The survey can point LIB at a git worktree, which shares the main repo's .git but has no
+ * vendor/ of its own (only the main checkout is composer-installed). Prefer this checkout's
+ * vendor/, then fall back to the main checkout resolved via the shared git common dir.
+ */
+function survey_resolveAutoloader(): ?string
+{
+    $candidates = [dirname(__DIR__, 2) . '/vendor/autoload.php'];
+
+    $commonDir = trim((string) @shell_exec(
+        'git -C ' . escapeshellarg(__DIR__)
+        . ' rev-parse --path-format=absolute --git-common-dir 2>/dev/null',
+    ));
+
+    if ($commonDir !== '' && ($mainGitDir = realpath($commonDir)) !== false) {
+        $candidates[] = dirname($mainGitDir) . '/vendor/autoload.php';
+    }
+
+    return survey_firstExistingFile($candidates);
+}
+
 // CLI entry — only when invoked directly, so the file is safe to require in tests.
 if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__FILE__)) {
     $appDir = $argv[1] ?? null;
@@ -287,7 +322,15 @@ if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__F
         $published = json_decode($raw, true);
 
         if (!is_array($published)) {
-            require_once dirname(__DIR__, 2) . '/vendor/autoload.php';
+            $autoloader = survey_resolveAutoloader();
+
+            if ($autoloader === null) {
+                fwrite(STDERR, "metrics.php: could not locate vendor/autoload.php to parse a YAML spec "
+                    . "(is the main checkout composer-installed?)\n");
+                exit(2);
+            }
+
+            require_once $autoloader;
             $published = (array) Symfony\Component\Yaml\Yaml::parse($raw);
         }
 

--- a/tools/survey/metrics.php
+++ b/tools/survey/metrics.php
@@ -325,7 +325,7 @@ if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__F
             $autoloader = survey_resolveAutoloader();
 
             if ($autoloader === null) {
-                fwrite(STDERR, "metrics.php: could not locate vendor/autoload.php to parse a YAML spec "
+                fwrite(STDERR, 'metrics.php: could not locate vendor/autoload.php to parse a YAML spec '
                     . "(is the main checkout composer-installed?)\n");
                 exit(2);
             }


### PR DESCRIPTION
## The bug

`tools/survey/metrics.php` requires `<LIB>/vendor/autoload.php` (via `dirname(__DIR__, 2)`) when
parsing a **YAML** published spec, to load `Symfony\Component\Yaml\Yaml`. When the surveyor points
`LIB` at a **git worktree** (the standard autonomous-team candidate layout), that worktree has **no
`vendor/`** of its own (only the main checkout is composer-installed), so the bare `require_once`
fatals. The app's metrics come back `null`, which reads as a spurious survey FAIL even though
generation fully succeeded. This false-FAILs every app that ships a YAML published spec (e.g.
InvoiceNinja, Koel) whenever the survey measures a worktree.

## The fix (issue option a)

`metrics.php` now resolves its Composer autoloader robustly instead of a bare require:

1. Prefer this checkout's `vendor/autoload.php` (the normal main-checkout case — unchanged).
2. When absent, fall back to the **main checkout's** autoloader. A worktree shares the main repo's
   `.git`; `git rev-parse --path-format=absolute --git-common-dir` returns `<main>/.git`, whose
   parent is the main checkout root. The result is `realpath`-normalised before use.
3. If neither resolves, write a clear message to STDERR and `exit(2)` rather than letting a bare
   require fatal — a clean failure beats a fatal.

Implemented as two small functions near the CLI block: a pure `survey_firstExistingFile()` seam
(picks the first existing path from an ordered candidate list) and `survey_resolveAutoloader()`
(builds the candidate list, shelling out to git for the worktree fallback).

## Verification

- **Unit:** added a focused test for the pure `survey_firstExistingFile()` seam (first-existing and
  none-existing cases). The git-shelling resolver is verified manually below rather than mocked.
- **Manual, worktree fallback:** ran the resolver from a vendorless detached worktree of this
  branch — it returned the **main checkout's** `/Users/moritz/Projects/laravel-openapi/vendor/autoload.php`,
  exactly the intended fallback.
- **Manual, end-to-end:** ran `php metrics.php <app> --published=<spec.yaml>` against a fixture app
  with a YAML published spec from **both** a vendorless worktree (the bug scenario) and the main
  checkout. Both now emit the metrics JSON (YAML parsed, no fatal); previously the worktree run
  fataled.
- `composer check` (format:check + lint + test) green locally: 3230 tests pass.

## Scope

Fast-path `area:survey` change to internal tooling under `tools/`. No generation impact, so no
survey gate. No `docs/` change needed — `tools/survey/README.md` and `methodology.md` describe the
unchanged CLI interface, not the autoloader internals.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mTGxbjxEkd6Ck4Q1DqWJ3
