### PR TITLE
fix(core): consolidate Tier-1 return-resolution + fix Data stale-mutation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ All notable changes to this project are documented here.
 - `openapi:generate` emits an advisory hint on stderr when an integration package (`league/fractal`, `spatie/laravel-fractal`, `spatie/laravel-query-builder`) is installed but its plugin is not enabled, pointing at the `config/openapi.php` line that would let it infer schemas and parameters. Advisory only: never auto-enables, never pollutes the `--output=-` document. (#444)
 - Inferred array query parameters (`ids[]` from a scalar-list validation rule) now carry `style: form` and `explode: true`, matching PHP's `name[]` repeated-pair wire format and removing the ambiguous serialisation that tripped the library's own `parameter.query-array-no-explode` lint rule. Scalar query parameters and explicit `#[QueryParam]` arrays are unchanged. (#454)
 - New `operation.action-method-missing` lint rule (level 1) flags routes whose action resolves to a controller method that does not exist (e.g. an over-registered resourceful route): the operation is documented but would fault at runtime. Skips closures and routes whose controller class is itself absent. (#448)
+- Fixed: the Spatie Data and API Resource return-expression readers no longer attribute a stale value to a returned variable that is mutated after its single unconditional assignment (`$data['k'] = …`, `$data += …`); such a body now degrades to the honest fallback, matching the array-literal finder. Consolidates the three divergent return-resolution copies onto a shared `ReturnExpressionResolver`. (#486)
 
 ## [0.1.0] - 2026-05-18
 

--- a/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
+++ b/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
@@ -9,12 +9,8 @@ use Illuminate\Database\Eloquent\Attributes\UseResource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
-use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\Closure as ClosureExpression;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_ as NewExpression;
@@ -23,15 +19,14 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Return_;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Radiergummi\OpenApi\Enums\PaginatorKind;
 use Radiergummi\OpenApi\Routing\ResourceTarget;
-use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
-use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnExpressionResolver;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnVariableRefusal;
 use Radiergummi\OpenApi\Support\PhpDoc\DocBlockParser;
 use Radiergummi\OpenApi\Support\Types\TypeNodeResolver;
 use ReflectionClass;
@@ -44,7 +39,6 @@ use function class_exists;
 use function count;
 use function in_array;
 use function is_a;
-use function is_array;
 use function is_string;
 use function method_exists;
 use function sprintf;
@@ -97,16 +91,13 @@ final class ReturnExpressionResourceReader
      */
     private array $cache = [];
 
-    private readonly StatementNodeFinder $statementNodeFinder;
-
     public function __construct(
         private readonly MethodBodyScanner $scanner,
         private readonly DocBlockParser $docBlockParser,
         private readonly TypeNodeResolver $typeNodeResolver,
         private readonly LoggerInterface $logger,
-    ) {
-        $this->statementNodeFinder = new StatementNodeFinder();
-    }
+        private readonly ReturnExpressionResolver $returnExpressionResolver = new ReturnExpressionResolver(),
+    ) {}
 
     public static function create(?LoggerInterface $logger = null): self
     {
@@ -438,13 +429,7 @@ final class ReturnExpressionResourceReader
      */
     private function methodLevelReturns(array $statements): array
     {
-        $found = [];
-
-        foreach ($statements as $statement) {
-            $this->collectMethodLevelReturns($statement, $found);
-        }
-
-        return $found;
+        return $this->returnExpressionResolver->methodLevelReturns($statements);
     }
 
     // endregion
@@ -452,37 +437,9 @@ final class ReturnExpressionResourceReader
     // region Call-shape matching
 
     /**
-     * @param list<Return_> $found
-     */
-    private function collectMethodLevelReturns(Node $node, array &$found): void
-    {
-        if (
-            $node instanceof ClosureExpression
-            || $node instanceof ArrowFunction
-            || $node instanceof ClassLike
-        ) {
-            return;
-        }
-
-        if ($node instanceof Return_) {
-            $found[] = $node;
-        }
-
-        foreach ($node->getSubNodeNames() as $subNodeName) {
-            /** @var mixed $children */
-            $children = $node->{$subNodeName};
-
-            foreach (is_array($children) ? $children : [$children] as $child) {
-                if ($child instanceof Node) {
-                    $this->collectMethodLevelReturns($child, $found);
-                }
-            }
-        }
-    }
-
-    /**
-     * Resolves `return $variable;` through the single unconditional assignment to that variable.
-     * A conditional reassignment makes the type a guess. Pass `log: false` to suppress the notice.
+     * Resolves `return $variable;` through the single unconditional assignment to that variable,
+     * refused when the variable is dynamically named, not assigned exactly once on the
+     * unconditional path, or mutated after its assignment. Pass `log: false` to suppress the notice.
      *
      * @param list<Stmt> $statements
      */
@@ -492,50 +449,35 @@ final class ReturnExpressionResourceReader
         ReflectionMethod $method,
         bool $log = true,
     ): ?Expr {
-        $variableName = $variable->name;
+        $resolution = $this->returnExpressionResolver->resolveVariable($variable, $statements);
 
-        if (!is_string($variableName)) {
-            if ($log) {
-                $this->note($method, 'returns a dynamically-named variable');
-            }
-
-            return null;
+        if ($resolution->expression !== null) {
+            return $resolution->expression;
         }
 
-        $isAssignmentToVariable = static fn(Node $node): bool
-            => $node instanceof Assign
-            && $node->var instanceof Variable
-            && $node->var->name === $variableName;
-
-        $allAssignments = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::IncludeConditionalContexts,
-            $isAssignmentToVariable,
-        );
-        $unconditionalAssignments = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::SkipConditionalContexts,
-            $isAssignmentToVariable,
-        );
-
-        if (count($allAssignments) !== 1 || count($unconditionalAssignments) !== 1) {
-            if ($log) {
-                $this->note(
-                    $method,
-                    sprintf(
-                        'returns $%s, which is not assigned exactly once on the unconditional path',
-                        $variableName,
-                    ),
-                );
-            }
-
-            return null;
+        if ($log) {
+            $this->note($method, $this->refusalReason($resolution->refusal, $variable));
         }
 
-        /** @var Assign $assignment */
-        $assignment = $unconditionalAssignments[0];
+        return null;
+    }
 
-        return $assignment->expr;
+    /**
+     * The existing per-refusal notice wording, preserved verbatim so the log surface is unchanged.
+     */
+    private function refusalReason(?ReturnVariableRefusal $refusal, Variable $variable): string
+    {
+        return match ($refusal) {
+            ReturnVariableRefusal::DynamicallyNamedVariable => 'returns a dynamically-named variable',
+            ReturnVariableRefusal::MutatedAfterAssignment => sprintf(
+                'returns $%s, which is mutated after its single unconditional assignment',
+                is_string($variable->name) ? $variable->name : '{dynamic}',
+            ),
+            default => sprintf(
+                'returns $%s, which is not assigned exactly once on the unconditional path',
+                is_string($variable->name) ? $variable->name : '{dynamic}',
+            ),
+        };
     }
 
     /**

--- a/src/Plugins/Core/ErrorContributors/AbortErrorContributor.php
+++ b/src/Plugins/Core/ErrorContributors/AbortErrorContributor.php
@@ -20,6 +20,7 @@ use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
 use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
+use Radiergummi\OpenApi\Support\MethodBody\UnqualifiedHelperCall;
 use ReflectionMethod;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -27,7 +28,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 use function array_key_exists;
 use function array_search;
-use function function_exists;
 use function is_int;
 use function is_string;
 use function sprintf;
@@ -118,17 +118,7 @@ final readonly class AbortErrorContributor implements ErrorResponseContributor
             return null;
         }
 
-        if ($call->name->isFullyQualified()) {
-            return $name;
-        }
-
-        $namespacedName = $call->name->getAttribute('namespacedName');
-
-        if ($namespacedName instanceof Name && function_exists($namespacedName->toString())) {
-            return null;
-        }
-
-        return $name;
+        return UnqualifiedHelperCall::resolvesToGlobalHelper($call->name) ? $name : null;
     }
 
     // endregion

--- a/src/Plugins/Core/Support/FormRequestStaticRulesReader.php
+++ b/src/Plugins/Core/Support/FormRequestStaticRulesReader.php
@@ -5,23 +5,20 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Plugins\Core\Support;
 
 use Illuminate\Container\Attributes\Scoped;
-use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\Return_;
 use Radiergummi\OpenApi\Support\MethodBody\AstLiteralEvaluator;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnExpressionResolver;
 use Radiergummi\OpenApi\Support\MethodBody\RuleFieldLiteralMapper;
 use Radiergummi\OpenApi\Support\MethodBody\SingleReturnArrayLiteralFinder;
 use ReflectionMethod;
 
 use function count;
 use function in_array;
-use function is_array;
 use function is_string;
 
 /**
@@ -44,8 +41,12 @@ final readonly class FormRequestStaticRulesReader
 
     public function __construct(
         private MethodBodyScanner $scanner,
+        private ReturnExpressionResolver $returnExpressionResolver = new ReturnExpressionResolver(),
     ) {
-        $this->bareReturnFinder = new SingleReturnArrayLiteralFinder($this->scanner);
+        $this->bareReturnFinder = new SingleReturnArrayLiteralFinder(
+            $this->scanner,
+            $this->returnExpressionResolver,
+        );
     }
 
     /**
@@ -76,12 +77,7 @@ final readonly class FormRequestStaticRulesReader
             return null;
         }
 
-        /** @var list<Return_> $returns */
-        $returns = [];
-
-        foreach ($statements as $statement) {
-            $this->collectReturns($statement, $returns);
-        }
+        $returns = $this->returnExpressionResolver->methodLevelReturns($statements);
 
         if (count($returns) !== 1) {
             return null;
@@ -155,32 +151,5 @@ final readonly class FormRequestStaticRulesReader
         }
 
         return $rules === [] ? null : $rules;
-    }
-
-    /**
-     * Depth-first return collection, skipping nested function-like scopes (closures, anon classes).
-     *
-     * @param list<Return_> $returns
-     */
-    private function collectReturns(Node $node, array &$returns): void
-    {
-        if ($node instanceof FunctionLike) {
-            return;
-        }
-
-        if ($node instanceof Return_) {
-            $returns[] = $node;
-        }
-
-        foreach ($node->getSubNodeNames() as $subNodeName) {
-            /** @var mixed $children */
-            $children = $node->{$subNodeName};
-
-            foreach (is_array($children) ? $children : [$children] as $child) {
-                if ($child instanceof Node) {
-                    $this->collectReturns($child, $returns);
-                }
-            }
-        }
     }
 }

--- a/src/Plugins/Core/Support/InlineJsonCallReader.php
+++ b/src/Plugins/Core/Support/InlineJsonCallReader.php
@@ -21,9 +21,9 @@ use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
 use Radiergummi\OpenApi\Support\MethodBody\SchemaDefinitionFromLiteral;
 use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
+use Radiergummi\OpenApi\Support\MethodBody\UnqualifiedHelperCall;
 
 use function array_find;
-use function function_exists;
 use function in_array;
 use function is_int;
 use function sprintf;
@@ -94,13 +94,7 @@ final readonly class InlineJsonCallReader
             return false;
         }
 
