### PR TITLE
chore(autonomous-team): sign the seed commit and name the PR head explicitly

### DIFF
--- a/.claude/skills/autonomous-team/SKILL.md
+++ b/.claude/skills/autonomous-team/SKILL.md
@@ -143,7 +143,7 @@ single-active-label / closing-keyword / footer invariants.
 | `set-phase <num> <phase> [comment]` | lead | move phase: enforce one `agent:*` label + post annotation; on a PR, also clears the closed issue's stale label (issue→PR migration) |
 | `finish-pr <pr> [comment]` | lead | un-draft + squash-merge + delete branch + remove worktree + comment; cleanup is best-effort and warns about leftovers |
 | `start-issue <type> <N> [slug]` | planner | branch off fresh `origin/main`, empty commit, push; echoes branch. Checks nothing out — the primary checkout stays free |
-| `open-pr <N> <title> [body-file]` | planner | open PR with labels/`Closes`/footer/assignee (`PR_DRAFT=1` for draft) |
+| `open-pr <N> <title> [body-file]` | planner | open PR with labels/`Closes`/footer/assignee (`PR_DRAFT=1` for draft; head defaults to the unique pushed `<type>/<N>-*` branch, override with `PR_HEAD`) |
 | `worktree-add <branch>` | coder / docs-writer | add/reuse a worktree under `.claude/worktrees/`; echoes path |
 | `sync-branch` | coder / docs-writer | from a worktree: fetch + rebase `origin/main` + `composer check` |
 

--- a/.claude/skills/autonomous-team/bin/open-pr
+++ b/.claude/skills/autonomous-team/bin/open-pr
@@ -9,6 +9,8 @@
 # Env:
 #   PR_ASSIGNEE   maintainer to assign/request review (default: Radiergummi)
 #   PR_DRAFT=1    open as a draft instead of ready-for-review
+#   PR_HEAD       branch to open the PR from; defaults to the unique pushed
+#                 `<type>/<issue>-*` branch, which is what `start-issue` creates
 #
 # Echoes the created PR URL on success.
 set -euo pipefail
@@ -23,22 +25,28 @@ assignee="${PR_ASSIGNEE:-Radiergummi}"
 # issue number unless the caller pins it.
 head="${PR_HEAD:-}"
 if [ -z "$head" ]; then
