### PR TITLE
fix(tooling): guard empty-array expansion in bin/open-pr for bash 3.2

### DIFF
--- a/.claude/skills/autonomous-team/bin/open-pr
+++ b/.claude/skills/autonomous-team/bin/open-pr
@@ -53,5 +53,5 @@ gh pr create \
   --title "$title" \
   --body "$body" \
   --assignee "$assignee" \
-  "${label_args[@]}" \
-  "${draft_args[@]}"
+  "${label_args[@]+"${label_args[@]}"}" \
+  "${draft_args[@]+"${draft_args[@]}"}"


### PR DESCRIPTION
Closes #470

## What
Guard the empty-array expansions in `.claude/skills/autonomous-team/bin/open-pr` so the script runs under macOS's stock **bash 3.2**.

## Why
`"${draft_args[@]}"` (and `"${label_args[@]}"`) under `set -u` raise `unbound variable` on bash 3.2 when the array is **empty** — which is the common case for `draft_args` on a ready (non-draft) PR. The script aborted before calling `gh pr create`. Discovered during the #468 run, where the coder had to mirror the label logic by hand.

## Fix
Use the bash 3.2-safe `"${arr[@]+"${arr[@]}"}"` idiom for both `label_args` and `draft_args`. An empty array now expands to nothing instead of erroring.

A sweep of the other `bin/` scripts found **no other** `[@]` empty-array expansions, so `open-pr` was the only affected script.

## Verification
- `bash -n` clean; reproduced the original `unbound variable` abort on `/bin/bash 3.2.57` and confirmed the fixed idiom expands correctly for empty, populated, and both-empty arrays.
- **This PR was opened with the fixed `bin/open-pr`** (ready, non-draft, empty `draft_args`) — dogfooded.

Fast-path (tooling-only, no `src/` change, non-generation-affecting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)