-        if ($receiver->name->isFullyQualified()) {
-            return true;
-        }
-
-        $namespacedName = $receiver->name->getAttribute('namespacedName');
-
-        return !($namespacedName instanceof Name && function_exists($namespacedName->toString()));
+        return UnqualifiedHelperCall::resolvesToGlobalHelper($receiver->name);
     }
 
     // endregion

--- a/src/Plugins/SpatieData/Support/DataReturnExpressionReader.php
+++ b/src/Plugins/SpatieData/Support/DataReturnExpressionReader.php
@@ -5,22 +5,16 @@ declare(strict_types=1);
 namespace Radiergummi\OpenApi\Plugins\SpatieData\Support;
 
 use Illuminate\Container\Attributes\Scoped;
-use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\Closure as ClosureExpression;
 use PhpParser\Node\Expr\New_ as NewExpression;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Return_;
-use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
-use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnExpressionResolver;
 use ReflectionMethod;
 use Spatie\LaravelData\Data;
 
@@ -28,17 +22,16 @@ use function array_key_exists;
 use function class_exists;
 use function count;
 use function is_a;
-use function is_array;
-use function is_string;
 
 /**
  * Recovers the concrete Spatie {@see Data} class an action returns when its signature names only a
  * generic container (`Collection`, `array`, …). Consulted by `DataResponseResolver` as a fallback.
  *
  * Bounded scan of the first {@see self::STATEMENT_LIMIT} statements: one unconditional return (or
- * the variable it names, assigned exactly once on the unconditional path), matched against two
- * literal-class shapes — `DataClass::collect(...)` (collection) and `new DataClass(...)` (single).
- * Anything else, or a non-Data class, reads back as null and degrades silently. Memoised per method.
+ * the variable it names, assigned exactly once on the unconditional path and never mutated after),
+ * matched against two literal-class shapes — `DataClass::collect(...)` (collection) and
+ * `new DataClass(...)` (single). Anything else, or a non-Data class, reads back as null and degrades
+ * silently. Memoised per method.
  *
  * @internal
  */
