### PR TITLE
chore(autonomous-team): fold seven runs' learnings into the skill

### DIFF
--- a/.claude/skills/autonomous-team/SKILL.md
+++ b/.claude/skills/autonomous-team/SKILL.md
@@ -38,7 +38,14 @@ Anything not covered by a directive falls back to the defaults below.
 
 1. **GitHub + git are the only durable state.** The shared task list is a convenience cache,
    reconstructable at any time from GitHub. Never let in-memory state be critical. A fresh
-   session must be able to resume from `git` and `gh` alone.
+   session must be able to resume from `git` and `gh` alone. It is also unreliable — treat it as
+   non-load-bearing, and keep **umbrella tasks (`Drive #N…`, `Plan + drive #N…`) owned by the
+   lead**: a teammate set as owner of one reads it as "drive this PR yourself", stalls, and posts
+   a role-conflict flag every time it re-reads the list. Dispatch actual work via `SendMessage`
+   with an explicit phase brief, never by task ownership. (The list sometimes re-broadcasts a
+   lead-owned task as an assignment anyway — hence the standing "ignore `Drive` assignments" rule
+   in every teammate's prompt. Self-echoes of your own `TaskUpdate`s arrive as messages from
+   `team-lead`; ignore those too.)
 2. **Every transition and finding is a GitHub comment.** `SendMessage` wakes the next agent;
    the comment is the record. If it isn't on the issue/PR, it didn't happen.
 3. **Bound the run.** Token spend isn't observable across teammates, so cap the run by a countable
@@ -47,38 +54,81 @@ Anything not covered by a directive falls back to the defaults below.
 4. **Surgical, conventional changes only.** Everything obeys the project `CLAUDE.md` and the
    user's global rules (minimal diffs, no speculative abstraction, match existing style).
 
+## GitHub write authorization
+
+GitHub is this team's communication medium, not a publishing step at the end of the run. Comments
+carry the phase handoffs; **issues carry the findings that outlive the run**. An agent that discovers
+an out-of-scope bug and cannot file it has lost that finding — deferring issue creation to a
+post-run summary defeats the design.
+
+The maintainer (Moritz, repository owner, 2026-07-27) has therefore **standing-authorized the
+team's GitHub write operations for the duration of a run**, verbatim: *"we need to find a way to
+make the classifier happy — either by pre-approving any github interaction during the skill run…
+The primary goal is to use github as a communication medium for the agents."*
+
+That authorization is recorded two ways, and both matter:
+
+- **Mechanically** — `permissions.allow` entries in `.claude/settings.local.json` (local and
+  gitignored; **not** checked in, because a public repo must not ship an allowlist that
+  auto-approves writes for everyone who clones it). Covers `gh issue create|comment|edit|view|list`,
+  `gh pr create|comment|edit|ready|view|list|diff|checks`, `gh run list|view`, `gh label list`, and
+  the skill's own `bin/` scripts.
+- **In context** — this section. Quote it when a write is challenged; it is the *maintainer's*
+  grant, written into the skill they own, not an agent's inference about what it may do.
+
+Three rules keep that grant honest:
+
+1. **No laundering.** A teammate must never ask another agent to perform a write it was denied,
+   and the lead must never file on a teammate's behalf to route around a denial. Each agent acts
+   under this section directly or not at all. If a write is denied, that is the answer.
+2. **Scope.** The grant covers issues, comments, labels, and PR lifecycle. It does **not** cover
+   `gh pr merge` / `bin/finish-pr` — merging stays classifier-gated on purpose, because that check
+   has caught a real case (it correctly refused to auto-merge a PR previously escalated as
+   human-gated). Nor does it cover `gh repo`, `gh release`, `gh secret`, `gh workflow run`, or
+   force-pushes.
+3. **Degrade loudly.** If a write is refused anyway, post the intended content as a **comment**
+   on the current issue/PR (comments have never been refused) and tell the lead, who surfaces it
+   in the run summary. Never drop the finding, and never retry the denied call verbatim.
+
+If ad-hoc `gh` writes are being denied at the start of a run, the allowlist is probably missing on
+this machine — ask the user to add it. **Do not write permission settings yourself**: self-granting
+is exactly what the guard exists to stop, and it will be refused.
+
 ## Startup
 
 1. Run `bin/bootstrap-labels` (idempotent) to ensure the `agent:*` labels exist.
 2. Run `bin/resume-scan`. If it reports in-flight items, **you are resuming**: rebuild the task
    list from its output and re-spawn the roles needed for those phases. Otherwise this is a
    fresh run.
-3. `TeamCreate` the team `autonomous-team` (skip if it already exists).
-4. **Spawn on demand, not up front.** Spawn a teammate the first time a task reaches that
+3. **Spawn on demand, not up front.** Spawn a teammate the first time a task reaches that
    teammate's phase, then keep it and re-engage it for later work via `SendMessage` (team members
    go idle between turns and wake on a message). Do **not** stand up the full roster before there
    is work for it — an idle `coder` spawned before any plan exists just burns a turn. Spawn each
