### PR TITLE
test: replace a third-party consumer's identifiers in fixtures with neutral placeholders

### DIFF
--- a/tests/Fixtures/Lint/InvalidExternalDocsController.php
+++ b/tests/Fixtures/Lint/InvalidExternalDocsController.php
@@ -13,7 +13,7 @@ use Radiergummi\OpenApi\Lint\Rules\ExternaldocsInvalidUrl;
  */
 final class InvalidExternalDocsController
 {
-    #[ExternalDocs(url: 'https://docs.matchory.com/search')]
+    #[ExternalDocs(url: 'https://docs.example.com/search')]
     public function withValidUrl(): JsonResponse
     {
         return response()->json();

--- a/tests/Fixtures/RouteBoundFormRequest.php
+++ b/tests/Fixtures/RouteBoundFormRequest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 /**
- * Mirrors matchory-webapp's `ContactInfoCallbackRequest`: rules() reads a route-bound model and
+ * Mirrors a real-world FormRequest whose rules() reads a route-bound model and
  * uses one of its properties inside a `Rule::in([...])`.
  */
 class RouteBoundFormRequest extends FormRequest

--- a/tests/Fixtures/UserBoundFormRequest.php
+++ b/tests/Fixtures/UserBoundFormRequest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 /**
- * Mirrors matchory-webapp's `UpdateCurrentCustomerRequest`: rules() reads `$this->user()` to
+ * Mirrors a real-world FormRequest whose rules() reads `$this->user()` to
  * scope a `unique` rule.
  */
 class UserBoundFormRequest extends FormRequest

--- a/tests/Unit/Lint/IdentifierCaseTest.php
+++ b/tests/Unit/Lint/IdentifierCaseTest.php
@@ -13,7 +13,7 @@ it('matches the expected input', function (IdentifierCase $case, string $input):
     'Dot: kebab in last segment' => [IdentifierCase::Dot, 'api.v0.projects.list-active'],
     'Dot: kebab in multiple segments' => [IdentifierCase::Dot, 'api.v0.user-accounts.list-active'],
     'Dot: kebab-only, no dots' => [IdentifierCase::Dot, 'auth-callback'],
-    'Dot: matchory auth.resolve-account' => [IdentifierCase::Dot, 'auth.resolve-account'],
+    'Dot: kebab in two-segment id' => [IdentifierCase::Dot, 'auth.reset-password'],
     'Pascal: single-word' => [IdentifierCase::Pascal, 'Users'],
     'Pascal: multi-word' => [IdentifierCase::Pascal, 'ApiV0ProjectsIndex'],
     'Train: single-word' => [IdentifierCase::Train, 'Api'],

--- a/tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php
+++ b/tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php
@@ -74,7 +74,7 @@ it('emits a finding when info.description is missing or blank', function (?strin
 
 it('emits no findings when info.description is set', function (): void {
     $rule = new InfoDescriptionMissing();
-    $context = makeInfoContext('The Matchory supplier discovery API.');
+    $context = makeInfoContext('The Example Pet Store API.');
 
     $findings = iterator_to_array($rule->checkApi($context->api, $context));
 


### PR DESCRIPTION
Neutralizes illustrative references to a private consumer application in test fixtures and two lint test cases — its name, domain, and class names — replacing them with neutral placeholders (`example.com`, generic descriptions). No production code touched; test semantics are identical.

**Files:**
- `tests/Fixtures/RouteBoundFormRequest.php` — docblock → generic wording
- `tests/Fixtures/UserBoundFormRequest.php` — docblock → generic wording
- `tests/Fixtures/Lint/InvalidExternalDocsController.php` — external-docs URL → `https://docs.example.com/search`
- `tests/Unit/Lint/IdentifierCaseTest.php` — dataset label + sample identifier → neutral dotted-kebab id
- `tests/Unit/Lint/Rules/InfoDescriptionMissingTest.php` — sample info description → `The Example Pet Store API.`

Gate: `composer check` green (3649 passed; Pint + PHPStan clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)