@@ -54,12 +47,10 @@ final class DataReturnExpressionReader
      */
     private array $cache = [];
 
-    private readonly StatementNodeFinder $statementNodeFinder;
-
-    public function __construct(private readonly MethodBodyScanner $scanner)
-    {
-        $this->statementNodeFinder = new StatementNodeFinder();
-    }
+    public function __construct(
+        private readonly MethodBodyScanner $scanner,
+        private readonly ReturnExpressionResolver $returnExpressionResolver = new ReturnExpressionResolver(),
+    ) {}
 
     public static function create(): self
     {
@@ -87,7 +78,7 @@ final class DataReturnExpressionReader
         }
 
         $expression = $returnExpression instanceof Variable
-            ? $this->expressionAssignedTo($returnExpression, $statements)
+            ? $this->returnExpressionResolver->resolveVariable($returnExpression, $statements)->expression
             : $returnExpression;
 
         if ($expression === null) {
@@ -119,89 +110,11 @@ final class DataReturnExpressionReader
             return null;
         }
 
-        $found = [];
-
-        foreach ($statements as $statement) {
-            $this->collectMethodLevelReturns($statement, $found);
-        }
-
-        if (count($found) > 1) {
+        if (count($this->returnExpressionResolver->methodLevelReturns($statements)) > 1) {
             return null;
         }
 
         return $topLevelReturn->expr;
-    }
-
-    /**
-     * Returns belonging to the method itself; closures, arrow functions, and anonymous classes
-     * open their own scope and are excluded.
-     *
-     * @param list<Return_> $found
-     */
-    private function collectMethodLevelReturns(Node $node, array &$found): void
-    {
-        if (
-            $node instanceof ClosureExpression
-            || $node instanceof ArrowFunction
-            || $node instanceof ClassLike
-        ) {
-            return;
-        }
-
-        if ($node instanceof Return_) {
-            $found[] = $node;
-        }
-
-        foreach ($node->getSubNodeNames() as $subNodeName) {
-            /** @var mixed $children */
-            $children = $node->{$subNodeName};
-
-            foreach (is_array($children) ? $children : [$children] as $child) {
-                if ($child instanceof Node) {
-                    $this->collectMethodLevelReturns($child, $found);
-                }
-            }
-        }
-    }
-
-    /**
-     * Resolves `return $variable;` through the single unconditional assignment to that variable.
-     * A conditional reassignment makes the type a guess.
-     *
-     * @param list<Stmt> $statements
-     */
-    private function expressionAssignedTo(Variable $variable, array $statements): ?Expr
-    {
-        $variableName = $variable->name;
-
-        if (!is_string($variableName)) {
-            return null;
-        }
-
-        $isAssignmentToVariable = static fn(Node $node): bool
-            => $node instanceof Assign
-            && $node->var instanceof Variable
-            && $node->var->name === $variableName;
-
-        $allAssignments = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::IncludeConditionalContexts,
-            $isAssignmentToVariable,
-        );
-        $unconditionalAssignments = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::SkipConditionalContexts,
-            $isAssignmentToVariable,
-        );
-
-        if (count($allAssignments) !== 1 || count($unconditionalAssignments) !== 1) {
-            return null;
-        }
-
-        /** @var Assign $assignment */
-        $assignment = $unconditionalAssignments[0];
-
-        return $assignment->expr;
     }
 
     /**

--- a/src/Support/MethodBody/ReturnExpressionResolver.php
+++ b/src/Support/MethodBody/ReturnExpressionResolver.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\MethodBody;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Return_;
+
+use function count;
+use function is_array;
+use function is_string;
+
+/**
+ * Shared return-resolution primitive for the bounded body scanners.
+ *
+ * Two concerns the Data, API Resource, and array-literal readers each hand-rolled:
+ *  - collecting the method's own top-level returns (skipping nested closures / anonymous classes);
+ *  - reducing a `return $variable;` to the single expression the variable is assigned, refusing a
+ *    dynamically-named variable, zero/multiple/conditional assignments, and — critically — any
+ *    unconditional mutation *after* the assignment (an element write `$v['k'] = …` or a compound
+ *    assignment `$v += …`), which would leave the base value stale.
+ *
+ * Log-free by design: refusals are returned as {@see ReturnVariableRefusal} so plugin readers can
+ * apply their own logging without pushing that policy into the Support layer.
+ *
+ * @internal
+ */
+final readonly class ReturnExpressionResolver
+{
+    public function __construct(
+        private StatementNodeFinder $statementNodeFinder = new StatementNodeFinder(),
+    ) {}
+
+    /**
+     * The method's own return statements, in source order. Closures, arrow functions, and
+     * anonymous classes open their own scope and are excluded.
+     *
+     * @param list<Stmt> $statements
+     *
+     * @return list<Return_>
+     */
+    public function methodLevelReturns(array $statements): array
+    {
+        $returns = [];
+
+        foreach ($statements as $statement) {
+            $this->collectReturns($statement, $returns);
+        }
+
+        return $returns;
+    }
+
+    /**
+     * Resolves `return $variable;` through the variable's single unconditional assignment.
+     *
+     * @param list<Stmt> $statements
+     */
+    public function resolveVariable(Variable $variable, array $statements): ReturnVariableResolution
+    {
+        $variableName = $variable->name;
+
+        if (!is_string($variableName)) {
+            return ReturnVariableResolution::refused(ReturnVariableRefusal::DynamicallyNamedVariable);
+        }
+
+        $isAssignmentToVariable = static fn(Node $node): bool
+            => $node instanceof Assign
+            && $node->var instanceof Variable
+            && $node->var->name === $variableName;
+
+        $allAssignments = $this->statementNodeFinder->findAll(
+            $statements,
+            ConditionalContextPolicy::IncludeConditionalContexts,
+            $isAssignmentToVariable,
+        );
+        $unconditionalAssignments = $this->statementNodeFinder->findAll(
+            $statements,
+            ConditionalContextPolicy::SkipConditionalContexts,
+            $isAssignmentToVariable,
+        );
+
+        if (count($allAssignments) !== 1 || count($unconditionalAssignments) !== 1) {
+            return ReturnVariableResolution::refused(ReturnVariableRefusal::NotAssignedOnce);
+        }
+
+        $unconditionalMutations = $this->statementNodeFinder->findAll(
+            $statements,
+            ConditionalContextPolicy::SkipConditionalContexts,
+            fn(Node $node): bool => $this->mutatesVariable($node, $variableName),
+        );
+
+        if ($unconditionalMutations !== []) {
+            return ReturnVariableResolution::refused(ReturnVariableRefusal::MutatedAfterAssignment);
+        }
+
+        /** @var Assign $assignment */
+        $assignment = $unconditionalAssignments[0];
+
+        return ReturnVariableResolution::resolved($assignment->expr);
+    }
+
+    /**
+     * Whether the node mutates the named variable after its assignment: an element write
+     * (`$v['k'] = …`, an `Assign` whose target is an array-dimension fetch rooted at the variable)
+     * or any compound assignment (`$v += …`, `$v['k'] .= …`).
+     */
+    private function mutatesVariable(Node $node, string $variableName): bool
+    {
+        $target = match (true) {
+            $node instanceof AssignOp => $node->var,
+            $node instanceof Assign && $node->var instanceof ArrayDimFetch => $node->var,
+            default => null,
+        };
+
+        while ($target instanceof ArrayDimFetch) {
+            $target = $target->var;
+        }
+
+        return $target instanceof Variable && $target->name === $variableName;
+    }
+
+    /**
+     * Depth-first return collection, skipping nested scopes (closures, arrow functions, functions,
+     * and anonymous classes). {@see FunctionLike} covers closures/arrow functions/nested functions;
+     * {@see ClassLike} covers anonymous classes — the union is a superset of the skip-predicates the
+     * consolidated readers used.
+     *
+     * @param list<Return_> $returns
+     */
+    private function collectReturns(Node $node, array &$returns): void
+    {
+        if ($node instanceof FunctionLike || $node instanceof ClassLike) {
+            return;
+        }
+
+        if ($node instanceof Return_) {
+            $returns[] = $node;
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+            /** @var mixed $children */
+            $children = $node->{$subNodeName};
+
+            foreach (is_array($children) ? $children : [$children] as $child) {
+                if ($child instanceof Node) {
+                    $this->collectReturns($child, $returns);
+                }
+            }
+        }
+    }
+}