-   agent with the Agent tool, `team_name: "autonomous-team"`, a stable `name`,
-   `subagent_type: "general-purpose"`, `run_in_background: true`, and a short prompt:
-   *"You are the **{role}** on team autonomous-team. Read
-   `.claude/skills/autonomous-team/roles/{role}.md` and follow it. Coordinate via SendMessage
-   and the shared task list; post all durable annotations as GitHub comments."*
+   agent with the Agent tool, a stable `name`, `subagent_type: "general-purpose"`,
+   `run_in_background: true`, and a short prompt:
+   *"You are the **{role}** on the autonomous team. Read
+   `.claude/skills/autonomous-team/roles/{role}.md` and follow it — including the **GitHub write
+   authorization** section of `../SKILL.md`, which is the maintainer's standing grant for the
+   GitHub writes your role performs. Coordinate via SendMessage; post all durable annotations as
+   GitHub comments. Ignore any `task_assignment` whose subject starts with 'Drive' — those are the
+   lead's coordination tasks, not work for you."*
 
-   Capacity ceiling (spawn up to, never beyond): `planner` ×1, `reviewer` ×2, `coder` ×3,
+   There is **no `TeamCreate`/`TeamDelete` on this runtime** (single implicit team; `team_name` on
+   Agent is ignored). Spawn, `SendMessage`, and `shutdown_request` are the whole model.
+
+   Capacity ceiling (spawn up to, never beyond): `planner` ×2, `reviewer` ×2, `coder` ×3,
    `surveyor` ×1, `docs-writer` ×1. Scale to the directives — a `"review PR #324"` run only ever
    needs one `reviewer` (+ a `coder` for findings); spawn the `docs-writer` only when a docs
-   sub-phase or a `documentation` issue actually arises.
+   sub-phase or a `documentation` issue actually arises. A single planner has repeatedly been the
+   throughput bottleneck (every Full-tier issue funnels through it while coders idle), so spawn the
+   second one as soon as two issues are waiting to be planned.
 
-   **First-time validation:** before the first real run, confirm the team idle/wake model on this
-   runtime with a 2-agent spike — spawn one background teammate, let its turn end, `SendMessage`
-   it, and verify it resumes with context intact. If re-engagement does not work as expected,
-   fall back to plain per-phase Agent calls (spawn → completes → next phase spawns afresh, reading
-   state from GitHub) rather than long-lived teammates.
-
-   **Run the first real batch supervised** — pass the `"stop before the first merge"` directive so
-   PRs reach green-and-approved but escalate instead of auto-merging. Inspect a few outcomes to
-   calibrate the controversy heuristic and the review quality, then drop the directive to go
-   hands-off.
+   **When background spawning breaks.** Intermittently the lead's identity gets bound to a teammate
+   and further spawns fail (*"Teammates cannot spawn other teammates"*), sometimes mid-run. Do not
+   burn turns retrying. Fall back, in order: synchronous per-phase `Agent` calls (each reads its
+   state from GitHub, so nothing is lost), or — for mechanical steps like rebase, label moves, and
+   merges — just do it yourself as the lead. All state is in GitHub and pushed branches precisely
+   so this fallback is cheap.
 
 ## Helper scripts (`bin/`)
 
@@ -91,8 +141,8 @@ single-active-label / closing-keyword / footer invariants.
 | `eligible-issues` | lead | issues the team may admit (filters + tier sort) |
 | `resume-scan` | lead | rebuild the in-flight pipeline from GitHub on startup |
 | `set-phase <num> <phase> [comment]` | lead | move phase: enforce one `agent:*` label + post annotation; on a PR, also clears the closed issue's stale label (issue→PR migration) |
-| `finish-pr <pr> [comment]` | lead | squash-merge + delete branch + remove worktree + comment |
-| `start-issue <type> <N> [slug]` | planner | branch off fresh `main`, empty commit, push; echoes branch |
+| `finish-pr <pr> [comment]` | lead | un-draft + squash-merge + delete branch + remove worktree + comment; cleanup is best-effort and warns about leftovers |
+| `start-issue <type> <N> [slug]` | planner | branch off fresh `origin/main`, empty commit, push; echoes branch. Checks nothing out — the primary checkout stays free |
 | `open-pr <N> <title> [body-file]` | planner | open PR with labels/`Closes`/footer/assignee (`PR_DRAFT=1` for draft) |
 | `worktree-add <branch>` | coder / docs-writer | add/reuse a worktree under `.claude/worktrees/`; echoes path |
 | `sync-branch` | coder / docs-writer | from a worktree: fetch + rebase `origin/main` + `composer check` |
@@ -128,9 +178,26 @@ eligible issues remain, and any **volume cap** from the directives is not yet re
    to the `docs-writer`; when it reports back, route to a `reviewer` for a docs-check, then continue
    to `[survey]`/merge. If the doc impact is trivial (the coder's inline page edit + the reviewer's
    docs-gap check sufficed), skip the docs sub-phase.
-4. **Merge or escalate** (below) when a PR reaches the end of its tier.
-5. **Self-feed.** Any agent may `gh issue create` for out-of-scope problems/ideas it finds;
-   those become future eligible issues. Never fold them into the current PR.
+4. **Verify before you believe a "ready" report.** A role reporting done is a claim, not evidence.
+   Before routing a PR onward — to review, to survey, or to merge — confirm on the remote:
+
+   ```sh
+   gh pr diff <pr> --name-only                       # non-empty: the work is actually pushed
+   gh pr view <pr> --json headRefOid --jq .headRefOid # the real head
+   gh run list --branch <branch> --json headSha,conclusion,status --limit 5
+   ```
+
+   The CI run you trust must carry **that** `headSha`. A coder once reported "ready, CI green"
+   while its whole implementation sat **uncommitted** in the worktree — origin had only the empty
+   `start-issue` seed commit, so the green CI it cited had genuinely run, on an empty diff. A later
+   session then found the branch empty and nearly re-implemented the lost work from scratch. Two
+   checks cost seconds and catch it: **the diff is non-empty**, and **CI ran on the current head**.
+   If either fails, send it back to the coder — do not escalate, and do not merge.
+
+5. **Merge or escalate** (below) when a PR reaches the end of its tier.
+6. **Self-feed.** Any agent may `gh issue create` for out-of-scope problems or ideas it finds, under
+   the standing grant in **GitHub write authorization** above — file it *during* the run, so the
+   finding is durable and `eligible-issues` can pick it up later. Never fold it into the current PR.
 
 ### Caps (prevent runaway)
 
