### PR TITLE
fix(swagger-php): support 6.4's Utils\Pipeline in the annotation harvester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to this project are documented here.
 - Internal: the body-scan readers now resolve a call argument by name or position through a single shared `Support\MethodBody\CallArgumentResolver`, replacing four copies of the same logic. No spec output change. (#512)
 
 ### Fixed
+- Compatibility with `zircote/swagger-php` 6.4, which moved `OpenApi\Pipeline` to `OpenApi\Utils\Pipeline` and now hands the base class to `withProcessorPipeline()` callbacks. The SwaggerPhp harvester's callback no longer pins the old subclass in a parameter type, so the scan works across the whole supported range (5.8, 6.1 to 6.4).
 - Lint now surfaces top-level and field-level bare `oneOf` / `anyOf` schemas across components, responses, and request bodies. (#294, #318)
 - Edit-time PHPStan rules resolve positionally-written attribute arguments, not just named ones. (#322)
 - `ErrorResponseInferenceStage` catches `Exception` only, so misbehaving resolvers throwing `Error`/`TypeError` fail loudly. (#308)

--- a/src/Plugins/SwaggerPhp/Support/AuthoredAnnotationScanner.php
+++ b/src/Plugins/SwaggerPhp/Support/AuthoredAnnotationScanner.php
@@ -296,15 +296,7 @@ final class AuthoredAnnotationScanner
     {
         try {
             return new Generator($this->logger)
-                ->withProcessorPipeline(
-                    // Drop the operation-id synthesiser so only truly authored operationIds are
-                    // indexed, not swagger-php-generated hashes. Drop AugmentTags too: it prunes any
-                    // root tag no operation references, which would hide an authored-but-unused
-                    // @OA\Tag the migration rule needs to see.
-                    static fn(Pipeline $pipeline): Pipeline => $pipeline
-                        ->remove(OperationId::class)
-                        ->remove(AugmentTags::class),
-                )
+                ->withProcessorPipeline($this->withoutGeneratedProcessors(...))
                 ->generate($this->scanPaths, validate: false);
         } catch (Throwable $exception) {
             $this->logger->warning(
@@ -313,6 +305,27 @@ final class AuthoredAnnotationScanner
 
             return null;
         }
+    }
+
+    /**
+     * Trims two default processors from the scan pipeline: the operation-id synthesiser, so only
+     * truly authored operationIds are indexed rather than swagger-php-generated hashes, and
+     * AugmentTags, which prunes any root tag no operation references (that would hide an
+     * authored-but-unused `@OA\Tag` the migration rule needs to see).
+     *
+     * The parameter carries no native type. swagger-php 6.4 hands the callback an
+     * `OpenApi\Utils\Pipeline`, while 5.8 to 6.3 hand it `OpenApi\Pipeline` (which 6.4 keeps as a
+     * subclass of the former), so a native type would break one end of the supported range. The
+     * PHPDoc names `OpenApi\Pipeline` because that is the one class present on every version;
+     * `remove()` mutates the pipeline in place, so nothing needs to be returned.
+     *
+     * @param Pipeline $pipeline
+     */
+    private function withoutGeneratedProcessors($pipeline): void
+    {
+        $pipeline
+            ->remove(OperationId::class)
+            ->remove(AugmentTags::class);
     }
 
     private function indexSchemas(OpenApi $document): void


### PR DESCRIPTION
## Problem

`zircote/swagger-php` 6.4 moved `OpenApi\Pipeline` to `OpenApi\Utils\Pipeline` (leaving `OpenApi\Pipeline` as a `@deprecated` subclass) and now hands the **base** `Utils\Pipeline` to `Generator::withProcessorPipeline()` callbacks.

`AuthoredAnnotationScanner::generate()` typed its callback parameter as the old `OpenApi\Pipeline` (the subclass). On 6.4 it receives the parent instance, so:

```
Argument #1 ($pipeline) must be of type OpenApi\Pipeline, OpenApi\Utils\Pipeline given
```

This TypeError aborts the harvester scan, failing **56 SwaggerPhp tests** on every floating-dependency CI cell (PHP 8.4/8.5 × Laravel 12/13). The supported range `^5.8 || ^6.1.2` admits 6.4, so `composer update` pulls it. The pinned jobs (swagger-php 5.8, locked snapshot) are unaffected and stay green — which is why `main` last went green when 6.2.0 was the newest release, and would be red on a fresh run today.

## Fix

No single class name spans the supported range — 5.8 and 6.1–6.3 have only `OpenApi\Pipeline`; `Utils\Pipeline` exists from 6.4 on — so a native parameter type would break one end or the other. The callback parameter now carries **no native type**; its PHPDoc type resolves against whichever version is installed, and `remove()` exists on both classes. The closure is extracted to a small private method to keep the PHPDoc clean.

## Verification

Ran the previously-failing SwaggerPhp suites plus the full test suite against three installed versions:

| swagger-php | Result |
|---|---|
| 5.8.3 (pinned CI path) | harvester tests pass, no autoload fatal from the PHPDoc-only `Utils\Pipeline` reference |
| 6.2.0 (current lock) | unchanged, green |
| 6.4.0 (floating CI) | previously-failing tests pass; full parallel suite 3467 green, PHPStan L8 clean, Pint clean |

Composer lock is intentionally left at 6.2.0 (the fix is source-only; CI's matrix floats).

Found while dogfooding; blocks the JSON:API (#537) and `->toResource()` receiver (#541) PRs whose CI inherits this break.