--- a/src/Support/MethodBody/ReturnVariableRefusal.php
+++ b/src/Support/MethodBody/ReturnVariableRefusal.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\MethodBody;
+
+/**
+ * Why {@see ReturnExpressionResolver} could not reduce a returned variable to a single, stable
+ * assignment expression. Callers that log map these onto their own wording; the resolver itself
+ * stays log-free.
+ *
+ * @internal
+ */
+enum ReturnVariableRefusal
+{
+    /** The variable name is an expression (`$$name`, `${…}`), not statically knowable. */
+    case DynamicallyNamedVariable;
+
+    /** Not assigned exactly once on the unconditional path (zero, multiple, or conditional). */
+    case NotAssignedOnce;
+
+    /** Assigned once, but mutated afterwards (`$v['k'] = …`, `$v += …`), so the value is stale. */
+    case MutatedAfterAssignment;
+}

--- a/src/Support/MethodBody/ReturnVariableResolution.php
+++ b/src/Support/MethodBody/ReturnVariableResolution.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\MethodBody;
+
+use PhpParser\Node\Expr;
+
+/**
+ * The outcome of resolving a returned variable through its single unconditional assignment: either
+ * the assigned expression, or the reason it could not be reduced to one. Exactly one of the two is
+ * set.
+ *
+ * @internal
+ */
+final readonly class ReturnVariableResolution
+{
+    private function __construct(
+        public ?Expr $expression,
+        public ?ReturnVariableRefusal $refusal,
+    ) {}
+
+    public static function resolved(Expr $expression): self
+    {
+        return new self($expression, null);
+    }
+
+    public static function refused(ReturnVariableRefusal $refusal): self
+    {
+        return new self(null, $refusal);
+    }
+}

--- a/src/Support/MethodBody/SingleReturnArrayLiteralFinder.php
+++ b/src/Support/MethodBody/SingleReturnArrayLiteralFinder.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace Radiergummi\OpenApi\Support\MethodBody;
 
-use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayDimFetch;
-use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Return_;
 use ReflectionMethod;
 
 use function count;
 use function in_array;
-use function is_array;
-use function is_string;
 
 /**
  * Locates the single top-level `return [...]` in a method body; the canonical shape for API
@@ -33,13 +24,10 @@ final readonly class SingleReturnArrayLiteralFinder
 {
     public const int STATEMENT_LIMIT = 10;
 
-    private StatementNodeFinder $statementNodeFinder;
-
     public function __construct(
         private MethodBodyScanner $scanner,
-    ) {
-        $this->statementNodeFinder = new StatementNodeFinder();
-    }
+        private ReturnExpressionResolver $returnExpressionResolver = new ReturnExpressionResolver(),
+    ) {}
 
     public function find(ReflectionMethod $method): ?Array_
     {
@@ -49,12 +37,7 @@ final readonly class SingleReturnArrayLiteralFinder
             return null;
         }
 
-        /** @var list<Return_> $returns */
-        $returns = [];
-
-        foreach ($statements as $statement) {
-            $this->collectReturns($statement, $returns);
-        }
+        $returns = $this->returnExpressionResolver->methodLevelReturns($statements);
 
         if (count($returns) !== 1) {
             return null;
@@ -71,114 +54,11 @@ final readonly class SingleReturnArrayLiteralFinder
         }
 
         if ($return->expr instanceof Variable) {
-            return $this->arrayLiteralAssignedTo($return->expr, $statements);
+            $resolution = $this->returnExpressionResolver->resolveVariable($return->expr, $statements);
+
+            return $resolution->expression instanceof Array_ ? $resolution->expression : null;
         }
 
         return null;