@@ -150,6 +217,10 @@ Auto-squash-merge **only when ALL hold**:
 - **Two independent reviewer approvals** with no open concerns (the two `reviewer` agents review
   separately; a coder's sibling reviewer alone is too thin for an unsupervised merge), **and** the
   diff did not deviate from the agreed plan.
+- **Both approvals are anchored to the current head.** Reviewers name the sha they approved; if
+  `headRefOid` has moved since, the approvals are void — re-gate before merging. An unreviewed
+  commit has slipped past two approvals this way before (the fix was to `git rebase --onto` back to
+  the approved sha and re-review). A rebase moves the sha too: re-confirm, don't assume.
 - The change is **non-controversial** — *none of*:
   - touches `src/Contracts/**` or changes registry/pipeline **stage order** (`area:core`)
   - adds/changes a **config key** or a lint-rule **default severity**
@@ -171,6 +242,10 @@ their CI is stale):
   told to add their entry as its own line at the end of the section to minimise overlap.
 - Re-watch CI on the rebased branch before it becomes merge-eligible — never merge a branch whose
   green CI predates the current `main`.
+- **If the force-push didn't fire Actions** (no run appears on the new sha after a few minutes),
+  `gh pr close <n>` then `gh pr reopen <n>` re-triggers the workflow **without changing the sha**,
+  so sha-anchored approvals survive. Pushing an empty commit would move the head and void them.
+  Confirm the new run's `headSha` matches HEAD before trusting it.
 - If a rebase conflict is outside CHANGELOG and the coder cannot resolve it cleanly within the
   loop cap, escalate that PR.
 
@@ -178,6 +253,13 @@ Otherwise → **escalate**: `bin/set-phase <num> needs-human "🤖 **[lead]** <w
 decision; worktree left in place>"`, **request Moritz's review** (`gh pr edit --add-reviewer`),
 leave the PR **ready but unmerged** with its worktree in place, drop it from the in-flight count,
 admit the next issue.
+
+**Escalation is a merge freeze.** Once a PR carries `agent:needs-human`, it stays unmerged until
+the maintainer re-admits it — green CI, two approvals, and a clean survey do **not** thaw it, and
+neither does a later instruction to "keep going" or "drive forward as far as you safely can". This
+is enforced from the outside too: the permission classifier refuses `finish-pr` on a PR that was
+escalated for a human decision. Don't work around it. If the maintainer is away, treat the whole
+run as supervised — drive everything to ready-and-escalated and merge only what was never gated.
 
 ## Budget checkpoint & exit
 
@@ -188,13 +270,24 @@ is **best-effort**, enforced via a **countable proxy**: stop admitting new issue
 directives say otherwise. The per-issue caps (3 review rounds, 3 CI-fix attempts, 3 survey
 attempts) bound the cost of each issue, so issues-admitted is a usable spend proxy.
 
+**Stopping early at a clean boundary is a good outcome, not a shortfall.** If the cheap work is
+done and everything left is a large tier-1/`spec` item, wrap up below the cap rather than opening
+an expensive issue you'll have to abandon mid-flight.
+
+**If the org hits its spend limit mid-run**, teammates start failing with a spend-limit
+`idleReason: "failed"`. Don't checkpoint everything reflexively — the lead can finish an approved,
+survey-gated PR **solo**, because the expensive parts aren't Claude inference: survey Layer A is
+PHP/shell (`tools/survey/corpus.sh`) and merges are mechanical git. Salvage the ready work, then
+stop. A killed surveyor often leaves a usable completed baseline at `$WS/gate-<pr>/baseline/` —
+check its `manifest.json` `libraryCommit` before regenerating, and clear the dead agent's stale
+`$WS/.survey.lock`.
+
 On stop: let in-flight coders push WIP and post a
 `🤖 **[lead]** paused at <phase>, resume with /autonomous-team` comment on each open PR. Post a run
-summary (counts: merged / escalated / in-flight), `shutdown_request` each teammate, and stop. **Do
-not `TeamDelete`** if anything is still in flight — leave the team so a later session resumes; only
-`TeamDelete` when the backlog is fully cleared.
+summary (counts: merged / escalated / in-flight, plus any findings a denied write left unfiled),
+`shutdown_request` each teammate, and stop.
 
 ## Termination
 
-No eligible issues **and** empty pipeline → post a final run summary, `shutdown_request` every
-teammate, then `TeamDelete`.
+No eligible issues **and** empty pipeline → post a final run summary, then `shutdown_request` every
+teammate. (There is no team to delete — see Startup.)

