### PR TITLE
refactor(core): extract shared CallArgumentResolver to Support\MethodBody (arg-resolver dedup; matcher deferred to #517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project are documented here.
 - Lint `Rule` contract now declares `id`, `severity`, and `description` as readable property requirements instead of getter methods; rule implementations declare them as plain typed properties with initializers. (#379)
 - Internal: unified the two docblock/type → schema engines on a single `symfony/type-info` `Type` representation (`TypeNodeToSchema` is removed; `JsonSchemaFromType` grew the structural array-shape/list/map cases and an optional leaf-class callback), with a `TypeNodeResolver::toType()` phpstan → symfony boundary. No spec output change except previously-unmapped array/collection shapes on the symfony path now resolve, `true`/`false` map to `boolean`, and array-shape properties serialize in sorted key order. (#480)
 - Internal: the `migration.*` lint rules now compare authored annotations against a retained inference-only view of the single generation instead of running a second, harvester-excluded generation; the `SpecPipeline` is a plain executor again (no per-run stage exclusion), and an ordinary `openapi:generate` pays nothing for the retention. (#208, #483)
+- Internal: the body-scan readers now resolve a call argument by name or position through a single shared `Support\MethodBody\CallArgumentResolver`, replacing four copies of the same logic. No spec output change. (#512)
 
 ### Fixed
 - Lint now surfaces top-level and field-level bare `oneOf` / `anyOf` schemas across components, responses, and request bodies. (#294, #318)

--- a/src/Plugins/Core/ErrorContributors/AbortErrorContributor.php
+++ b/src/Plugins/Core/ErrorContributors/AbortErrorContributor.php
@@ -16,6 +16,7 @@ use Radiergummi\OpenApi\Contracts\Registry\ErrorResponseContributor;
 use Radiergummi\OpenApi\Errors\ErrorDescriptor;
 use Radiergummi\OpenApi\Routing\ActionDescriptor;
 use Radiergummi\OpenApi\Support\MethodBody\AstLiteralEvaluator;
+use Radiergummi\OpenApi\Support\MethodBody\CallArgumentResolver;
 use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
@@ -193,16 +194,14 @@ final readonly class AbortErrorContributor implements ErrorResponseContributor
      */
     private function resolveArgument(array $arguments, array $parameters, string $parameterName): ?Arg
     {
-        foreach ($arguments as $argument) {
-            if ($argument->name !== null && $argument->name->toString() === $parameterName) {
-                return $argument;
-            }
-        }
+        $position = array_search($parameterName, $parameters, true);
 
-        $index = array_search($parameterName, $parameters, true);
-        $positional = $index === false ? null : ($arguments[$index] ?? null);
-
-        return $positional !== null && $positional->name === null ? $positional : null;
+        // A parameter the helper does not declare has no positional slot; only a named argument binds it.
+        return CallArgumentResolver::argument(
+            $arguments,
+            $parameterName,
+            $position === false ? -1 : $position,
+        );
     }
 
     private function literalValueOf(Expr $expression): mixed

--- a/src/Plugins/Core/Support/InlineJsonCallReader.php
+++ b/src/Plugins/Core/Support/InlineJsonCallReader.php
@@ -17,13 +17,13 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use Radiergummi\OpenApi\Support\Generator\SchemaFromArrayDefinition;
 use Radiergummi\OpenApi\Support\MethodBody\AstLiteralEvaluator;
+use Radiergummi\OpenApi\Support\MethodBody\CallArgumentResolver;
 use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
 use Radiergummi\OpenApi\Support\MethodBody\SchemaDefinitionFromLiteral;
 use Radiergummi\OpenApi\Support\MethodBody\StatementNodeFinder;
 use Radiergummi\OpenApi\Support\MethodBody\UnqualifiedHelperCall;
 
-use function array_find;
 use function in_array;
 use function is_int;
 use function sprintf;
@@ -147,7 +147,7 @@ final readonly class InlineJsonCallReader
             return $chainStatus;
         }
 
-        $statusArgument = $this->argument($arguments, 'status', self::STATUS_ARGUMENT_POSITION);
+        $statusArgument = CallArgumentResolver::argument($arguments, 'status', self::STATUS_ARGUMENT_POSITION);
 
         if ($statusArgument === null) {
             return 200;
@@ -254,24 +254,12 @@ final readonly class InlineJsonCallReader
 
     /**
      * @param array<int, Arg> $arguments
-     */
-    private function argument(array $arguments, string $name, int $position): ?Arg
-    {
-        return array_find(
-            $arguments,
-            fn(Arg $argument, int $index): bool
-                => $argument->name === null ? $index === $position : $argument->name->toString() === $name,
-        );
-    }
-
-    /**
-     * @param array<int, Arg> $arguments
      *
      * @return array{0: ?Schema, 1: bool, 2: ?string}
      */
     private function readBody(array $arguments): array
     {
-        $dataArgument = $this->argument($arguments, 'data', self::DATA_ARGUMENT_POSITION);
+        $dataArgument = CallArgumentResolver::argument($arguments, 'data', self::DATA_ARGUMENT_POSITION);
 
         if ($dataArgument === null) {
             return [null, true, null];

--- a/src/Plugins/Core/Support/RequestAccessorReader.php
+++ b/src/Plugins/Core/Support/RequestAccessorReader.php
@@ -7,7 +7,6 @@ namespace Radiergummi\OpenApi\Plugins\Core\Support;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Http\Request;
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure as ClosureExpression;
 use PhpParser\Node\Expr\FuncCall;
@@ -16,6 +15,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use Radiergummi\OpenApi\Support\MethodBody\AstLiteralEvaluator;
+use Radiergummi\OpenApi\Support\MethodBody\CallArgumentResolver;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
 use ReflectionMethod;
@@ -112,7 +112,7 @@ final readonly class RequestAccessorReader
 
         foreach ($calls as $call) {
             $accessor = $call->name instanceof Identifier ? $call->name->toLowerString() : '';
-            $keyArgument = $this->argument($call->getArgs(), 0, 'key');
+            $keyArgument = CallArgumentResolver::argument($call->getArgs(), 'key', 0);
 
             if ($keyArgument === null) {
                 // Zero-argument query()/cookie()/header() reads the whole bag, not a named parameter.
@@ -253,24 +253,6 @@ final readonly class RequestAccessorReader
     // region Argument resolution
 
     /**
-     * @param array<int, Arg> $arguments
-     */
-    private function argument(array $arguments, int $position, string $name): ?Arg
-    {
-        foreach ($arguments as $index => $argument) {
-            $matches = $argument->name === null
-                ? $index === $position
-                : $argument->name->toString() === $name;
-
-            if ($matches) {
-                return $argument;
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Converts a dotted key to wire notation (`filter.name` → `filter[name]`). Returns null for
      * wildcard or empty segments.
      */
@@ -309,7 +291,7 @@ final readonly class RequestAccessorReader
      */
     private function defaultValueOf(MethodCall $call, string $type): mixed
     {
-        $defaultArgument = $this->argument($call->getArgs(), 1, 'default');
+        $defaultArgument = CallArgumentResolver::argument($call->getArgs(), 'default', 1);
 
         if ($defaultArgument === null) {
             return null;

--- a/src/Plugins/QueryBuilder/Support/QueryBuilderChainReader.php
+++ b/src/Plugins/QueryBuilder/Support/QueryBuilderChainReader.php
@@ -6,7 +6,6 @@ namespace Radiergummi\OpenApi\Plugins\QueryBuilder\Support;
 
 use Illuminate\Container\Attributes\Scoped;
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
@@ -14,6 +13,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use Radiergummi\OpenApi\Support\MethodBody\AstLiteralEvaluator;
+use Radiergummi\OpenApi\Support\MethodBody\CallArgumentResolver;
 use Radiergummi\OpenApi\Support\MethodBody\ConditionalContextPolicy;
 use Radiergummi\OpenApi\Support\MethodBody\MethodBodyScanner;
 use Radiergummi\OpenApi\Support\MethodBody\NonLiteralValueException;
@@ -287,7 +287,7 @@ final class QueryBuilderChainReader
             return null;
         }
 
-        $nameArgument = $this->argument($call->getArgs(), 0, 'name');
+        $nameArgument = CallArgumentResolver::argument($call->getArgs(), 'name', 0);
 
         if ($nameArgument === null) {
             return $call->name->toLowerString() === 'trashed' ? 'trashed' : null;
@@ -300,24 +300,6 @@ final class QueryBuilderChainReader
         }
 
         return is_string($value) ? $this->normaliseName($value, $kind) : null;
-    }
-
-    /**
-     * @param array<int, Arg> $arguments
-     */
-    private function argument(array $arguments, int $position, string $name): ?Arg
-    {
-        foreach ($arguments as $index => $argument) {
-            $matches = $argument->name === null
-                ? $index === $position
-                : $argument->name->toString() === $name;
-
-            if ($matches) {
-                return $argument;
-            }
-        }
-
-        return null;
     }
 
     /** Strips the leading `-` direction marker from sort names. Returns null for empty strings. */

--- a/src/Support/MethodBody/CallArgumentResolver.php
+++ b/src/Support/MethodBody/CallArgumentResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Support\MethodBody;
+
+use PhpParser\Node\Arg;
+
+use function array_find;
+
+/**
+ * Resolves a call argument the way PHP binds it: by name if the caller named it, otherwise by
+ * positional index. A named argument matches at any position; an unnamed argument matches only at
+ * the given slot.
+ *
+ * Pure: it does not filter spread arguments or fold literals. Callers keep their own such logic.
+ *
+ * @internal
+ */
+final readonly class CallArgumentResolver
+{
+    /**
+     * @param array<int, Arg> $arguments
+     */
+    public static function argument(array $arguments, string $name, int $position): ?Arg
+    {
+        return array_find(
+            $arguments,
+            static fn(Arg $argument, int $index): bool
+                => $argument->name === null ? $index === $position : $argument->name->toString() === $name,
+        );
+    }
+}

--- a/tests/Unit/Support/MethodBody/CallArgumentResolverTest.php
+++ b/tests/Unit/Support/MethodBody/CallArgumentResolverTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Radiergummi\OpenApi\Tests\Unit\Support\MethodBody;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use Radiergummi\OpenApi\Support\MethodBody\CallArgumentResolver;
+
+uses()->group('openapi');
+
+function positionalArgument(string $value): Arg
+{
+    return new Arg(new String_($value));
+}
+
+function namedArgument(string $name, string $value): Arg
+{
+    return new Arg(new String_($value), name: new Identifier($name));
+}
+
+it('resolves a named argument at any position', function (): void {
+    $arguments = [positionalArgument('data'), namedArgument('status', 'named')];
+
+    expect(CallArgumentResolver::argument($arguments, 'status', 1))
+        ->toBe($arguments[1]);
+});
+
+it('resolves an unnamed argument by position', function (): void {
+    $arguments = [positionalArgument('data'), positionalArgument('status')];
+
+    expect(CallArgumentResolver::argument($arguments, 'status', 1))
+        ->toBe($arguments[1]);
+});
+
+it('returns null when a differently named argument sits at the position', function (): void {
+    $arguments = [positionalArgument('data'), namedArgument('headers', 'other')];
+
+    expect(CallArgumentResolver::argument($arguments, 'status', 1))
+        ->toBeNull();
+});
+
+it('returns null when no argument matches by name or position', function (): void {
+    $arguments = [positionalArgument('data')];
+
+    expect(CallArgumentResolver::argument($arguments, 'status', 1))
+        ->toBeNull();
+});
+
+it('never matches a positional slot for a negative position', function (): void {
+    $arguments = [positionalArgument('data'), positionalArgument('status')];
+
+    expect(CallArgumentResolver::argument($arguments, 'status', -1))
+        ->toBeNull();
+});


### PR DESCRIPTION
## What this does

**Refs #512.** Extracts the copy-pasted "resolve a call argument by name, else by position"
lookup into one pure, plugin-agnostic `Support\MethodBody\CallArgumentResolver` and refactors the
four on-`main` body-scan readers onto it, **byte-identically**. No spec output change; internal
refactor of the existing Tier-1 substrate (not an inference-tier change).

`#512` stays **open** as the call-shape *matcher* tracker (its titled intent). The JSON matcher
half is **deferred to #517** (its plan item 1 owns the `Support\MethodBody\` matcher extraction and
closes #512 when it lands). Hence `Refs`, not `Closes`.

## Scope (final, arg-resolver only)

**Create (`@internal`, plugin-agnostic):**
- `src/Support/MethodBody/CallArgumentResolver.php` — one static method
  `argument(array $arguments, string $name, int $position): ?Arg`, named-first then
  positional-if-unnamed. **Pure**: no spread/unpack filtering, no literal folding — callers keep
  their own such logic.
- `tests/Unit/Support/MethodBody/CallArgumentResolverTest.php` — named hit at any position,
  positional hit, differently-named-at-position → null, miss → null, negative position never
  matches a slot (the Abort param-not-in-spec case).

**Refactor onto it (byte-identical):**
- `src/Plugins/Core/Support/InlineJsonCallReader.php` — exact drop-in; private `argument()` deleted.
- `src/Plugins/Core/Support/RequestAccessorReader.php` — arg-order swap (`(position, name)` →
  `(name, position)`); private `argument()` deleted.
- `src/Plugins/QueryBuilder/Support/QueryBuilderChainReader.php` — same swap. (`spatie/laravel-query-builder`
  is `require-dev`, so this runs in the main `tests` job — in scope.)
- `src/Plugins/Core/ErrorContributors/AbortErrorContributor.php` — keeps its `HELPER_PARAMETERS`
  name→position `array_search` mapping (and the `false` guard) in the caller; delegates only the
  `(name, position)` lookup. The two-pass → single-pass collapse is equivalent for any compilable
  call (a positional arg *and* a later named arg for the same parameter is a duplicate-argument
  fatal, impossible in running code).

**Deferred (NOT in this PR):** the `ResponseJsonCallMatcher` extraction — single-consumer on `main`;
owned by #517 item 1.

## Guards

- Snapshot group (`tests/Feature/ExamplesTest.php`) + existing reader/Abort tests = the
  byte-identical proof.
- `CoreBoundaryTest` stays green: the new class lives in `Support\` and depends only on
  php-parser's `Arg` (no Core/plugin deps).
- New focused unit test for `CallArgumentResolver`.

CHANGELOG: one `[Unreleased]` internal line.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSxvAhwArZ9oxt46N5o4Js