-    }
-
-    /**
-     * The array literal a returned variable is assigned, when it is assigned exactly once on the
-     * unconditional path and that assignment's value is an array literal. Refuses a dynamically-
-     * named variable, zero or multiple assignments, a conditional assignment, or a non-literal
-     * value.
-     *
-     * Any further unconditional write that mutates the variable after the literal (an element
-     * write `$data['k'] = …` or a compound assignment like `$data += [...]`) also refuses: the
-     * base literal alone would understate the value, so the caller's richer fallback (e.g. the
-     * wrapped model schema) is the honest answer. The same writes guarded behind a condition stay
-     * unread, leaving the base literal as a never-wrong subset of the genuinely-present fields.
-     *
-     * @param list<Stmt> $statements
-     */
-    private function arrayLiteralAssignedTo(Variable $variable, array $statements): ?Array_
-    {
-        $variableName = $variable->name;
-
-        if (!is_string($variableName)) {
-            return null;
-        }
-
-        $isAssignmentToVariable = static fn(Node $node): bool
-            => $node instanceof Assign
-            && $node->var instanceof Variable
-            && $node->var->name === $variableName;
-
-        $allAssignments = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::IncludeConditionalContexts,
-            $isAssignmentToVariable,
-        );
-        $unconditionalAssignments = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::SkipConditionalContexts,
-            $isAssignmentToVariable,
-        );
-
-        if (count($allAssignments) !== 1 || count($unconditionalAssignments) !== 1) {
-            return null;
-        }
-
-        $unconditionalMutations = $this->statementNodeFinder->findAll(
-            $statements,
-            ConditionalContextPolicy::SkipConditionalContexts,
-            fn(Node $node): bool => $this->mutatesVariable($node, $variableName),
-        );
-
-        if ($unconditionalMutations !== []) {
-            return null;
-        }
-
-        /** @var Assign $assignment */
-        $assignment = $unconditionalAssignments[0];
-
-        return $assignment->expr instanceof Array_ ? $assignment->expr : null;
-    }
-
-    /**
-     * Whether the node mutates the named variable after its assignment: an element write
-     * (`$data['k'] = …`, an `Assign` whose target is an array-dimension fetch rooted at the
-     * variable) or any compound assignment (`$data += …`, `$data['k'] .= …`).
-     */
-    private function mutatesVariable(Node $node, string $variableName): bool
-    {
-        $target = match (true) {
-            $node instanceof AssignOp => $node->var,
-            $node instanceof Assign && $node->var instanceof ArrayDimFetch => $node->var,
-            default => null,
-        };
-
-        while ($target instanceof ArrayDimFetch) {
-            $target = $target->var;
-        }
-
-        return $target instanceof Variable && $target->name === $variableName;
-    }
-
-    /**
-     * Depth-first return collection, skipping nested function-like scopes (closures, anon classes).
-     *
-     * @param list<Return_> $returns
-     */
-    private function collectReturns(Node $node, array &$returns): void
-    {
-        if ($node instanceof FunctionLike) {
-            return;
-        }
-
-        if ($node instanceof Return_) {
-            $returns[] = $node;
-        }
-
-        foreach ($node->getSubNodeNames() as $subNodeName) {
-            /** @var mixed $children */
-            $children = $node->{$subNodeName};
-
-            foreach (is_array($children) ? $children : [$children] as $child) {
-                if ($child instanceof Node) {
-                    $this->collectReturns($child, $returns);
-                }
-            }
-        }
     }
 }

--- a/src/Support/MethodBody/UnqualifiedHelperCall.php
+++ b/src/Support/MethodBody/UnqualifiedHelperCall.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\MethodBody;
+
+use PhpParser\Node\Name;
+
+use function function_exists;
+
+/**
+ * Resolves whether a called function name refers to a global helper (`abort()`, `response()`, …).
+ *
+ * A fully-qualified name (`\response`) always does. An unqualified name usually does too, unless a
+ * function of that name is declared in the call's own namespace: PHP's name resolution would bind to
+ * that local function instead, so the bounded scanners must not assume the global helper.
+ *
+ * @internal
+ */
+final readonly class UnqualifiedHelperCall
+{
+    /**
+     * Whether the name resolves to the global helper rather than a same-namespace function that
+     * would shadow it. Requires the `namespacedName` attribute set by php-parser's name resolver.
+     */
+    public static function resolvesToGlobalHelper(Name $name): bool
+    {
+        if ($name->isFullyQualified()) {
+            return true;
+        }
+
+        $namespacedName = $name->getAttribute('namespacedName');
+
+        return !($namespacedName instanceof Name && function_exists($namespacedName->toString()));
+    }
+}

--- a/tests/Fixtures/ReturnExpressionResolverFixture.php
+++ b/tests/Fixtures/ReturnExpressionResolverFixture.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Fixtures;
+
+use stdClass;
+
+/**
+ * Parse-only fixture exercising {@see \Radiergummi\OpenApi\Support\MethodBody\ReturnExpressionResolver}.
+ * Actions are never invoked; each returns a variable resolved through its body.
+ */
+class ReturnExpressionResolverFixture
+{
+    public function singleAssignment(): stdClass
+    {
+        $value = new stdClass();
+
+        return $value;
+    }
+
+    public function conditionalAssignment(bool $flag): stdClass
+    {
+        if ($flag) {
+            $value = new stdClass();
+        } else {
+            $value = new stdClass();
+        }
+
+        return $value;
+    }
+
+    public function multipleAssignments(): stdClass
+    {
+        $value = new stdClass();
+        $value = new stdClass();
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     */
+    public function elementWriteAfterAssignment(array $value): array
+    {
+        $value = ['a' => 1];
+        $value['b'] = 2;
+
+        return $value;
+    }
+
+    public function compoundAssignAfterAssignment(int $value): int
+    {
+        $value = 1;
+        $value += 2;
+
+        return $value;
+    }
+
+    public function noMatchingAssignment(stdClass $value): stdClass
+    {
+        return $value;
+    }
+
+    public function dynamicallyNamedVariable(string $name): mixed
+    {
+        $$name = new stdClass();
+
+        return $$name;
+    }
+
+    public function returnsClosureNotThisMethod(): callable
+    {
+        $value = static function (): int {
+            $inner = 1;
+
+            return $inner;
+        };
+
+        return $value;
+    }
+}

--- a/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
+++ b/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
@@ -225,6 +225,33 @@ class ReaderFixtureController
 
         return null;
     }
+
+    public function mutatedAfterAssignment(): AnonymousResourceCollection
+    {
+        /** @var AnonymousResourceCollection $resources */
+        $resources = NestedAuthorResource::collection(Author::all());
+        $resources['extra'] = NestedAuthorResource::make(Author::query()->firstOrFail());
+
+        return $resources;
+    }
+
+    public function conditionallyAssignedVariable(bool $flag): AnonymousResourceCollection
+    {
+        if ($flag) {
+            $resources = NestedAuthorResource::collection(Author::query()->paginate());
+        } else {
+            $resources = NestedAuthorResource::collection(Author::all());
+        }
+
+        return $resources;
+    }
+
+    public function dynamicallyNamedVariable(string $name): AnonymousResourceCollection
+    {
+        $$name = NestedAuthorResource::collection(Author::all());
+
+        return $$name;
+    }
 }
 
 function readerFor(?LoggerInterface $logger = null): ReturnExpressionResourceReader