-  candidates=$(
+  # Prune first: a remote-tracking ref for a branch deleted after its merge would
+  # otherwise look like a perfectly good single match, and fail at GitHub instead.
+  git fetch --prune origin >/dev/null 2>&1 || true
+
+  refs=$(
     git for-each-ref --format='%(refname:short)' \
       'refs/remotes/origin/feat/*' 'refs/remotes/origin/fix/*' \
-      'refs/remotes/origin/chore/*' 'refs/remotes/origin/docs/*' \
-      | sed 's|^origin/||' \
-      | grep -E "^(feat|fix|chore|docs)/${issue}-" || true
+      'refs/remotes/origin/chore/*' 'refs/remotes/origin/docs/*'
   )
+  # The trailing '-' keeps '587' off 'fix/5871-…'; sed strips the remote prefix.
+  candidates=$(printf '%s\n' "$refs" | sed 's|^origin/||' \
+    | grep -E "^(feat|fix|chore|docs)/${issue}-" || true)
   count=$(printf '%s' "$candidates" | grep -c . || true)
   if [ "$count" -eq 1 ]; then
     head="$candidates"
   elif [ "$count" -eq 0 ]; then
-    echo "error: no pushed branch matches '<type>/${issue}-*'; run bin/start-issue first, or set PR_HEAD" >&2
+    echo "error: no pushed branch matches '<type>/${issue}-*';" >&2
+    echo "       run bin/start-issue first, or set PR_HEAD" >&2
     exit 2
   else
     echo "error: several branches match '<type>/${issue}-*'; set PR_HEAD to pick one:" >&2
-    printf '  %s\n' $candidates >&2
+    printf '%s\n' "$candidates" | sed 's/^/  /' >&2
     exit 2
   fi
 fi

--- a/.claude/skills/autonomous-team/bin/open-pr
+++ b/.claude/skills/autonomous-team/bin/open-pr
@@ -18,6 +18,31 @@ title="${2:?usage: open-pr <issue-number> <title> [body-file]}"
 body_file="${3:--}"
 assignee="${PR_ASSIGNEE:-Radiergummi}"
 
+# `gh pr create` infers the head from the checked-out branch, but `start-issue` checks
+# nothing out on purpose, so the head has to be named explicitly. Derive it from the
+# issue number unless the caller pins it.
+head="${PR_HEAD:-}"
+if [ -z "$head" ]; then
+  candidates=$(
+    git for-each-ref --format='%(refname:short)' \
+      'refs/remotes/origin/feat/*' 'refs/remotes/origin/fix/*' \
+      'refs/remotes/origin/chore/*' 'refs/remotes/origin/docs/*' \
+      | sed 's|^origin/||' \
+      | grep -E "^(feat|fix|chore|docs)/${issue}-" || true
+  )
+  count=$(printf '%s' "$candidates" | grep -c . || true)
+  if [ "$count" -eq 1 ]; then
+    head="$candidates"
+  elif [ "$count" -eq 0 ]; then
+    echo "error: no pushed branch matches '<type>/${issue}-*'; run bin/start-issue first, or set PR_HEAD" >&2
+    exit 2
+  else
+    echo "error: several branches match '<type>/${issue}-*'; set PR_HEAD to pick one:" >&2
+    printf '  %s\n' $candidates >&2
+    exit 2
+  fi
+fi
+
 # Read the bespoke body (file or stdin).
 if [ "$body_file" = "-" ]; then
   body=$(cat)
@@ -50,6 +75,8 @@ draft_args=()
 [ "${PR_DRAFT:-0}" = "1" ] && draft_args+=(--draft)
 
 gh pr create \
+  --base main \
+  --head "$head" \
   --title "$title" \
   --body "$body" \
   --assignee "$assignee" \

--- a/.claude/skills/autonomous-team/bin/start-issue
+++ b/.claude/skills/autonomous-team/bin/start-issue
@@ -51,7 +51,9 @@ fi
 git fetch origin main >/dev/null
 
 base=$(git rev-parse origin/main)
-commit=$(git commit-tree "${base}^{tree}" -p "$base" \
+# `-S` is not optional: the repository ruleset rejects unsigned commits, and unlike
+# `git commit`, `commit-tree` ignores `commit.gpgsign`.
+commit=$(git commit-tree -S "${base}^{tree}" -p "$base" \
   -m "${type}: ${title} (#${issue})" \
   -m "Co-Authored-By: ${CO_AUTHOR:-Claude <noreply@anthropic.com>}")
 


### PR DESCRIPTION
Closes #617

## What broke

Both bugs reported in #617 hit **this run**, in the first two commands: `start-issue` for #587 was
rejected by the ruleset (`GH013: Commits must have verified signatures`), and `open-pr` aborted
with `you must first push the current branch to a remote, or use the --head flag`. Together they
made it impossible to open any PR at all, which is why this was fixed before anything else rather
than left for between runs as the issue advises. No agents were running at the time — the fix
landed in the gap the issue asks for.

Both fixes are the reporter's proposed ones, now **verified end-to-end**: they are what opened
PR #621 (#587) and this PR.

## 1. `start-issue`: sign the seed commit

`git commit-tree` does not honour `commit.gpgsign` the way `git commit` does. Pass `-S`.

## 2. `open-pr`: name the head explicitly

`gh pr create` infers the head from the checked-out branch, but `start-issue` checks nothing out
on purpose — that is what keeps the primary checkout free while coders work in worktrees. So the
head has to be named.

Rather than add a required argument (which would break every existing call site and every role
doc that documents the two-argument form), the branch is **derived from the issue number**: the
unique pushed `<type>/<issue>-*` ref. `PR_HEAD` overrides it, and both the zero-match and
multi-match cases fail with an actionable message instead of falling through to the old
inferred-head behaviour. `--base main` is pinned at the same time.

Deliberately avoids `mapfile` — the scripts run under `#!/usr/bin/env bash`, which on macOS may
resolve to bash 3.2.

## Verification

- `bash -n` on both scripts.
- `start-issue fix 587 …` → signed seed commit, push accepted.
- `open-pr 587 …` from a checkout sitting on an unrelated branch → PR #621 created, labels
  mirrored, `Closes #587` and footer present.
- `start-issue chore 617 …` + `open-pr 617 …` → this PR.

## Not included

No `CHANGELOG.md` entry: this is agent harness tooling under `.claude/`, not library behaviour,
and the changelog documents the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)