--- a/.claude/skills/autonomous-team/bin/eligible-issues
+++ b/.claude/skills/autonomous-team/bin/eligible-issues
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Emit open issues the team may pick up, lowest-numbered first, tier-0 before tier-1.
-# Excludes: blocked/deferred/epic/human-task, anything already in an agent:* phase,
-# and any issue already referenced (Closes/Fixes/Resolves #N) by an open PR.
+# Excludes: blocked/blocked:upstream/deferred/epic/human-task, anything already in an
+# agent:* phase, and any issue already referenced (Closes/Fixes/Resolves #N) by an open PR.
+#
+# `spec` is deliberately NOT excluded: here it means "OpenAPI-specification work", not
+# "planning-only issue", and it covers nearly the whole backlog.
 # Output: JSON array of {number,title,labels}.
 set -euo pipefail
 
-EXCLUDE='["blocked","deferred","epic","human-task","agent:planning","agent:plan-review","agent:coding","agent:in-review","agent:docs","agent:survey","agent:needs-human"]'
+EXCLUDE='["blocked","blocked:upstream","deferred","epic","human-task","agent:planning","agent:plan-review","agent:coding","agent:in-review","agent:docs","agent:survey","agent:needs-human"]'
 
 # Issue numbers already claimed by an open PR (via closing keywords in the PR body).
 CLAIMED=$(gh pr list --state open --limit 200 --json body \

--- a/.claude/skills/autonomous-team/bin/finish-pr
+++ b/.claude/skills/autonomous-team/bin/finish-pr
@@ -13,20 +13,34 @@ comment="${*:-🤖 **[lead]** all gates green + non-controversial → squash-mer
 
 branch=$(gh pr view "$pr" --json headRefName --jq '.headRefName')
 
+# A PR scaffolded with PR_DRAFT=1 is still a draft, and `gh pr merge` refuses those.
+# Already-ready PRs make this a no-op.
+gh pr ready "$pr" >/dev/null 2>&1 || true
+
 # Merge first (squash). Defer branch deletion until after the worktree is gone:
 # `gh pr merge --delete-branch` cannot remove the local branch while its worktree
 # still references it, so we delete the branch explicitly below instead.
 gh pr merge "$pr" --squash
 
+# Everything past this point is best-effort: the merge already happened, so a
+# cleanup failure must never abort before the closing annotation is posted.
+# (Worktree removal in particular can be refused by the sandbox.)
+leftovers=()
+
 root=$(git rev-parse --show-toplevel)
 slug=$(printf '%s' "$branch" | tr '/' '-')
 path="${root}/.claude/worktrees/${slug}"
-[ -d "$path" ] && git worktree remove "$path" --force
-git worktree prune
+if [ -d "$path" ]; then
+  git worktree remove "$path" --force 2>/dev/null || leftovers+=("worktree ${path}")
+fi
+git worktree prune 2>/dev/null || true
 
 # Branch is now unreferenced — delete it locally and on the remote.
-git branch -D "$branch" 2>/dev/null || true
-git push origin --delete "$branch" 2>/dev/null || true
+git branch -D "$branch" 2>/dev/null || leftovers+=("local branch ${branch}")
+git push origin --delete "$branch" 2>/dev/null || leftovers+=("remote branch ${branch}")
 
 gh pr comment "$pr" --body "$comment" >/dev/null
-echo "merged + cleaned: PR #${pr} (${branch})"
+echo "merged: PR #${pr} (${branch})"
+if [ ${#leftovers[@]} -gt 0 ]; then
+  printf 'warning: manual cleanup still needed: %s\n' "${leftovers[*]}" >&2
+fi

--- a/.claude/skills/autonomous-team/bin/resume-scan
+++ b/.claude/skills/autonomous-team/bin/resume-scan
@@ -4,7 +4,7 @@
 # Output: JSON { phase: [ {number, title, kind, url} ] } — the lead rebuilds tasks from this.
 set -euo pipefail
 
-PHASES='agent:planning agent:plan-review agent:coding agent:in-review agent:survey agent:needs-human'
+PHASES='agent:planning agent:plan-review agent:coding agent:in-review agent:docs agent:survey agent:needs-human'
 
 emit_for_label() {
   local label="$1"

--- a/.claude/skills/autonomous-team/bin/start-issue
+++ b/.claude/skills/autonomous-team/bin/start-issue
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # Kick off the draft-PR ritual for one issue (CLAUDE.md development workflow):
-# branch from a fresh main, seed an empty commit so the branch has a diff, push.
+# branch from a fresh origin/main, seed an empty commit so the branch has a diff, push.
 # The planner follows this with `gh pr create --draft` (or use bin/open-pr later).
+#
+# Leaves the primary checkout untouched — no branch is checked out here, so concurrent
+# agents keep working. The coder gets its own copy via `bin/worktree-add <branch>`.
+# Re-running for an existing branch is a no-op that just echoes it.
 #
 # Usage: bin/start-issue <type> <issue-number> [slug]
 #   <type>  one of: feat | fix | chore | docs
 #   [slug]  optional branch suffix; derived from the issue title when omitted
+#
+# Env:
+#   CO_AUTHOR  trailer identity for the seed commit (default: Claude <noreply@anthropic.com>)
 #
 # Echoes the created branch name on success.
 set -euo pipefail
@@ -33,17 +40,22 @@ fi
 
 branch="${type}/${issue}-${slug}"
 
-# Refuse to clobber uncommitted work — durable state must never be lost silently.
-if ! git diff --quiet || ! git diff --cached --quiet; then
-  echo "error: working tree is dirty; commit or stash before starting a new issue" >&2
-  exit 1
+if git show-ref --quiet "refs/heads/${branch}"; then
+  echo "$branch"
+  exit 0
 fi
 
-git checkout main
-git pull --ff-only
-git checkout -b "$branch"
-git commit --allow-empty -m "${type}: ${title} (#${issue})" \
-  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+# Build the branch and its seed commit with plumbing, so nothing is ever checked out
+# here: the primary checkout is shared with concurrent agents, and taking it hostage
+# (or rebasing its `main`) collides with whatever else is running.
+git fetch origin main >/dev/null
+
+base=$(git rev-parse origin/main)
+commit=$(git commit-tree "${base}^{tree}" -p "$base" \
+  -m "${type}: ${title} (#${issue})" \
+  -m "Co-Authored-By: ${CO_AUTHOR:-Claude <noreply@anthropic.com>}")
+
+git branch "$branch" "$commit"
 git push -u origin "$branch"
 
 echo "$branch"

--- a/.claude/skills/autonomous-team/reference/state-machine.md
+++ b/.claude/skills/autonomous-team/reference/state-machine.md
@@ -50,8 +50,12 @@ annotation atomically — keeping the single-active-label invariant intact. Once
 transition the **PR** number: `set-phase` detects a PR and also clears the stale label from the
 issue(s) it closes, so the phase locus migrates issue → PR with no double-count on `resume-scan`.
 
-Issues carrying any of `blocked`, `deferred`, `spec`, `epic`, `human-task`, or `agent:needs-human`
-are **never** picked up.
+Issues carrying any of `blocked`, `blocked:upstream`, `deferred`, `epic`, `human-task`, or
+`agent:needs-human` are **never** picked up.
+
+`spec` is **not** on that list. Here it means *"OpenAPI-specification work"* — the generation
+behaviour of the library — not *"planning-only issue"*. Nearly the whole backlog carries it, so
+excluding it would leave the team nothing to do. `bin/eligible-issues` is the source of truth.
 
 ## Comment protocol (durable annotations)
 

--- a/.claude/skills/autonomous-team/roles/coder.md
+++ b/.claude/skills/autonomous-team/roles/coder.md
@@ -6,8 +6,19 @@ and respond to review findings. Read `../reference/state-machine.md` and the pro
 ## When the lead assigns you a `coding` task
 
 1. **Worktree.** `path=$(bin/worktree-add <branch>)` — adds (or reuses) a worktree under
-   `.claude/worktrees/` for the PR's branch and echoes its path. `cd "$path"` and work only there.
-   Never touch `main` or another agent's worktree.
+   `.claude/worktrees/` for the PR's branch and echoes its path. Work only there; never touch
+   `main` or another agent's worktree.
+   - **Your shell's working directory resets between tool calls.** Do not rely on a `cd` from an
+     earlier call — pass the absolute path every time (`git -C "$path" …`, `composer -d "$path" …`,
+     absolute file paths). This is not a style preference: a coder that assumed its `cd` had stuck
+     ran its commits against the *primary* checkout, left its whole implementation uncommitted in
+     the worktree, and reported green CI that had actually run on an empty branch.
+   - **A fresh worktree has no `vendor/`** (it is gitignored, so `git worktree add` doesn't copy
+     it). Run `composer install --no-interaction` inside it before any gate, or `composer check`
+     fails with a confusing "no such file or directory".
+   - If you are *resuming* someone's branch, check `git -C "$path" status --porcelain` and
+     `git -C "$path" stash list` **before** re-implementing — a previous session's work is often
+     sitting there uncommitted, and re-doing it from scratch is how it gets lost for good.
 2. **TDD.** Write the failing test(s) first (per the plan), then the minimal implementation that
    makes them pass. Match surrounding style. No speculative abstraction — minimum code that solves
    the issue; if you write 200 lines and it could be 50, rewrite it.
@@ -34,7 +45,19 @@ and respond to review findings. Read `../reference/state-machine.md` and the pro
 6. **Push frequently** — every meaningful checkpoint, so durable state survives a session
    interruption. Mark the PR **ready** (`gh pr ready`) once local gates pass; then watch remote CI
    (`gh pr checks --watch`) and fix any matrix-only failures before handing to review.
-7. Post `🤖 **[coder]** implemented; local gates green; pushed <sha>. Ready for review.` and
+   - **If you amend, re-verify before pushing.** Amending and *then* making further edits leaves
+     those edits out of the commit — `git -C "$path" show HEAD:<file>` to confirm the commit matches
+     what you intend, and re-amend if it doesn't. A pushed amend that dropped a fix has failed CI
+     on dead code this way.
+7. **Prove it before you claim it.** "Ready" means the work is on the remote, not in your worktree.
+   Confirm all three, then quote the sha:
+   ```sh
+   git -C "$path" status --porcelain                              # empty
+   git -C "$path" diff --numstat origin/main...origin/<branch>    # non-empty
+   gh pr checks <pr>                                              # green, on that same sha
+   ```
+   The lead re-checks this anyway; a false "ready" costs the run a full review cycle.
+8. Post `🤖 **[coder]** implemented; local gates green; pushed <sha>. Ready for review.` and
    `SendMessage` the lead to move it to review.
 
 ## Review-loop rounds
@@ -66,5 +89,8 @@ reviewer will check for it.
 
 ## Out-of-scope discoveries
 
-Found a separate bug or a good idea? `gh issue create` with the right `bug`/`area:*` labels.
-**Do not** fold it into this PR. Mention it in a comment so the lead can queue it later.
+Found a separate bug or a good idea? `gh issue create` with the right `bug`/`area:*` labels, **now**
+— the maintainer's standing grant for this is the **GitHub write authorization** section of
+`../SKILL.md`, and a finding you defer is a finding you lose. **Do not** fold it into this PR.
+Mention it in a comment so the lead can queue it later. If the write is refused anyway, post the
+issue body as a PR comment and tell the lead — never ask another agent to file it for you.

--- a/.claude/skills/autonomous-team/roles/docs-writer.md
+++ b/.claude/skills/autonomous-team/roles/docs-writer.md
@@ -43,4 +43,9 @@ index is `docs/README.md`; the lint-rule catalog is the hand-maintained block in
 
 Document what this change requires — don't rewrite unrelated pages. If you spot a separate docs
 gap (an existing under-documented feature), `gh issue create` it with the `documentation` label
-rather than expanding the current PR. Never modify `src/` to make docs easier — docs follow code.
+during the run — see the **GitHub write authorization** section of `../SKILL.md` — rather than
+expanding the current PR. Never modify `src/` to make docs easier — docs follow code.
+
+Your worktree needs `composer install --no-interaction` before `composer check` (a fresh worktree
+has no `vendor/`), and your shell's working directory resets between tool calls — use the absolute
+path from `worktree-add` every time.

--- a/.claude/skills/autonomous-team/roles/planner.md
+++ b/.claude/skills/autonomous-team/roles/planner.md
@@ -11,17 +11,35 @@ Read `../reference/state-machine.md` for the label/comment protocol. Read the pr
 1. `gh issue view <N>` — read the spec fully. If the issue is too ambiguous or underspecified to
    form a plan (genuine missing decision, not just effort), post a comment stating exactly what's
    unclear, `SendMessage` the lead to escalate, and stop. Do not guess.
-2. **Create the branch + draft PR with the helpers** (they encode the CLAUDE.md ritual):
+2. **Dependency pre-check — do this before investing in a plan.** Planning against shifting or
+   blocked ground wastes the run: stale line references, guaranteed conflicts, or a plan that
+   cannot compile until an unmerged contract lands. Two checks:
+   - **Does it depend on an unmerged or escalated PR's contract?** If a referenced refactor is
+     still open, read its *widened* contract and write the plan against the post-merge code,
+     flagging the merge-order dependency to the lead.
+   - **Do any open PRs touch the same files?** `gh pr list --state open --json number` then
+     `gh pr diff <n> --name-only` (or `--patch` for hunk headers) over the files you intend to
+     change.
+
+   If the issue is gated or collides heavily, **stop and `SendMessage` the lead** rather than plan
+   blocked work — the lead defers it and admits something else. Say which PR gates it and why.
+   Note that ordering can cut both ways: when two issues in a family touch the same scan logic, the
+   one that *narrows* behaviour usually has to merge before the one that *widens* it.
+3. **Create the branch + draft PR with the helpers** (they encode the CLAUDE.md ritual):
    - `branch=$(bin/start-issue <type> <N>)` — `<type>` ∈ `feat|fix|chore|docs`; branches off a
-     fresh `main`, seeds an empty commit, pushes, leaves the primary checkout on the branch.
+     fresh `origin/main`, seeds an empty commit, pushes. It never checks anything out, so the
+     shared primary checkout stays free for concurrent agents — you have nothing to release
+     afterwards.
    - Write the **implementation plan** (below) to a file, then
      `PR_DRAFT=1 bin/open-pr <N> "<title>" plan.md` — opens the draft PR, mirrors the issue's
      kind/area/tier labels, guarantees `Closes #<N>`, appends the footer, assigns the maintainer.
      (`open-pr` assigns, it does **not** request review — correct, since auto-merge candidates
      squash before a human looks; the lead requests review only on escalation.)
-   - **`git checkout main`** to release the branch — the coder needs it free to add a worktree.
-3. Post `🤖 **[planner]** plan posted — see PR body. Ready for plan-review.` on the PR.
-4. `SendMessage` the lead: planning done, PR #<num> ready for plan-review.
+4. Post `🤖 **[planner]** plan posted — see PR body. Ready for plan-review.` on the PR.
+5. `SendMessage` the lead: planning done, PR #<num> ready for plan-review.
+
+If a second planner is active, reconcile before starting: an already-open draft PR for the issue
+means it is planned — say so and take the next one rather than competing.
 
 ## What a good plan contains
 

--- a/.claude/skills/autonomous-team/roles/reviewer.md
+++ b/.claude/skills/autonomous-team/roles/reviewer.md
@@ -60,9 +60,22 @@ Review the pushed diff adversarially. Reject unless **all** hold:
 - **No scope creep / no deviation from the agreed plan** (if it deviated, the coder must have
   documented why as a PR comment).
 
+- **Mutation/fixer code needs an end-to-end golden, not just unit tests.** If the change rewrites
+  source (the AST `Fix` backend, a code fixer, anything that applies edits), demand a test that runs
+  the *real* mutation over a real file and asserts the resulting text. Unit tests here have a habit
+  of encoding the author's mental model rather than the behaviour: a shipped fix-conflict detector
+  once passed a green suite while silently corrupting source, because every unit test asserted the
+  same wrong model. Only the E2E golden caught it.
+
 Post findings as a numbered list: `🤖 **[reviewer]** review round <n> — <k> findings:` each with
-`file:line` and what's wrong. If clean, post `🤖 **[reviewer]** review round <n>: approved, no
-concerns.` Then `SendMessage` the responsible coder (findings) or the lead (approved).
+`file:line` and what's wrong. If clean, post
+`🤖 **[reviewer]** review round <n>: approved at <sha>, no concerns.`
+Then `SendMessage` the responsible coder (findings) or the lead (approved).
+
+**Always name the sha you approved** (`gh pr view <pr> --json headRefOid`). Your approval covers
+that diff and nothing else — the lead voids it if the head moves, which is what stops an unreviewed
+commit from riding in behind two approvals. If you're re-reviewing after a rebase, re-state the new
+sha explicitly rather than referring back to your earlier approval.
 
 The lead enforces the 3-round cap. If you and the coder can't converge, say so explicitly so the
 lead escalates to a human.

--- a/.claude/skills/autonomous-team/roles/surveyor.md
+++ b/.claude/skills/autonomous-team/roles/surveyor.md
@@ -19,8 +19,17 @@ post `🤖 **[surveyor]** skipped — non-generation-affecting (<area>).` and pa
 
 `main` moves on every merge, so a cached baseline goes stale. Before comparing, check whether
 `main` advanced since the cached `$WS/results.json` was produced (compare the recorded `main` SHA);
-if it did, **regenerate the baseline** on the current `main` first. Never compare a candidate
-against a baseline from an older `main`.
+if it did, **regenerate the baseline** on the current `main` first.
+
+**The one exception:** the rule exists because a merge normally changes generated specs. When an
+intervening merge is **provably generation-neutral** — the byte-exact `snapshot` group green *and*
+its own survey fully flat, or a lint/CLI-only change — it demonstrably didn't, and the older
+baseline is still valid. Say which proof you relied on. Don't stretch this: "probably harmless" is
+not a proof.
+
+Corpus runs are the expensive part of the whole pipeline (~45–75 min per candidate), so also
+**pre-generate the next baseline in the background** during planning/coding dead time rather than
+starting it when the PR is already waiting on you.
 
 ## Environment (per the survey skill)
 - `export WS="$HOME/Projects/laravel-openapi-dogfood"`
@@ -38,12 +47,45 @@ against a baseline from an older `main`.
 3. **Compare per app:**
    - **FAIL** if any app's generation crashes (non-zero gen_exit / error in the spec output) that
      was green on baseline.
-   - **FAIL** if any deterministic metric **regresses** (paths, operations, schemas, parameters,
-     responses counts, `requestBodies`, `operationsWithSecurity` drop) vs baseline. Every watched
-     metric is higher-is-better, so a drop always reads as the regression it is.
+   - **FAIL** if any deterministic metric **regresses** (paths, operations, schemas, responses
+     counts, `requestBodies`, `operationsWithSecurity` drop) vs baseline. These are all
+     higher-is-better, so a drop normally reads as the regression it is — but see the exception
+     below before failing one.
    - **PASS** otherwise (equal or improved across the corpus).
+   - `tools/survey/metrics.php` emits **no `parameters` count** — verify parameter-level work by
+     diffing the generated specs directly, not from the metrics rollup.
+
+### The intentional-reduction exception (do not skip this)
+
+The goal is **fidelity, not maximal counts.** When a PR's whole purpose is to *remove* spec noise —
+a denylist that drops wrongly-inferred headers, a guard that refuses a confidently-wrong schema —
+the expected metric moves **down**, and a mechanical comparison fails a genuine improvement. Two
+such changes would have been wrongly rejected by the rule above.
+
+So: ask the lead what the change is *supposed* to do. If it is a reduction, **interpret, don't
+compare counts** — diff the actual items (parameter lists, response entries) between baseline and
+candidate, and:
+
+- **PASS** if every removed item is an intended removal and nothing else moved.
+- **FAIL** on removals outside the intended set, over-broad removal, or any new crash.
+
+Report the removed items, not just the delta, so the verdict is auditable.
+
+### Reading a diff without chasing ghosts
+
+- **Mask `operationId` before any byte-compare.** Unnamed routes get a non-deterministic
+  `generated::<Str::random>` suffix that differs per boot, and Livewire asset-URL hashes churn the
+  same way. All ~92 InvoiceNinja operationIds flipping together is RNG, not your change.
+- **Survey the PR head commit, not a coder's live worktree.** One run was invalidated by unresolved
+  rebase conflict markers producing parse errors that looked like real crashes. Keep the
+  conflict-marker guard.
 
 ## Reporting
+
+**Poll your own background run.** Corpus runs finish without reliably notifying you — the results
+sit on disk while you sit idle, and the lead has to prod you with an enumerated-outcomes message to
+get a status. Check the background shell output yourself before going idle, and again whenever you
+wake. Nothing is wrong before ~90 minutes; report progress rather than waiting silently.
 
 - Pass: `🤖 **[surveyor]** Layer A pass — 0 regressions across <N> apps.` → `SendMessage` the lead
   (clear to merge).


### PR DESCRIPTION
Closes #572

Audit of `.claude/skills/autonomous-team/` against the seven runs from 2026-06-14 → 2026-07-24.
Every operational lesson those runs produced lived in session memory, not in the skill — so each
run re-learned them, and several cost real work. This folds them in, and fixes five defects found
while reading the skill against them.

## Script defects

| | |
|---|---|
| `resume-scan` | Its `PHASES` list omitted `agent:docs`, so a PR parked in the docs sub-phase was **invisible to a resuming session** — the one phase that silently lost work across sessions. |
| `eligible-issues` | Did not exclude `blocked:upstream` (the label exists and is genuinely off-limits). |
| `finish-pr` | Refused `PR_DRAFT=1` PRs — `gh pr merge` rejects drafts, hit on run 4. Also aborted post-merge cleanup on the first failure under `set -e`, so a sandbox-refused `git worktree remove` (seen 2026-07-24) skipped the branch deletion *and* the closing annotation. Cleanup is now best-effort and reports leftovers. |
| `start-issue` | Checked the new branch out in the **shared primary worktree**, colliding with concurrent agents (#572). Now builds the branch with `commit-tree` + `git branch` and checks out nothing. Re-running for an existing branch is a no-op. Stale `Opus 4.8` co-author trailer replaced with an overridable generic. |
| `state-machine.md` | Still listed `spec` among never-picked-up labels — contradicting `eligible-issues` (fixed in 33ad88b8) and the label's meaning here (*OpenAPI-specification work*, i.e. most of the backlog). |

Verified: all nine scripts pass `bash -n`; `resume-scan` now emits seven phases including
`agent:docs`; `eligible-issues` returns 37; `start-issue`'s plumbing produces an empty diff vs
`origin/main` with the right parent and message, leaving the working tree untouched.

## GitHub as the agents' communication medium

`gh issue create` has been classifier-blocked in every run since 2026-06-17, for subagent self-feed
*and* for the lead filing on a teammate's behalf (correctly flagged as permission laundering). The
previous workaround — defer findings to a post-run summary — defeats the design: an out-of-scope
bug that can't be filed while it's found is a finding that gets lost.

Fixed at both levels:

- **Mechanically** — a scoped `permissions.allow` list in `.claude/settings.local.json`. That file
  is gitignored *by design*: this is a public repo, and a checked-in allowlist would auto-approve
  GitHub writes for everyone who clones it. Covers issues, comments, labels, PR lifecycle, and the
  skill's own `bin/` scripts.
- **In context** — a new **GitHub write authorization** section carrying the maintainer's grant
  verbatim and dated, so a challenged write can point at a *user* grant rather than an agent's
  inference.

Deliberately **not** granted: `gh pr merge` / `bin/finish-pr`. Merging stays classifier-gated
because that gate has caught a real case — it correctly refused to auto-merge a PR previously
escalated as human-gated. Also excluded: `gh repo`, `gh release`, `gh secret`, `gh workflow run`,
force-pushes. Three rules keep the grant honest (no laundering, bounded scope, degrade loudly into
a comment rather than dropping the finding).

## Gates the runs paid for

- **Phantom-green gate** (`SKILL.md`, `coder.md`) — verify a "ready" report against the remote
  before routing it onward: non-empty `gh pr diff`, and a CI run carrying the current `headRefOid`.
  A coder once reported "ready, CI green" while its entire implementation sat uncommitted in the
  worktree; the CI it cited had genuinely run, on an empty diff. A later session found the branch
  empty and nearly re-implemented the lost work. Root cause — the shell's cwd resets between tool
  calls — is now stated as a rule: absolute `git -C` everywhere, plus `composer install` in a fresh
  worktree and a `status`/`stash list` check before resuming someone's branch.
- **Sha-anchored approvals** (`SKILL.md`, `reviewer.md`) — reviewers name the sha they approved;
  the lead voids approvals when the head moves. An unreviewed commit rode past two approvals once.
- **Survey: intentional reductions** (`surveyor.md`) — "any metric drop = FAIL" is wrong for changes
  whose purpose is removing spec noise; it would have wrongly failed #530 and #578. The surveyor now
  diffs the actual items and passes if the delta is exactly the intended removal set. Plus: the
  baseline-staleness rule gets an explicit exception for a *provably* generation-neutral merge,
  `operationId` RNG masking, and a note that `metrics.php` emits no `parameters` count.
- **Planner dependency pre-check** (`planner.md`) — called out on 2026-07-22 as the single most
  valuable thing the planner did (it caught three would-be-blocked plans). Now step 2.
- **Fixer E2E goldens** (`reviewer.md`) — from PR #396, where a green unit suite encoded the
  author's wrong model while the fixer silently corrupted source.

## Runtime reality

`TeamCreate`/`TeamDelete` don't exist here (single implicit team; `team_name` is ignored) — the
skill called both. Background spawning breaks intermittently, so the fallback ladder is documented
rather than rediscovered. Umbrella `Drive …` tasks must stay lead-owned, and every teammate now
carries the standing "ignore `Drive` assignments" rule. Escalation is stated as a **merge freeze**
that "drive forward as far as you safely can" does not thaw. `planner` capacity raised to ×2 — the
documented throughput bottleneck. Spend-limit halts now have a solo-salvage path, since Layer A is
PHP/shell and merges are git, not inference.

No `CHANGELOG.md` entry: `.claude/` agent tooling is not consumer-visible, matching prior tooling
PRs (#340, #357, #473).

🤖 Generated with [Claude Code](https://claude.com/claude-code)