@@ -323,6 +350,57 @@ it('refuses a collection call on an abstract resource subclass with a note', fun
         ->and(array_filter(
             $logger->records,
             static fn(array $record): bool => str_contains($record['message'], 'abstractClassCollection'),
+        ))->toHaveCount(1);
+});
+
+it('refuses a conditionally-assigned returned variable with the not-assigned-once note', function (): void {
+    $logger = recordingLogger();
+    $target = readerFor($logger)->read(readerMethod('conditionallyAssignedVariable'));
+
+    expect($target)->toBeNull()
+        ->and(array_filter(
+            $logger->records,
+            static fn(array $record): bool => str_contains(
+                $record['message'],
+                'The return expression of ' . ReaderFixtureController::class . '::conditionallyAssignedVariable'
+                . ' returns $resources, which is not assigned exactly once on the unconditional path;'
+                . ' the concrete resource stays unresolved. Annotate the action with #[ResponseResource]'
+                . ' to document the response.',
+            ),
+        ))->toHaveCount(1);
+});
+
+it('refuses a dynamically-named returned variable with the dynamic-variable note', function (): void {
+    $logger = recordingLogger();
+    $target = readerFor($logger)->read(readerMethod('dynamicallyNamedVariable'));
+
+    expect($target)->toBeNull()
+        ->and(array_filter(
+            $logger->records,
+            static fn(array $record): bool => str_contains(
+                $record['message'],
+                'The return expression of ' . ReaderFixtureController::class . '::dynamicallyNamedVariable'
+                . ' returns a dynamically-named variable;'
+                . ' the concrete resource stays unresolved. Annotate the action with #[ResponseResource]'
+                . ' to document the response.',
+            ),
+        ))->toHaveCount(1);
+});
+
+it('refuses a returned variable mutated after its assignment with the mutation note', function (): void {
+    $logger = recordingLogger();
+    $target = readerFor($logger)->read(readerMethod('mutatedAfterAssignment'));
+
+    expect($target)->toBeNull()
+        ->and(array_filter(
+            $logger->records,
+            static fn(array $record): bool => str_contains(
+                $record['message'],
+                'The return expression of ' . ReaderFixtureController::class . '::mutatedAfterAssignment'
+                . ' returns $resources, which is mutated after its single unconditional assignment;'
+                . ' the concrete resource stays unresolved. Annotate the action with #[ResponseResource]'
+                . ' to document the response.',
+            ),
         ))->toHaveCount(1);
 });
 

--- a/tests/Unit/Plugins/SpatieData/DataReturnExpressionReaderTest.php
+++ b/tests/Unit/Plugins/SpatieData/DataReturnExpressionReaderTest.php
@@ -64,6 +64,15 @@ class ReaderFixture
 
         return new ScalarOnlyData('b', 2);
     }
+
+    public function elementWriteAfterAssignment(): Collection
+    {
+        /** @var Collection<int|string, ScalarOnlyData> $data */
+        $data = ScalarOnlyData::collect(collect([]));
+        $data['extra'] = new ScalarOnlyData('x', 1);
+
+        return $data;
+    }
 }
 
 function readTarget(string $method): ?DataReturnTarget
