### PR TITLE
feat(#540): resolve ->toResource() receiver from any declared type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- `->toResource()` / `->toResourceCollection()` responses now resolve their receiver from any statically-declared type, not only a Model-typed parameter: a Model-typed property, a method whose declared return is a concrete Model, a base-`Model`/`self` passthrough call (typed from its Model argument, e.g. `$request->resolve($model)`), a local assigned from `new Model()` / a model-returning static factory (`Model::create()`/`findOrFail()`/…), and a local narrowed by `assert($x instanceof Model)`. (#540)
 - Laravel 13's first-party `JsonApiResource` is documented as a JSON:API resource object (`type`/`id`/`attributes`/`relationships`/`links`/`meta`), reading each member from its `to*()` literal with the same bounded rule as `toArray()`. Previously every such resource produced an empty schema. (#536)
 - `openapi:generate` no longer aborts when swagger-php emits a validation warning. The warnings are collected and reported; the run fails only on `validate()`'s own verdict. Previously a host error handler that promotes `E_USER_WARNING` to an exception (Laravel's does) turned any warning into a fatal, so a legal document with a float `multipleOf` — as inferred from a `decimal` column — crashed the very first run with no file written. (#539)
 - `AstLiteralEvaluator` resolves `self::`/`static::` class constants when the caller supplies the enclosing class, so array literals keyed by class constants are no longer refused wholesale. (#538)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -209,10 +209,17 @@ Recognised shapes:
 - The two-statement form `$projects = X::collection(...); return $projects;`,
   as long as the variable is assigned exactly once on the unconditional path.
 - `->toResource(X::class)` / `->toResourceCollection(X::class)` — the literal
-  class argument is decisive. A bare `$model->toResource()` works when `$model`
-  is a Model-typed parameter: the resource resolves through Laravel's own
-  convention (the model's `#[UseResource]` attribute, then the
-  `App\Http\Resources\{Model}Resource` guess).
+  class argument is decisive. A bare `$model->toResource()` (no class argument)
+  resolves through Laravel's own convention (the model's `#[UseResource]`
+  attribute, then the `App\Http\Resources\{Model}Resource` guess) whenever the
+  receiver's Model type is statically declared. That covers a Model-typed
+  parameter, a Model-typed property, a method whose declared return is a concrete
+  Model, a base-`Model`/`self` passthrough call typed from its Model argument
+  (`$request->resolve($model)->toResource()`), a local assigned from
+  `new Model()` or a model-returning static factory
+  (`Model::create()`/`findOrFail()`/`firstOrFail()`/…), and a local narrowed by
+  `assert($model instanceof Model)`. A receiver whose type is not statically
+  known (a query-builder chain, an untyped local) still refuses.
 - `new JsonResource($model)` (the base class itself) wrapping a Model-typed
   parameter documents the **wrapped model's schema** directly.
 - A `@return AnonymousResourceCollection<ProjectResource>` docblock generic is

--- a/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
+++ b/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
@@ -12,8 +12,11 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_ as NewExpression;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -33,14 +36,17 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ReflectionProperty;
 
 use function array_key_exists;
 use function class_exists;
 use function count;
 use function in_array;
+use function interface_exists;
 use function is_a;
 use function is_string;
 use function method_exists;
+use function property_exists;
 use function sprintf;
 
 /**
@@ -73,6 +79,26 @@ final class ReturnExpressionResourceReader
     private const array RESOURCE_PRESERVING_CHAIN_METHODS = ['additional'];
 
     /**
+     * Eloquent static methods that return a model instance (not a query builder), so a
+     * `Model::x(...)->toResource()` receiver names the model. Query entrypoints (`query`, `where`,
+     * …) are absent: they return a builder, whose element type is not statically knowable here.
+     */
+    private const array MODEL_RETURNING_STATICS = [
+        'create',
+        'forcecreate',
+        'make',
+        'find',
+        'findornew',
+        'findorfail',
+        'first',
+        'firstornew',
+        'firstorcreate',
+        'firstorfail',
+        'updateorcreate',
+        'sole',
+    ];
+
+    /**
      * Paginator chain methods that don't change the paginated nature or item shape (URL/metadata
      * tweaks only). Item-mapping chains (`through()`) are absent: they may change item shape.
      * Any other trailing call falls back to the plain `{data}` envelope.
@@ -90,6 +116,14 @@ final class ReturnExpressionResourceReader
      * @var array<string, ?ResourceTarget>
      */
     private array $cache = [];
+
+    /**
+     * The method statements of the resolution in flight, so a receiver that is a local variable can
+     * be traced to its assignment. Set per `resolve()` call; only ever read synchronously within it.
+     *
+     * @var list<Stmt>
+     */
+    private array $resolutionStatements = [];
 
     public function __construct(
         private readonly MethodBodyScanner $scanner,
@@ -138,6 +172,7 @@ final class ReturnExpressionResourceReader
         }
 
         $statements = $this->scanner->firstStatements($method, self::STATEMENT_LIMIT);
+        $this->resolutionStatements = $statements;
 
         if (count($this->methodLevelReturns($statements)) > 1) {
             return $this->reconcileMultipleReturns($statements, $method, $silent);
@@ -175,6 +210,7 @@ final class ReturnExpressionResourceReader
         ReflectionMethod $method,
         bool $silent,
     ): ?ResourceTarget {
+        $this->resolutionStatements = $statements;
         $resolved = [];
 
         foreach ($this->methodLevelReturns($statements) as $return) {
@@ -704,6 +740,327 @@ final class ReturnExpressionResourceReader
     }
 
     /**
+     * The Model class a `->toResource()` receiver expression resolves to, or null.
+     *
+     * Resolves the shapes whose type is statically declared, no dataflow:
+     *
+     * - a Model-typed parameter: `$model->toResource()`;
+     * - a property whose declared type is a Model: `$document->author->toResource()`;
+     * - a method call whose declared return type is a concrete Model:
+     *   `$repository->find($id)->toResource()`;
+     * - a "passthrough" call whose declared return type is the base `Model` (or `self`/`static`)
+     *   and which takes a Model-typed argument that does resolve: `$request->resolve($model)`,
+     *   `$this->reload($model)`. The returned instance is the one passed in, so its argument
+     *   carries the concrete type.
+     *
+     * @return null|class-string<Model>
+     *
+     * @throws ReflectionException
+     */
+    private function receiverModelClass(Expr $receiver, ReflectionMethod $method): ?string
+    {
+        if ($receiver instanceof Variable && is_string($receiver->name)) {
+            $parameterModel = $this->parameterModelClass($method, $receiver->name);
+
+            if ($parameterModel !== null) {
+                return $parameterModel;
+            }
+
+            // An `assert($var instanceof Model)` narrowing types the local directly, even when its
+            // assignment expression is not itself statically resolvable.
+            $asserted = $this->assertedModelClass($receiver->name, $method);
+
+            if ($asserted !== null) {
+                return $asserted;
+            }
+
+            // Otherwise trace the local's single unconditional assignment and resolve that.
+            $assigned = $this->expressionAssignedTo($receiver, $this->resolutionStatements, $method, log: false);
+
+            return $assigned === null ? null : $this->receiverModelClass($assigned, $method);
+        }
+
+        if ($receiver instanceof NewExpression && $receiver->class instanceof Name) {
+            $class = $receiver->class->toString();
+
+            return is_a($class, Model::class, allow_string: true) ? $class : null;
+        }
+
+        if (
+            $receiver instanceof StaticCall
+            && $receiver->class instanceof Name
+            && $receiver->name instanceof Identifier
+        ) {
+            $class = $receiver->class->toString();
+
+            return in_array($receiver->name->toLowerString(), self::MODEL_RETURNING_STATICS, strict: true)
+                && is_a($class, Model::class, allow_string: true)
+                    ? $class
+                    : null;
+        }
+
+        if ($receiver instanceof PropertyFetch && $receiver->name instanceof Identifier) {
+            $ownerClass = $this->expressionClass($receiver->var, $method);
+
+            return $ownerClass === null
+                ? null
+                : $this->propertyModelClass($ownerClass, $receiver->name->toString());
+        }
+
+        if ($receiver instanceof MethodCall && $receiver->name instanceof Identifier) {
+            return $this->methodCallModelClass($receiver, $method);
+        }
+
+        return null;
+    }
+
+    /**
+     * The Model class asserted for a local via `assert($var instanceof Model)`, or null.
+     *
+     * A common narrowing after a loosely-typed lookup (`$x = $request->user()->customer;
+     * assert($x instanceof Customer);`); the assertion states the concrete type the assignment
+     * expression alone does not carry.
+     *
+     * @return null|class-string<Model>
+     */
+    private function assertedModelClass(string $variableName, ReflectionMethod $method): ?string
+    {
+        foreach ($this->resolutionStatements as $statement) {
+            if (!$statement instanceof Stmt\Expression || !$statement->expr instanceof FuncCall) {
+                continue;
+            }
+
+            $call = $statement->expr;
+
+            if (!$call->name instanceof Name || $call->name->toLowerString() !== 'assert') {
+                continue;
+            }
+
+            $argument = $call->getArgs()[0]->value ?? null;
+
+            if (
+                !$argument instanceof Instanceof_
+                || !($argument->expr instanceof Variable && $argument->expr->name === $variableName)
+                || !$argument->class instanceof Name
+            ) {
+                continue;
+            }
+
+            $class = $argument->class->toString();
+
+            if (is_a($class, Model::class, allow_string: true)) {
+                /** @var class-string<Model> $class */
+                return $class;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The Model resolved from a method-call receiver: its declared concrete return type, or, for a
+     * base-`Model` passthrough, the first argument that resolves to a Model.
+     *
+     * @return null|class-string<Model>
+     *
+     * @throws ReflectionException
+     */
+    private function methodCallModelClass(MethodCall $call, ReflectionMethod $method): ?string
+    {
+        $ownerClass = $this->expressionClass($call->var, $method);
+
+        if ($ownerClass === null || !($call->name instanceof Identifier)) {
+            return null;
+        }
+
+        $returnType = $this->methodReturnType($ownerClass, $call->name->toString());
+
+        if ($returnType === null) {
+            return null;
+        }
+
+        // A concrete Model return names the resource directly.
+        if ($returnType !== Model::class && is_a($returnType, Model::class, allow_string: true)) {
+            /** @var class-string<Model> $returnType */
+            return $returnType;
+        }
+
+        // A base-Model (or self/static) return is a passthrough: the concrete type rides in on the
+        // argument. Anything else (a non-Model return) is not a resource source.
+        if ($returnType !== Model::class && !$this->isSelfReturn($ownerClass, $returnType)) {
+            return null;
+        }
+
+        foreach ($call->getArgs() as $argument) {
+            $modelClass = $this->receiverModelClass($argument->value, $method);
+
+            if ($modelClass !== null) {
+                return $modelClass;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The class an expression evaluates to, for receiver-chain resolution: `$this`, a typed
+     * parameter, a typed property, or a method's declared return type. Null when not statically
+     * known.
+     *
+     * @return null|class-string
+     *
+     * @throws ReflectionException
+     */
+    private function expressionClass(Expr $expression, ReflectionMethod $method): ?string
+    {
+        if ($expression instanceof Variable) {
+            if ($expression->name === 'this') {
+                return $method->getDeclaringClass()->getName();
+            }
+
+            return is_string($expression->name)
+                ? $this->parameterClass($method, $expression->name)
+                : null;
+        }
+
+        if ($expression instanceof PropertyFetch && $expression->name instanceof Identifier) {
+            $ownerClass = $this->expressionClass($expression->var, $method);
+
+            return $ownerClass === null
+                ? null
+                : $this->propertyClass($ownerClass, $expression->name->toString());
+        }
+
+        if ($expression instanceof MethodCall && $expression->name instanceof Identifier) {
+            $ownerClass = $this->expressionClass($expression->var, $method);
+            $returnType = $ownerClass === null
+                ? null
+                : $this->methodReturnType($ownerClass, $expression->name->toString());
+
+            return $returnType !== null && (class_exists($returnType) || interface_exists($returnType))
+                ? $returnType
+                : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * The class the named parameter is typed with (any class, not only Models), or null.
+     *
+     * @return null|class-string
+     */
+    private function parameterClass(ReflectionMethod $method, string $parameterName): ?string
+    {
+        foreach ($method->getParameters() as $parameter) {
+            if ($parameter->getName() !== $parameterName) {
+                continue;
+            }
+
+            $type = $parameter->getType();
+
+            return $type instanceof ReflectionNamedType && !$type->isBuiltin()
+                ? $this->asClassString($type->getName())
+                : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * The declared class of a property on the owner class, or null.
+     *
+     * @param class-string $ownerClass
+     *
+     * @return null|class-string
+     *
+     * @throws ReflectionException
+     */
+    private function propertyClass(string $ownerClass, string $property): ?string
+    {
+        if (!property_exists($ownerClass, $property)) {
+            return null;
+        }
+
+        $type = new ReflectionProperty($ownerClass, $property)->getType();
+
+        return $type instanceof ReflectionNamedType && !$type->isBuiltin()
+            ? $this->asClassString($type->getName())
+            : null;
+    }
+
+    /**
+     * Narrows a reflected type name to a known class-string, or null when no such class/interface
+     * is loadable.
+     *
+     * @return null|class-string
+     */
+    private function asClassString(string $name): ?string
+    {
+        return class_exists($name) || interface_exists($name) ? $name : null;
+    }
+
+    /**
+     * The declared property class when it is a Model subclass, or null.
+     *
+     * @param class-string $ownerClass
+     *
+     * @return null|class-string<Model>
+     *
+     * @throws ReflectionException
+     */
+    private function propertyModelClass(string $ownerClass, string $property): ?string
+    {
+        $class = $this->propertyClass($ownerClass, $property);
+
+        if ($class !== null && is_a($class, Model::class, allow_string: true)) {
+            /** @var class-string<Model> $class */
+            return $class;
+        }
+
+        return null;
+    }
+
+    /**
+     * The class named by a method's declared return type (nullable/`self`/`static` resolved), or
+     * null when untyped or a builtin.
+     *
+     * @param class-string $ownerClass
+     *
+     * @return null|class-string
+     *
+     * @throws ReflectionException
+     */
+    private function methodReturnType(string $ownerClass, string $methodName): ?string
+    {
+        if (!method_exists($ownerClass, $methodName)) {
+            return null;
+        }
+
+        $type = new ReflectionMethod($ownerClass, $methodName)->getReturnType();
+
+        if (!$type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        $name = $type->getName();
+
+        // `self`/`static` name the receiver's own class.
+        return in_array($name, ['self', 'static'], strict: true) ? $ownerClass : $this->asClassString($name);
+    }
+
+    /**
+     * Whether a resolved return type is the receiver's own class (a `self`/`static`/`$this`-style
+     * passthrough).
+     *
+     * @param class-string $ownerClass
+     */
+    private function isSelfReturn(string $ownerClass, string $returnType): bool
+    {
+        return $returnType === $ownerClass;
+    }
+
+    /**
      * Handles `->toResource(X::class)` / `->toResourceCollection(X::class)` and bare
      * `$model->toResource()` on a Model-typed parameter. Other receivers need dataflow and refuse.
      *
@@ -754,9 +1111,7 @@ final class ReturnExpressionResourceReader
             return null;
         }
 
-        $modelClass = $call->var instanceof Variable && is_string($call->var->name)
-            ? $this->parameterModelClass($method, $call->var->name)
-            : null;
+        $modelClass = $this->receiverModelClass($call->var, $method);
 
         if ($modelClass === null) {
             $this->note(

--- a/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
+++ b/src/Plugins/ApiResources/Support/ReturnExpressionResourceReader.php
@@ -99,6 +99,23 @@ final class ReturnExpressionResourceReader
     ];
 
     /**
+     * Model instance methods that return the same model (instance or a refreshed copy of the same
+     * class), so `$model->x(...)` preserves the model type. Used to see through a passthrough
+     * callee's `return $param->refresh();`-style body.
+     */
+    private const array IDENTITY_PRESERVING_MODEL_CALLS = [
+        'refresh',
+        'fresh',
+        'load',
+        'loadmissing',
+        'loadcount',
+        'loadaggregate',
+        'setrelation',
+        'unsetrelation',
+        'withoutrelations',
+    ];
+
+    /**
      * Paginator chain methods that don't change the paginated nature or item shape (URL/metadata
      * tweaks only). Item-mapping chains (`through()`) are absent: they may change item shape.
      * Any other trailing call falls back to the plain `{data}` envelope.
@@ -768,7 +785,7 @@ final class ReturnExpressionResourceReader
 
             // An `assert($var instanceof Model)` narrowing types the local directly, even when its
             // assignment expression is not itself statically resolvable.
-            $asserted = $this->assertedModelClass($receiver->name, $method);
+            $asserted = $this->assertedModelClass($receiver->name);
 
             if ($asserted !== null) {
                 return $asserted;
@@ -823,7 +840,7 @@ final class ReturnExpressionResourceReader
      *
      * @return null|class-string<Model>
      */
-    private function assertedModelClass(string $variableName, ReflectionMethod $method): ?string
+    private function assertedModelClass(string $variableName): ?string
     {
         foreach ($this->resolutionStatements as $statement) {
             if (!$statement instanceof Stmt\Expression || !$statement->expr instanceof FuncCall) {
@@ -859,7 +876,7 @@ final class ReturnExpressionResourceReader
 
     /**
      * The Model resolved from a method-call receiver: its declared concrete return type, or, for a
-     * base-`Model` passthrough, the first argument that resolves to a Model.
+     * verified base-`Model` passthrough, the model type of the argument the callee returns.
      *
      * @return null|class-string<Model>
      *
@@ -885,21 +902,88 @@ final class ReturnExpressionResourceReader
             return $returnType;
         }
 
-        // A base-Model (or self/static) return is a passthrough: the concrete type rides in on the
-        // argument. Anything else (a non-Model return) is not a resource source.
+        // A base-Model (or self/static) return may be a passthrough: the concrete type rides in on
+        // the argument. Anything else (a non-Model return) is not a resource source.
         if ($returnType !== Model::class && !$this->isSelfReturn($ownerClass, $returnType)) {
             return null;
         }
 
-        foreach ($call->getArgs() as $argument) {
-            $modelClass = $this->receiverModelClass($argument->value, $method);
+        // Only trust the passthrough when the callee actually returns one of its parameters (the
+        // identity idiom, e.g. `resolve(Model $x): Model { return $x; }`). A method that merely
+        // has a base-Model signature but returns something unrelated must not borrow an argument's
+        // type, or the response schema would be silently wrong.
+        $parameterIndex = $this->calleeReturnedParameterIndex($ownerClass, $call->name->toString());
 
-            if ($modelClass !== null) {
-                return $modelClass;
+        if ($parameterIndex === null) {
+            return null;
+        }
+
+        $argument = $call->getArgs()[$parameterIndex]->value ?? null;
+
+        return $argument === null ? null : $this->receiverModelClass($argument, $method);
+    }
+
+    /**
+     * The zero-based index of the parameter a method returns by identity, or null when it does not
+     * return a parameter (or the body is not a single statically-readable return).
+     *
+     * Looks through identity-preserving model calls on the parameter (`refresh()`, `fresh()`,
+     * `load()`, …), which return the same model instance/shape.
+     *
+     * @param class-string $ownerClass
+     *
+     * @throws ReflectionException
+     */
+    private function calleeReturnedParameterIndex(string $ownerClass, string $methodName): ?int
+    {
+        if (!method_exists($ownerClass, $methodName)) {
+            return null;
+        }
+
+        $callee = new ReflectionMethod($ownerClass, $methodName);
+
+        if ($callee->isAbstract() || $callee->getDeclaringClass()->isInterface()) {
+            return null;
+        }
+
+        $statements = $this->scanner->firstStatements($callee, self::STATEMENT_LIMIT);
+        $returns = $this->methodLevelReturns($statements);
+
+        if (count($returns) !== 1 || $returns[0]->expr === null) {
+            return null;
+        }
+
+        $returnedName = $this->identityParameterName($returns[0]->expr);
+
+        if ($returnedName === null) {
+            return null;
+        }
+
+        foreach ($callee->getParameters() as $index => $parameter) {
+            if ($parameter->getName() === $returnedName) {
+                return $index;
             }
         }
 
         return null;
+    }
+
+    /**
+     * The variable name an expression is the identity of: a bare `$var`, or `$var` behind a chain
+     * of identity-preserving model calls (`$var->refresh()`, `$var->fresh()->load(...)`). Null for
+     * anything else.
+     */
+    private function identityParameterName(Expr $expression): ?string
+    {
+        while (
+            $expression instanceof MethodCall
+            && $expression->name instanceof Identifier
+            && in_array($expression->name->toLowerString(), self::IDENTITY_PRESERVING_MODEL_CALLS, strict: true)
+        ) {
+            $expression = $expression->var;
+        }
+
+        return $expression instanceof Variable && is_string($expression->name) ? $expression->name : null;
     }
 
     /**

--- a/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
+++ b/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Psr\Log\LoggerInterface;
 use Radiergummi\OpenApi\Plugins\ApiResources\Support\ReturnExpressionResourceReader;
+use Radiergummi\OpenApi\Tests\Fixtures\Http\Resources\AuthorResource;
 use Radiergummi\OpenApi\Tests\Fixtures\Models\Author;
 use Radiergummi\OpenApi\Tests\Fixtures\Resources\LiteralOnlyResource;
 use Radiergummi\OpenApi\Tests\Fixtures\Resources\NestedAuthorResource;
@@ -39,6 +40,59 @@ class ReaderFixtureController
     public function __construct(
         public Author $author,
     ) {}
+
+    public function methodReturnModelToResource(): JsonResource
+    {
+        return $this->findAuthor()->toResource();
+    }
+
+    public function findAuthor(): Author
+    {
+        return $this->author;
+    }
+
+    public function passthroughToResource(Author $author): JsonResource
+    {
+        return $this->reload($author)->toResource();
+    }
+
+    public function reload(Author $author): Model
+    {
+        return $author->refresh();
+    }
+
+    public function unresolvableReceiverToResource(): JsonResource
+    {
+        return $this->makeSomething()->toResource();
+    }
+
+    public function makeSomething(): Model
+    {
+        return $this->author;
+    }
+
+    public function localNewModelToResource(): JsonResource
+    {
+        $author = new Author();
+        $author->save();
+
+        return $author->toResource();
+    }
+
+    public function localStaticFactoryToResource(): JsonResource
+    {
+        $author = Author::create(['name' => 'x']);
+
+        return $author->toResource();
+    }
+
+    public function assertNarrowedLocalToResource(): JsonResource
+    {
+        $author = $this->author->fresh();
+        assert($author instanceof Author);
+
+        return $author->toResource();
+    }
 
     public function staticModelPaginate(): AnonymousResourceCollection
     {
@@ -435,8 +489,50 @@ it('emits no refusal notice when a @return-docblock collection has a conditional
         ))->toBeEmpty();
 });
 
-it('refuses a bare ->toResource() whose receiver is not a typed parameter', function (): void {
-    expect(readerFor()->read(readerMethod('propertyReceiverToResource')))->toBeNull();
+it('resolves a ->toResource() whose receiver is a Model-typed property', function (): void {
+    $target = readerFor()->read(readerMethod('propertyReceiverToResource'));
+
+    expect($target?->resourceClass)->toBe(AuthorResource::class)
+        ->and($target?->isCollection)->toBeFalse();
+});
+
+it('resolves a ->toResource() whose receiver is a method with a concrete Model return', function (): void {
+    $target = readerFor()->read(readerMethod('methodReturnModelToResource'));
+
+    expect($target?->resourceClass)->toBe(AuthorResource::class)
+        ->and($target?->isCollection)->toBeFalse();
+});
+
+it('resolves a ->toResource() through a base-Model passthrough call, from its argument', function (): void {
+    $target = readerFor()->read(readerMethod('passthroughToResource'));
+
+    expect($target?->resourceClass)->toBe(AuthorResource::class)
+        ->and($target?->isCollection)->toBeFalse();
+});
+
+it('refuses a base-Model return with no Model-typed argument to carry the type', function (): void {
+    expect(readerFor()->read(readerMethod('unresolvableReceiverToResource')))->toBeNull();
+});
+
+it('resolves a ->toResource() on a local assigned from new Model()', function (): void {
+    $target = readerFor()->read(readerMethod('localNewModelToResource'));
+
+    expect($target?->resourceClass)->toBe(AuthorResource::class)
+        ->and($target?->isCollection)->toBeFalse();
+});
+
+it('resolves a ->toResource() on a local assigned from a model-returning static factory', function (): void {
+    $target = readerFor()->read(readerMethod('localStaticFactoryToResource'));
+
+    expect($target?->resourceClass)->toBe(AuthorResource::class)
+        ->and($target?->isCollection)->toBeFalse();
+});
+
+it('resolves a ->toResource() on a local narrowed by assert(instanceof)', function (): void {
+    $target = readerFor()->read(readerMethod('assertNarrowedLocalToResource'));
+
+    expect($target?->resourceClass)->toBe(AuthorResource::class)
+        ->and($target?->isCollection)->toBeFalse();
 });
 
 it('resolves a bare ->toResource() through the model #[UseResource] attribute', function (): void {

--- a/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
+++ b/tests/Unit/Plugins/ApiResources/ReturnExpressionResourceReaderTest.php
@@ -61,6 +61,17 @@ class ReaderFixtureController
         return $author->refresh();
     }
 
+    public function nonReturningPassthroughToResource(Author $author): JsonResource
+    {
+        return $this->currentActor($author)->toResource();
+    }
+
+    public function currentActor(Author $subject): Model
+    {
+        // Ignores its argument and returns an unrelated model — must NOT be treated as a passthrough.
+        return new ReaderFixtureCuratedAuthor();
+    }
+
     public function unresolvableReceiverToResource(): JsonResource
     {
         return $this->makeSomething()->toResource();
@@ -512,6 +523,10 @@ it('resolves a ->toResource() through a base-Model passthrough call, from its ar
 
 it('refuses a base-Model return with no Model-typed argument to carry the type', function (): void {
     expect(readerFor()->read(readerMethod('unresolvableReceiverToResource')))->toBeNull();
+});
+
+it('refuses a base-Model call that does not return its argument (no false passthrough)', function (): void {
+    expect(readerFor()->read(readerMethod('nonReturningPassthroughToResource')))->toBeNull();
 });
 
 it('resolves a ->toResource() on a local assigned from new Model()', function (): void {


### PR DESCRIPTION
Closes #540

> **Stacked on #537** (`feat/jsonapi-resource-support`). Base will retarget to `main` once #537 merges. Review #537 first.

## What

`ReturnExpressionResourceReader` resolved a bare `$model->toResource()` only when the receiver was a **Model-typed method parameter**. Every other receiver refused with *"model type is not statically knowable"*. This generalises receiver resolution to all statically-declared shapes — no dataflow, all reflection/AST reads on declared types:

| Receiver shape | Example |
|---|---|
| Model-typed property | `$document->author->toResource()` |
| method with a concrete Model return | `$repository->find($id)->toResource()` |
| base-`Model`/`self` passthrough call | `$request->resolve($model)->toResource()` |
| local from `new Model()` / static factory | `$c = new Client(); … return $c->toResource();` |
| local narrowed by `assert()` | `assert($x instanceof Customer); return $x->toResource();` |

The passthrough case reads the concrete type off the **argument**: a method declared `resolve(Model $x): Model` returns the instance it was given, so the argument carries the type the return signature erases. Only base-`Model`/`self`/`static` returns trigger this; a concrete-Model return is used directly, and any other return type refuses.

Model-returning static factories are a fixed whitelist (`create`, `make`, `findOrFail`, `first`, `firstOrFail`, `updateOrCreate`, …); query entrypoints (`query`, `where`) are excluded because a builder's element type is not statically known here.

Unknown receivers (query-builder chains, untyped locals) still refuse and log exactly as before. `#[UseResource]`/`guessResourceName` resolution and the `{data}` envelope are reused unchanged.

## Provenance & impact

Found by dogfooding a private consumer app — the dominant remaining response gap was `->toResource()` on non-parameter receivers (`$request->resolve($model)`, locals from `new`, `assert`-narrowed locals). Combined with an app-side Action-delegation plugin, the app went **69% → 81%** of `/api` operations complete; response gaps **88 → 35**, with zero regressions vs the pre-change spec.

## Tests

New `ReturnExpressionResourceReaderTest` cases cover property, method-return, passthrough, `new`, static-factory, and assert receivers, plus the refusal when a base-Model return has no Model argument to carry the type. Full suite green (3484), PHPStan level 8 clean, Pint clean.