@@ -106,4 +115,8 @@ it('returns null when the body is not a recognised factory shape', function (): 
 
 it('returns null for a conditional / multiple-return body', function (): void {
     expect(readTarget('conditional'))->toBeNull();
+});
+
+it('returns null when the returned variable is mutated after its single assignment', function (): void {
+    expect(readTarget('elementWriteAfterAssignment'))->toBeNull();
 });

--- a/tests/Unit/Support/MethodBody/ReturnExpressionResolverTest.php
+++ b/tests/Unit/Support/MethodBody/ReturnExpressionResolverTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\Expr\New_ as NewExpression;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Return_;
+use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnExpressionResolver;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnVariableRefusal;
+use Radiergummi\OpenApi\Support\MethodBody\ReturnVariableResolution;
+use Radiergummi\OpenApi\Tests\Fixtures\ReturnExpressionResolverFixture;
+
+uses()->group('openapi');
+
+/**
+ * Scans the fixture method and resolves its final top-level `return $variable;`.
+ */
+function resolveReturnVariable(string $method): ReturnVariableResolution
+{
+    $resolver = new ReturnExpressionResolver();
+    $statements = new MethodBodyScanner()->firstStatements(
+        new ReflectionMethod(ReturnExpressionResolverFixture::class, $method),
+        limit: 10,
+    );
+
+    $variable = null;
+
+    foreach ($statements as $statement) {
+        if ($statement instanceof Return_ && $statement->expr instanceof Variable) {
+            $variable = $statement->expr;
+        }
+    }
+
+    if (!$variable instanceof Variable) {
+        throw new RuntimeException("Fixture method {$method} has no top-level return of a variable.");
+    }
+
+    return $resolver->resolveVariable($variable, $statements);
+}
+
+it('resolves a single unconditional assignment to its expression', function (): void {
+    $resolution = resolveReturnVariable('singleAssignment');
+
+    expect($resolution->expression)->toBeInstanceOf(NewExpression::class)
+        ->and($resolution->refusal)->toBeNull();
+});
+
+it('refuses a conditional assignment as not-assigned-once', function (): void {
+    $resolution = resolveReturnVariable('conditionalAssignment');
+
+    expect($resolution->expression)->toBeNull()
+        ->and($resolution->refusal)->toBe(ReturnVariableRefusal::NotAssignedOnce);
+});
+
+it('refuses multiple unconditional assignments as not-assigned-once', function (): void {
+    $resolution = resolveReturnVariable('multipleAssignments');
+
+    expect($resolution->expression)->toBeNull()
+        ->and($resolution->refusal)->toBe(ReturnVariableRefusal::NotAssignedOnce);
+});
+
+it('refuses an element write after the assignment as mutation', function (): void {
+    $resolution = resolveReturnVariable('elementWriteAfterAssignment');
+
+    expect($resolution->expression)->toBeNull()
+        ->and($resolution->refusal)->toBe(ReturnVariableRefusal::MutatedAfterAssignment);
+});
+
+it('refuses a compound assignment after the assignment as mutation', function (): void {
+    $resolution = resolveReturnVariable('compoundAssignAfterAssignment');
+
+    expect($resolution->expression)->toBeNull()
+        ->and($resolution->refusal)->toBe(ReturnVariableRefusal::MutatedAfterAssignment);
+});
+
+it('refuses a variable with no matching assignment as not-assigned-once', function (): void {
+    $resolution = resolveReturnVariable('noMatchingAssignment');
+
+    expect($resolution->expression)->toBeNull()
+        ->and($resolution->refusal)->toBe(ReturnVariableRefusal::NotAssignedOnce);
+});
+
+it('refuses a dynamically-named returned variable', function (): void {
+    $resolution = resolveReturnVariable('dynamicallyNamedVariable');
+
+    expect($resolution->expression)->toBeNull()
+        ->and($resolution->refusal)->toBe(ReturnVariableRefusal::DynamicallyNamedVariable);
+});
+
+it('does not descend into a closure body when collecting method-level returns', function (): void {
+    $resolver = new ReturnExpressionResolver();
+    $statements = new MethodBodyScanner()->firstStatements(
+        new ReflectionMethod(ReturnExpressionResolverFixture::class, 'returnsClosureNotThisMethod'),
+        limit: 10,
+    );
+
+    expect($resolver->methodLevelReturns($statements))->toHaveCount(1);
+});

--- a/tests/Unit/Support/MethodBody/UnqualifiedHelperCallTest.php
+++ b/tests/Unit/Support/MethodBody/UnqualifiedHelperCallTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Support\MethodBody\ShadowingScope;
+
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Radiergummi\OpenApi\Support\MethodBody\UnqualifiedHelperCall;
+
+uses()->group('openapi');
+
+/** A same-namespace function that shadows a would-be global helper of the same short name. */
+function shadowingHelper(): void {}
+
+it('resolves a fully-qualified name to the global helper', function (): void {
+    expect(UnqualifiedHelperCall::resolvesToGlobalHelper(new FullyQualified('response')))->toBeTrue();
+});
+
+it('resolves an unqualified name with no same-namespace function to the global helper', function (): void {
+    $name = new Name('abort');
+    $name->setAttribute('namespacedName', new Name('App\\Http\\Controllers\\abort'));
+
+    expect(UnqualifiedHelperCall::resolvesToGlobalHelper($name))->toBeTrue();
+});
+
+it('refuses an unqualified name shadowed by a same-namespace function', function (): void {
+    $name = new Name('shadowingHelper');
+    $name->setAttribute('namespacedName', new Name(__NAMESPACE__ . '\\shadowingHelper'));
+
+    // Reference the local function so it is autoloaded and function_exists() sees it.
+    shadowingHelper();
+
+    expect(UnqualifiedHelperCall::resolvesToGlobalHelper($name))->toBeFalse();
+});
+
+it('treats an unqualified name without a namespacedName attribute as the global helper', function (): void {
+    expect(UnqualifiedHelperCall::resolvesToGlobalHelper(new Name('response')))->toBeTrue();
+});


### PR DESCRIPTION
Closes #486

## Implementation plan — #486

**Tier:** stays entirely within **Tier-1** (bounded AST whitelist). This is consolidation +
**one latent-bug fix**, not new inference. Explicitly **not** a PHPStan-collector rebuild (rejected
in the epic; recorded in the issue).

### The load-bearing part first: the latent bug (must land as a pinned test)

Three classes independently implement "resolve `return $var` through its single unconditional
assignment", and they **diverge**:

| class | method | mutation check? | return |
|---|---|---|---|
| `SingleReturnArrayLiteralFinder` (Support) | `arrayLiteralAssignedTo` (:94) | **yes** (`mutatesVariable`, :143) | `?Array_` |
| `DataReturnExpressionReader` (SpatieData) | `expressionAssignedTo` (:173) | **no** | `?Expr` |
| `ReturnExpressionResourceReader` (ApiResources) | `expressionAssignedTo` (:489) | **no** | `?Expr` (+ `note()` logging) |

The Data reader can therefore attribute a **stale literal** to the return when the variable is
mutated after its single assignment, e.g.:

```php
public function index(): Collection {
    $data = FooData::collect($foos);
    $data = $data->concat($bars);   // unconditional reassignment / mutation after the literal
    return $data;
}
```

`SingleReturnArrayLiteralFinder` refuses this (its richer fallback is the honest answer);
`DataReturnExpressionReader` does not, so it emits a `DataReturnTarget` for a value the code has
since changed. **This is a bug fix, and the mutation check must be covered by a test that fails
before and passes after** (per the lead's note).

Note the two lax readers return arbitrary `?Expr` (a `new X()` / `X::collect()`), not just an
`Array_`, so the mutation guard must be lifted to the *general* case: "the variable is assigned
exactly once unconditionally **and never mutated afterward** on the unconditional path" — the same
`mutatesVariable` semantics (`ArrayDimFetch` element writes + any `AssignOp`), independent of what
the assigned expression is.

### Proposed change (surgical, in dependency order)

**1. Shared `ReturnExpressionResolver` (Support\MethodBody), with the mutation check.**

New `@internal readonly` service in `src/Support/MethodBody/`. One public method resolving a
returned variable to its single unconditional assignment expression, refusing on: dynamically-named
variable, zero/multiple assignments (any-context vs unconditional counts must both be 1, as today),
and **any post-assignment unconditional mutation** (the `mutatesVariable` guard hoisted verbatim
from `SingleReturnArrayLiteralFinder`). Returns `?Expr`.

Also fold in the shared "collect method-level returns, skipping nested scopes" walk (currently
hand-rolled 4×): a method returning `list<Return_>` for the method's own returns. Reconcile the two
skip-predicates — `SingleReturnArrayLiteralFinder`/`FormRequestStaticRulesReader` skip
`FunctionLike`; the other two skip `Closure|ArrowFunction|ClassLike`. At method-body top-level these
are behaviourally equivalent (no nested `ClassMethod`/`Function_` decls appear in a controller body),
but to be safe the shared version skips **`FunctionLike` OR `ClassLike`** (superset of both), and
this equivalence is asserted by keeping every existing per-consumer test green.

Consumers refactored onto it, **deleting the duplicates**:
- `SingleReturnArrayLiteralFinder::arrayLiteralAssignedTo` → call the resolver, then narrow the
  result to `Array_` (`return $expr instanceof Array_ ? $expr : null`). Keep its `find()` shape.
- `DataReturnExpressionReader::expressionAssignedTo` → **deleted**; call the resolver. **This is
  where the bug is fixed** (it now inherits the mutation guard).
- `ReturnExpressionResourceReader::expressionAssignedTo` → replace body with a resolver call. It
  keeps its `note()` logging by mapping the resolver's null outcome to the existing notice(s); to
  preserve today's exact log wording (dynamically-named vs not-assigned-once), the resolver returns
  enough to distinguish, OR (simpler, preferred) the reader keeps a thin wrapper that logs then
  delegates. Chosen: **thin logging wrapper** so log messages are byte-identical and the resolver
  stays log-free (matches the Support-layer "no plugin/log policy" convention). Flag: this reader
  currently does **not** have the mutation check, so tightening it may change resource resolution
  on a mutated-variable body — the survey gate must confirm this is a net-neutral/positive change,
  not a regression. If the survey shows resource-count drops, we scope the mutation-guard tightening
  to the Data path only and leave ApiResources unchanged (documented decision in a PR comment).

**2. Single shared `StatementNodeFinder` instance.**

It is `final readonly` and stateless. Currently `new StatementNodeFinder()` appears in **14
classes** across `src/` (Core resolvers/contributors, ApiResources, Fractal, QueryBuilder,
SpatieData, Support). Two options:
- (a) inject it via the container (`#[Scoped]` or plain — it's stateless, a plain shared singleton
  is fine) and replace the 14 `new`s with a promoted ctor param;
- (b) leave construction but centralise.

Chosen: **(a) constructor injection** for the classes already container-resolved; for the handful of
Support/leaf classes constructed by hand in tests, keep a no-arg-default *only if* it does not
reintroduce the #485 anti-pattern — since `StatementNodeFinder` is **stateless**, a
`= new StatementNodeFinder()` default is harmless (no cache to defeat) and the #485 arch rule is
scoped to `MethodBodyScanner` specifically. This keeps the 14-site change mechanical and test-safe.
*(If plan-review prefers a hard "no `new` defaults at all" rule, that widens the test churn; flagged.)*

**3. Extract the helper-shadowing guard.**

`AbortErrorContributor::helperName` (:109) and `InlineJsonCallReader::isResponseHelperCall` (:85)
both implement verbatim: "an unqualified helper name is skipped when a same-namespace function of
that name exists (PHP would call that instead)". Extract to a small `@internal` static helper in
`Support\MethodBody` (e.g. `UnqualifiedHelperCall::isShadowed(Name $name): bool` or
`resolvesToGlobalHelper(...)`), used by both. The two call sites differ slightly (`FuncCall` name vs
`response()` receiver name), so the helper takes the `PhpParser\Node\Name` and returns whether it
resolves to the global helper (fully-qualified ⇒ yes; unqualified ⇒ yes unless a namespaced function
exists). Both call sites keep their surrounding shape.

**4. Call-shape matcher utility (scoped down).**

The issue asks for a "register a matcher" seam so a new whitelisted shape is closer to data than
plumbing, citing `abort_if` being a one-line map entry in `AbortErrorContributor` as the ideal.
`AbortErrorContributor` **already** demonstrates the data-driven pattern (`HELPER_PARAMETERS` map).
Building a *general* matcher-registration seam risks a speculative abstraction (CLAUDE.md §Simplicity;
no second consumer yet). **Recommendation: descope item 4 from this PR.** The concrete, non-
speculative wins are items 1–3 (a real bug fix + verbatim-duplication removal). A matcher-registry
seam should be its own `spec` issue, designed against ≥2 real new-shape requests, not built ahead of
demand. **This is the main scope decision for plan-review to confirm** — if the lead wants item 4
kept, it needs its own design pass and likely a human gate (new internal extension surface).

### Files

- **New:** `src/Support/MethodBody/ReturnExpressionResolver.php`; helper for item 3 (e.g.
  `src/Support/MethodBody/UnqualifiedHelperCall.php`).
- **Modified:** `SingleReturnArrayLiteralFinder`, `DataReturnExpressionReader`,
  `ReturnExpressionResourceReader`, `FormRequestStaticRulesReader` (its `collectReturns` can move to
  the shared walk too), `AbortErrorContributor`, `InlineJsonCallReader`, + the 14
  `new StatementNodeFinder()` sites (mechanical) if item 2 uses injection.

### Tests (TDD — failing first)

1. **Mutation-check regression, Data path** (`DataReturnExpressionReaderTest`): a fixture whose
   `index()` assigns `$data = FooData::collect(...)` then unconditionally mutates `$data`
   (reassign / `$data[] =` / `+=`) before `return $data;`. Assert `read()` returns **null**
   (refuses). **Fails on main** (stale literal attributed), **passes after**. This is the pinned bug
   test the lead requires.
2. **Resolver unit tests** (`tests/Unit/Support/MethodBody/ReturnExpressionResolverTest`): single
   unconditional assignment ⇒ resolves; conditional assignment ⇒ null; multiple assignments ⇒ null;
   dynamically-named var ⇒ null; post-assignment element write / compound assign ⇒ null;
   no matching assignment ⇒ null.
3. **Helper-shadowing guard** (item 3): keep/relocate the existing behaviour under a shared test;
   assert both `abort` and `response` unqualified-with-shadow cases refuse, fully-qualified pass.
4. **Green-preservation:** the full existing `SingleReturnArrayLiteralFinderTest`,
   `ReturnExpressionResourceReaderTest`, `ResourceClassLocatorTest`, `AbortErrorContributorTest`,
   and the inline-json/response tests must stay green (proves the consolidation is behaviour-
   preserving apart from the intended Data-path tightening).

### Observable behaviour / docs / changelog

- The **only** intended output change is the Data path refusing a mutated-variable return (was:
  stale schema; now: degrades to the honest fallback). Survey gate: `area:core` + `area:plugins`
  (SpatieData/ApiResources) ⇒ **survey required**; expect Data-path corpus deltas to be neutral or
  positive (fewer wrong schemas), and ApiResources to be unchanged (or, if the mutation-guard
  tightening there causes drops, scope it out per item 1's fallback).
- `docs/`: no user-facing surface change (all `@internal`). No page edit unless item 4 is kept
  (it isn't, per the recommendation).
- `CHANGELOG.md [Unreleased]` — "Fixed": Spatie Data response inference no longer attributes a
  stale value to a return variable that is mutated after its assignment.

### Controversial?

- No `Contracts/**`, no stage order, no config key, no public signature change — all touched classes
  are `@internal`. **Not** inherently a human gate.
- Two judgment calls for plan-review: **(a) descoping item 4** (matcher-registry seam → separate
  spec issue) and **(b) whether to tighten the ApiResources reader with the mutation guard** or
  scope that guard to the Data path. Both are called out so the reviewer can decide before coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)